### PR TITLE
fix(a11y): DiffBlock light theme contrast + WCAG AA CI gate

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -173,6 +173,35 @@ else
 fi
 echo ""
 
+# ─── Step 0.45: WCAG AA contrast check on staged components ──────
+STAGED_STYLE=$(git diff --cached --name-only --diff-filter=ACM -- 'src/components/*.astro' 'src/styles/*.css' 2>/dev/null || true)
+
+if [ -z "$STAGED_STYLE" ]; then
+    echo "✓ No component/style files staged — skipping contrast check"
+else
+    STYLE_COUNT=$(echo "$STAGED_STYLE" | wc -l | tr -d ' ')
+    echo "🎨 Contrast check: $STYLE_COUNT staged component/style file(s)..."
+
+    STYLE_FILES=""
+    for file in $STAGED_STYLE; do
+        if [ -f "$REPO_ROOT/$file" ]; then
+            STYLE_FILES="$STYLE_FILES $REPO_ROOT/$file"
+        fi
+    done
+
+    if [ -n "$STYLE_FILES" ]; then
+        if ! node "$REPO_ROOT/scripts/check-contrast.mjs" $STYLE_FILES; then
+            echo ""
+            echo "❌ WCAG AA contrast check FAILED."
+            echo "   Fix color pairs to meet ≥4.5:1 contrast ratio."
+            echo "   Run: pnpm run check:contrast"
+            exit 1
+        fi
+        echo "✓ Contrast check passed"
+    fi
+fi
+echo ""
+
 # ─── Step 0.5: ESLint check on staged files ──────────────────────
 STAGED_LINT=$(git diff --cached --name-only --diff-filter=ACM -- '*.ts' '*.tsx' '*.astro' '*.mjs' 2>/dev/null || true)
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,18 @@ jobs:
       - name: Prettier check
         run: pnpm run format:check
 
+  contrast:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v5
+      - uses: actions/setup-node@v6
+        with: { node-version: 22, cache: 'pnpm' }
+      - run: pnpm install --frozen-lockfile
+
+      - name: WCAG AA contrast check
+        run: pnpm run check:contrast
+
   validate-content:
     runs-on: ubuntu-latest
     steps:
@@ -72,7 +84,7 @@ jobs:
   # ─── Sequential tier: build after all checks pass ───────────────
   build:
     runs-on: ubuntu-latest
-    needs: [lockfile-consistency, lint, validate-content, security-gate]
+    needs: [lockfile-consistency, lint, contrast, validate-content, security-gate]
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v5

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "deps:check": "node scripts/dependency-freshness.mjs",
     "deps:report": "node scripts/dependency-freshness.mjs --verbose",
     "check:mermaid": "node scripts/check-mermaid-visual.mjs",
+    "check:contrast": "node scripts/check-contrast.mjs",
     "content:velocity": "node scripts/content-velocity.mjs",
     "api:dev": "cd sqaa-api && pnpm dev",
     "api:start": "cd sqaa-api && pnpm start",

--- a/scripts/check-contrast.mjs
+++ b/scripts/check-contrast.mjs
@@ -1,0 +1,159 @@
+#!/usr/bin/env node
+// WCAG AA contrast ratio checker for gu-log components.
+//
+// Scans .astro and .css files for foreground/background color pairs
+// declared via inline comments like:
+//   color: #116329; /* forest green — 6.66:1 on #f0f5e6 */
+//
+// The pattern "on #xxxxxx" tells the checker what background to test against.
+//
+// Exit 1 if any pair fails WCAG AA (4.5:1 for normal text).
+//
+// Usage:
+//   node scripts/check-contrast.mjs              # scan all components
+//   node scripts/check-contrast.mjs src/components/DiffBlock.astro
+
+import { readFileSync, existsSync } from 'fs';
+import { resolve, relative } from 'path';
+
+// ── WCAG math ───────────────────────────────────────────────────────
+
+function hexToRgb(hex) {
+  hex = hex.replace('#', '');
+  if (hex.length === 3) hex = hex[0] + hex[0] + hex[1] + hex[1] + hex[2] + hex[2];
+  return [
+    parseInt(hex.slice(0, 2), 16) / 255,
+    parseInt(hex.slice(2, 4), 16) / 255,
+    parseInt(hex.slice(4, 6), 16) / 255,
+  ];
+}
+
+function relativeLuminance(hex) {
+  const [r, g, b] = hexToRgb(hex).map((c) =>
+    c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4),
+  );
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+function contrastRatio(fg, bg) {
+  const l1 = relativeLuminance(fg);
+  const l2 = relativeLuminance(bg);
+  const lighter = Math.max(l1, l2);
+  const darker = Math.min(l1, l2);
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+// ── Hardcoded manifest for pairs that can't be auto-detected ────────
+// Format: { fg, bg, context, file }
+// Add entries here when CSS variables or complex selectors make
+// auto-detection impractical.
+
+const MANIFEST = [
+  // AiJudgeScore light theme
+  { fg: '#047857', bg: '#fdf6e3', context: 'light score-high', file: 'src/components/AiJudgeScore.astro' },
+  { fg: '#586e75', bg: '#fdf6e3', context: 'light score-pass', file: 'src/components/AiJudgeScore.astro' },
+  { fg: '#b71c1c', bg: '#fdf6e3', context: 'light score-fail', file: 'src/components/AiJudgeScore.astro' },
+  // ClawdNote light theme (orange on surface)
+  { fg: '#955330', bg: '#eee8d5', context: 'light clawd-orange on surface', file: 'src/components/ClawdNote.astro' },
+];
+
+// ── Auto-scan: extract "color: #xxx; /* ... on #yyy */" patterns ────
+
+const COLOR_ON_BG_RE = /color:\s*(#[0-9a-fA-F]{3,8});\s*\/\*.*?on\s+(#[0-9a-fA-F]{3,8})/g;
+
+function scanFile(filePath) {
+  const pairs = [];
+  const content = readFileSync(filePath, 'utf-8');
+  const lines = content.split('\n');
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    let match;
+    COLOR_ON_BG_RE.lastIndex = 0;
+    while ((match = COLOR_ON_BG_RE.exec(line)) !== null) {
+      pairs.push({
+        fg: match[1],
+        bg: match[2],
+        file: filePath,
+        line: i + 1,
+        context: line.trim(),
+      });
+    }
+  }
+  return pairs;
+}
+
+// ── Main ────────────────────────────────────────────────────────────
+
+const AA_NORMAL = 4.5;
+const AA_LARGE = 3.0;
+const THRESHOLD = AA_NORMAL; // we check normal text by default
+
+const args = process.argv.slice(2);
+const repoRoot = resolve(import.meta.dirname, '..');
+
+let files;
+if (args.length > 0) {
+  files = args.map((f) => resolve(f));
+} else {
+  // Scan all component and style files
+  const { execSync } = await import('node:child_process');
+  const found = execSync(
+    'find src/components src/styles -name "*.astro" -o -name "*.css" 2>/dev/null',
+    { cwd: repoRoot, encoding: 'utf-8' },
+  )
+    .trim()
+    .split('\n')
+    .filter(Boolean);
+  files = found.map((f) => resolve(repoRoot, f));
+}
+
+// Collect all pairs
+const allPairs = [];
+
+// Auto-scan files
+for (const file of files) {
+  if (!existsSync(file)) continue;
+  allPairs.push(...scanFile(file));
+}
+
+// Add manifest pairs
+for (const entry of MANIFEST) {
+  allPairs.push({
+    ...entry,
+    file: resolve(repoRoot, entry.file),
+    line: null,
+  });
+}
+
+// Check all pairs
+let failures = 0;
+let checked = 0;
+
+for (const pair of allPairs) {
+  checked++;
+  const ratio = contrastRatio(pair.fg, pair.bg);
+  const pass = ratio >= THRESHOLD;
+  const relFile = relative(repoRoot, pair.file);
+  const loc = pair.line ? `${relFile}:${pair.line}` : relFile;
+
+  if (!pass) {
+    failures++;
+    console.error(
+      `❌ FAIL  ${pair.fg} on ${pair.bg} → ${ratio.toFixed(2)}:1 (need ≥${THRESHOLD}:1)  ${loc}`,
+    );
+    if (pair.context) {
+      console.error(`         ${pair.context}`);
+    }
+  }
+}
+
+if (checked === 0) {
+  console.log('ℹ️  No contrast pairs found to check.');
+  console.log('   Add "/* ... on #xxxxxx */" comments to color declarations to enable checking.');
+} else if (failures === 0) {
+  console.log(`✓ All ${checked} color contrast pairs pass WCAG AA (≥${THRESHOLD}:1)`);
+} else {
+  console.error(`\n${failures}/${checked} pairs FAILED WCAG AA contrast check.`);
+  process.exit(1);
+}

--- a/scripts/check-contrast.mjs
+++ b/scripts/check-contrast.mjs
@@ -30,7 +30,7 @@ function hexToRgb(hex) {
 
 function relativeLuminance(hex) {
   const [r, g, b] = hexToRgb(hex).map((c) =>
-    c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4),
+    c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4)
   );
   return 0.2126 * r + 0.7152 * g + 0.0722 * b;
 }
@@ -50,11 +50,31 @@ function contrastRatio(fg, bg) {
 
 const MANIFEST = [
   // AiJudgeScore light theme
-  { fg: '#047857', bg: '#fdf6e3', context: 'light score-high', file: 'src/components/AiJudgeScore.astro' },
-  { fg: '#586e75', bg: '#fdf6e3', context: 'light score-pass', file: 'src/components/AiJudgeScore.astro' },
-  { fg: '#b71c1c', bg: '#fdf6e3', context: 'light score-fail', file: 'src/components/AiJudgeScore.astro' },
+  {
+    fg: '#047857',
+    bg: '#fdf6e3',
+    context: 'light score-high',
+    file: 'src/components/AiJudgeScore.astro',
+  },
+  {
+    fg: '#586e75',
+    bg: '#fdf6e3',
+    context: 'light score-pass',
+    file: 'src/components/AiJudgeScore.astro',
+  },
+  {
+    fg: '#b71c1c',
+    bg: '#fdf6e3',
+    context: 'light score-fail',
+    file: 'src/components/AiJudgeScore.astro',
+  },
   // ClawdNote light theme (orange on surface)
-  { fg: '#955330', bg: '#eee8d5', context: 'light clawd-orange on surface', file: 'src/components/ClawdNote.astro' },
+  {
+    fg: '#955330',
+    bg: '#eee8d5',
+    context: 'light clawd-orange on surface',
+    file: 'src/components/ClawdNote.astro',
+  },
 ];
 
 // ── Auto-scan: extract "color: #xxx; /* ... on #yyy */" patterns ────
@@ -100,7 +120,7 @@ if (args.length > 0) {
   const { execSync } = await import('node:child_process');
   const found = execSync(
     'find src/components src/styles -name "*.astro" -o -name "*.css" 2>/dev/null',
-    { cwd: repoRoot, encoding: 'utf-8' },
+    { cwd: repoRoot, encoding: 'utf-8' }
   )
     .trim()
     .split('\n')
@@ -140,7 +160,7 @@ for (const pair of allPairs) {
   if (!pass) {
     failures++;
     console.error(
-      `❌ FAIL  ${pair.fg} on ${pair.bg} → ${ratio.toFixed(2)}:1 (need ≥${THRESHOLD}:1)  ${loc}`,
+      `❌ FAIL  ${pair.fg} on ${pair.bg} → ${ratio.toFixed(2)}:1 (need ≥${THRESHOLD}:1)  ${loc}`
     );
     if (pair.context) {
       console.error(`         ${pair.context}`);

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -173,6 +173,35 @@ else
 fi
 echo ""
 
+# ─── Step 0.45: WCAG AA contrast check on staged components ──────
+STAGED_STYLE=$(git diff --cached --name-only --diff-filter=ACM -- 'src/components/*.astro' 'src/styles/*.css' 2>/dev/null || true)
+
+if [ -z "$STAGED_STYLE" ]; then
+    echo "✓ No component/style files staged — skipping contrast check"
+else
+    STYLE_COUNT=$(echo "$STAGED_STYLE" | wc -l | tr -d ' ')
+    echo "🎨 Contrast check: $STYLE_COUNT staged component/style file(s)..."
+
+    STYLE_FILES=""
+    for file in $STAGED_STYLE; do
+        if [ -f "$REPO_ROOT/$file" ]; then
+            STYLE_FILES="$STYLE_FILES $REPO_ROOT/$file"
+        fi
+    done
+
+    if [ -n "$STYLE_FILES" ]; then
+        if ! node "$REPO_ROOT/scripts/check-contrast.mjs" $STYLE_FILES; then
+            echo ""
+            echo "❌ WCAG AA contrast check FAILED."
+            echo "   Fix color pairs to meet ≥4.5:1 contrast ratio."
+            echo "   Run: pnpm run check:contrast"
+            exit 1
+        fi
+        echo "✓ Contrast check passed"
+    fi
+fi
+echo ""
+
 # ─── Step 0.5: ESLint check on staged files ──────────────────────
 STAGED_LINT=$(git diff --cached --name-only --diff-filter=ACM -- '*.ts' '*.tsx' '*.astro' '*.mjs' 2>/dev/null || true)
 

--- a/src/components/DiffBlock.astro
+++ b/src/components/DiffBlock.astro
@@ -79,7 +79,7 @@ const { before, after, beforeLabel = 'Before', afterLabel = 'After' } = Astro.pr
   }
 
   .diff-header--before {
-    color: #ff5555;
+    color: #ff5555; /* Dracula red — 7.45:1 on #282a36 */
   }
 
   /* After panel — green tones */
@@ -88,23 +88,24 @@ const { before, after, beforeLabel = 'Before', afterLabel = 'After' } = Astro.pr
   }
 
   .diff-header--after {
-    color: #50fa7b;
+    color: #50fa7b; /* Dracula green — 10.3:1 on #282a36 */
   }
 
-  /* Light theme */
+  /* Light theme — needs higher contrast on warm #fdf6e3 base */
   [data-theme='light'] .diff-before {
-    background: rgba(220, 50, 47, 0.06);
+    background: #fef2f1;
+    border-bottom-color: #e8c4c0;
   }
 
   [data-theme='light'] .diff-header--before {
-    color: #dc322f;
+    color: #9a3412; /* dark burnt orange — 6.68:1 on #fef2f1 */
   }
 
   [data-theme='light'] .diff-after {
-    background: rgba(42, 161, 68, 0.06);
+    background: #f0f5e6;
   }
 
   [data-theme='light'] .diff-header--after {
-    color: #2aa144;
+    color: #116329; /* forest green — 6.66:1 on #f0f5e6 */
   }
 </style>

--- a/src/components/DiffBlock.astro
+++ b/src/components/DiffBlock.astro
@@ -79,7 +79,7 @@ const { before, after, beforeLabel = 'Before', afterLabel = 'After' } = Astro.pr
   }
 
   .diff-header--before {
-    color: #ff5555; /* Dracula red — 7.45:1 on #282a36 */
+    color: #ff5555; /* Dracula red — 4.53:1 on #282a36 */
   }
 
   /* After panel — green tones */
@@ -88,7 +88,7 @@ const { before, after, beforeLabel = 'Before', afterLabel = 'After' } = Astro.pr
   }
 
   .diff-header--after {
-    color: #50fa7b; /* Dracula green — 10.3:1 on #282a36 */
+    color: #50fa7b; /* Dracula green — 10.38:1 on #282a36 */
   }
 
   /* Light theme — needs higher contrast on warm #fdf6e3 base */


### PR DESCRIPTION
## Summary
- **DiffBlock light theme fix**: headers were nearly invisible (green-on-green 2.89:1, orange-on-pink 4.21:1). Now uses solid bg tints (`#fef2f1` pink, `#f0f5e6` green) and WCAG AA-passing header colors (6.66:1, 6.68:1)
- **New `check:contrast` script**: convention-based — any `color:` declaration with `/* ... on #hex */` comment gets auto-tested against WCAG AA (≥4.5:1)
- **CI gate**: new parallel `contrast` job in PR Fast Gate workflow
- **Pre-commit hook**: Step 0.45 runs contrast check when `.astro`/`.css` files are staged

## Test plan
- [ ] Verify DiffBlock looks correct in light theme on SD-19 post
- [ ] Verify DiffBlock still looks correct in dark theme
- [ ] Run `pnpm run check:contrast` — should pass (8 pairs)
- [ ] Verify CI `contrast` job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)