### PR TITLE
fix: render markdown in Ask AI popup

### DIFF
--- a/src/components/AiPopup.astro
+++ b/src/components/AiPopup.astro
@@ -28,7 +28,6 @@ const apiUrl = import.meta.env.PUBLIC_API_URL || 'https://api.shroomdog.dev';
   <!-- Popup is created dynamically by JS -->
 </div>
 
-<script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js" is:inline></script>
 <script is:inline>
   (function () {
     'use strict';
@@ -176,6 +175,132 @@ const apiUrl = import.meta.env.PUBLIC_API_URL || 'https://api.shroomdog.dev';
       const div = document.createElement('div');
       div.textContent = str;
       return div.innerHTML;
+    }
+
+    function renderInlineMarkdown(text) {
+      return escapeHtml(text || '')
+        .replace(/`([^`]+)`/g, '<code>$1</code>')
+        .replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>')
+        .replace(/\*([^*\n]+)\*/g, '<em>$1</em>')
+        .replace(/\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g, function (_match, label, url) {
+          return (
+            '<a href="' + url + '" target="_blank" rel="noopener noreferrer">' + label + '</a>'
+          );
+        });
+    }
+
+    function renderMarkdown(response) {
+      const fragment = document.createDocumentFragment();
+      const lines = String(response || '')
+        .replace(/\r\n/g, '\n')
+        .replace(/\r/g, '\n')
+        .split('\n');
+      let paragraphLines = [];
+      let listEl = null;
+      let listType = '';
+      let i = 0;
+
+      function flushParagraph() {
+        if (!paragraphLines.length) return;
+        const paragraph = document.createElement('p');
+        paragraph.innerHTML = paragraphLines.map(renderInlineMarkdown).join('<br>');
+        fragment.appendChild(paragraph);
+        paragraphLines = [];
+      }
+
+      function flushList() {
+        if (!listEl) return;
+        fragment.appendChild(listEl);
+        listEl = null;
+        listType = '';
+      }
+
+      while (i < lines.length) {
+        const line = lines[i];
+        const trimmed = line.trim();
+
+        if (!trimmed) {
+          flushParagraph();
+          flushList();
+          i += 1;
+          continue;
+        }
+
+        if (/^```/.test(trimmed)) {
+          flushParagraph();
+          flushList();
+
+          const codeLines = [];
+          i += 1;
+          while (i < lines.length && !/^```/.test(lines[i].trim())) {
+            codeLines.push(lines[i]);
+            i += 1;
+          }
+
+          const pre = document.createElement('pre');
+          const code = document.createElement('code');
+          code.textContent = codeLines.join('\n');
+          pre.appendChild(code);
+          fragment.appendChild(pre);
+          i += 1;
+          continue;
+        }
+
+        const headingMatch = trimmed.match(/^(#{1,6})\s+(.*)$/);
+        if (headingMatch) {
+          flushParagraph();
+          flushList();
+          const level = Math.min(headingMatch[1].length, 6);
+          const heading = document.createElement('h' + level);
+          heading.innerHTML = renderInlineMarkdown(headingMatch[2]);
+          fragment.appendChild(heading);
+          i += 1;
+          continue;
+        }
+
+        const blockquoteMatch = trimmed.match(/^>\s?(.*)$/);
+        if (blockquoteMatch) {
+          flushParagraph();
+          flushList();
+          const quote = document.createElement('blockquote');
+          const quoteLines = [blockquoteMatch[1]];
+          i += 1;
+          while (i < lines.length) {
+            const nextMatch = lines[i].trim().match(/^>\s?(.*)$/);
+            if (!nextMatch) break;
+            quoteLines.push(nextMatch[1]);
+            i += 1;
+          }
+          quote.innerHTML = quoteLines.map(renderInlineMarkdown).join('<br>');
+          fragment.appendChild(quote);
+          continue;
+        }
+
+        const unorderedMatch = trimmed.match(/^[-*]\s+(.*)$/);
+        const orderedMatch = trimmed.match(/^\d+\.\s+(.*)$/);
+        if (unorderedMatch || orderedMatch) {
+          flushParagraph();
+          const nextListType = unorderedMatch ? 'ul' : 'ol';
+          if (!listEl || listType !== nextListType) {
+            flushList();
+            listEl = document.createElement(nextListType);
+            listType = nextListType;
+          }
+          const item = document.createElement('li');
+          item.innerHTML = renderInlineMarkdown((unorderedMatch || orderedMatch)[1]);
+          listEl.appendChild(item);
+          i += 1;
+          continue;
+        }
+
+        flushList();
+        paragraphLines.push(line);
+        i += 1;
+      }
+
+      flushParagraph();
+      flushList();
+      return fragment;
     }
 
     function createPopup() {
@@ -366,11 +491,7 @@ const apiUrl = import.meta.env.PUBLIC_API_URL || 'https://api.shroomdog.dev';
 
       const body = document.createElement('div');
       body.className = 'ai-popup-result-body';
-      if (typeof window.marked !== 'undefined') {
-        body.innerHTML = window.marked.parse(response);
-      } else {
-        body.textContent = response;
-      }
+      body.appendChild(renderMarkdown(response));
 
       content.appendChild(closeBtn);
       content.appendChild(body);

--- a/src/components/AiPopup.astro
+++ b/src/components/AiPopup.astro
@@ -28,6 +28,7 @@ const apiUrl = import.meta.env.PUBLIC_API_URL || 'https://api.shroomdog.dev';
   <!-- Popup is created dynamically by JS -->
 </div>
 
+<script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js" is:inline></script>
 <script is:inline>
   (function () {
     'use strict';
@@ -365,7 +366,11 @@ const apiUrl = import.meta.env.PUBLIC_API_URL || 'https://api.shroomdog.dev';
 
       const body = document.createElement('div');
       body.className = 'ai-popup-result-body';
-      body.textContent = response;
+      if (typeof window.marked !== 'undefined') {
+        body.innerHTML = window.marked.parse(response);
+      } else {
+        body.textContent = response;
+      }
 
       content.appendChild(closeBtn);
       content.appendChild(body);
@@ -1145,8 +1150,41 @@ const apiUrl = import.meta.env.PUBLIC_API_URL || 'https://api.shroomdog.dev';
     font-size: 0.9rem;
     line-height: 1.6;
     color: var(--color-text, #a9b1d6);
-    white-space: pre-wrap;
     word-break: break-word;
+  }
+
+  .ai-popup-result-body p {
+    margin: 0 0 0.75rem 0;
+  }
+
+  .ai-popup-result-body p:last-child {
+    margin-bottom: 0;
+  }
+
+  .ai-popup-result-body strong {
+    font-weight: 600;
+    color: var(--color-accent, #7aa2f7);
+  }
+
+  .ai-popup-result-body code {
+    font-family: var(--font-mono, monospace);
+    background: rgba(122, 162, 247, 0.1);
+    padding: 0.15em 0.3em;
+    border-radius: 4px;
+    font-size: 0.85em;
+  }
+
+  .ai-popup-result-body pre code {
+    display: block;
+    padding: 0.5rem;
+    overflow-x: auto;
+    background: var(--color-bg, #1a1b26);
+  }
+
+  .ai-popup-result-body ul,
+  .ai-popup-result-body ol {
+    margin: 0 0 0.75rem 1.5rem;
+    padding: 0;
   }
 
   .ai-popup-result--error .ai-popup-error-text {

--- a/tests/ai-popup-chatbox.spec.ts
+++ b/tests/ai-popup-chatbox.spec.ts
@@ -239,6 +239,29 @@ test.describe('AI Popup - Chat Box', () => {
     // Input should no longer be visible
     await expect(input).not.toBeVisible();
   });
+
+  test('GIVEN Ask AI returns markdown WHEN result renders THEN formatting is displayed instead of raw markdown', async ({ page }) => {
+    await page.route('**/ai/ask', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          response: 'Here is **bold** text, `code`, and a list:\n\n- first\n- second',
+        }),
+      });
+    });
+
+    const popup = await setupAndSelectText(page);
+    await popup.locator('[data-action="ask"]').click();
+    await popup.locator('[data-action="submit-ask"]').click();
+
+    const resultBody = popup.locator('.ai-popup-result-body');
+    await expect(resultBody).toBeVisible({ timeout: 5000 });
+    await expect(resultBody.locator('strong')).toHaveText('bold');
+    await expect(resultBody.locator('code')).toHaveText('code');
+    await expect(resultBody.locator('li')).toHaveCount(2);
+    await expect(resultBody).not.toContainText('**bold**');
+  });
 });
 
 test.describe('AI Popup - Error Detail Display', () => {


### PR DESCRIPTION
## Summary
- render Ask AI responses as safe markdown instead of raw text
- support common markdown blocks like headings, lists, code blocks, blockquotes, bold, italic, inline code, and links
- add a regression test covering markdown rendering in the AI popup

## Testing
- pnpm exec playwright test tests/ai-popup-chatbox.spec.ts

Fixes #11