### PR TITLE
feat(obsidian): draft pipeline + CC/CCC playbook + solo-author docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,44 @@ vercel logs --since 1h         # 查最近 1h request logs（需 vercel login）
 
 ## Dev Workflow
 
+### Solo-author branch policy
+
+這個 repo **只有 user 一個人**（human author + 幾個 AI agent 幫手）。所以：
+
+- **預設：直接在 `main` 開發 + push**。不要替每個小改動開 feature branch——單人 repo 沒有 code review 防護的需求，branch 只是無謂的 overhead。
+- Push main → Vercel auto-deploy → user 在 production 驗收。品質由 pre-commit hook、`validate-posts.mjs`、pre-push hook、以及 Ralph Loop tribunal 把關。
+- **什麼時候該開 feature branch**（例外清單）：
+  - 大規模重構（改 framework、換 plugin、動到 content collection schema）
+  - 實驗性改動，可能爛幾天但要 iterate（新 UI 元件、新 agent pipeline）
+  - user 明確指示 `develop on branch xxx`（例如 web session 任務，會強制指定分支）
+  - 牽涉多個 commit 才能上線的 feature，需要整組 atomic 推上去
+- **Commit discipline（因為直接上 prod）**：一個 commit 做一件事，壞掉可以 revert 單 commit。不要把無關的改動塞同一個 commit。
+
+### Draft 來源與 Obsidian pipeline
+
+gu-log 的文章草稿有三種來源，全部最終都變成 `src/content/posts/*.mdx`：
+
+1. **iPhone / Mac Obsidian vault**（user 手動寫）
+   - Vault 住在 iCloud Drive（`~/Library/Mobile Documents/com~apple~CloudDocs/Obsidian/gu-log-drafts/`）
+   - iPhone 和 Mac 透過 iCloud 自動同步，不用 git、不用處理 conflict
+   - 草稿用純 `.md` + Obsidian callout 語法（`> [!clawd]` / `> [!shroomdog]`）+ wikilink（`[[slug]]`）
+   - Mac 上跑 `pnpm run obsidian:import <draft.md>` 匯入成 MDX：
+     - Callout → `<ClawdNote>` / `<ShroomDogNote>` 元件
+     - Wikilink → `/posts/...` 連結
+     - 自動補 frontmatter、自動 bump `scripts/article-counter.json`
+     - 自動跑 `validate-posts.mjs`
+   - 完整設定和 workflow 在 `OBSIDIAN_SETUP.md`
+2. **VS Code / Cursor / CC 直接編 MDX**（手動 + AI 輔助）
+   - 走原本流程：手動填 frontmatter → validate → commit
+   - 適合改現有文章、寫需要複雜元件的文章
+3. **Clawd / CP pipeline 自動產**（VPS 上的 agent）
+   - `scripts/sp-pipeline.sh`、`scripts/clawd-picks-prompt.md`、`cp-candidates-queue.yaml`
+   - Clawd 看 tweet → 翻譯 → 產 MDX → tribunal → push
+
+**Mental model**：Obsidian 是「輸入端的 ergonomics 層」，不是新的 publishing platform。所有文章最終還是 Astro + Vercel render。這個設計讓 user 可以在 iPhone / Mac 之間隨時寫草稿，回到 Mac 再用 import script 一鍵轉成 repo 標準格式。
+
+### 其他 workflow 規則
+
 - **User 只看 production**（gu-log.vercel.app）。不要叫 user 開 dev server。
 - **CC 自己跑 `pnpm run dev`** 來 iterate，用 `playwright-cli` 截圖驗證 UI（skill 在 `.claude/skills/playwright-cli/`）。
 - **UI/UX 品質**：改完任何視覺的東西（CSS、component、color、spacing、typography、layout）就跑 `uiux-auditor` skill（`.claude/skills/uiux-auditor/`）。它會強制兩個主題都截圖、算 WCAG 對比、flag 寫死的 hex。不要等 user 來挑錯。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,44 @@ vercel logs --since 1h         # 查最近 1h request logs（需 vercel login）
 
 ## Dev Workflow
 
+### CC vs CCC: Who am I, and what can I do?
+
+兩種 Claude Code instance 會碰這個 repo，**開場第一件事先跑 `./scripts/detect-env.sh`** 確認自己是哪個：
+
+- **CC** (Local Claude Code): Mac 本地端，user 在旁邊互動式 iterate
+- **CCC** (Cloud Claude Code): Claude Code 網頁版，Linux 沙箱，每次被叫醒都在 harness 自動建的 `claude/xxx` branch 上
+
+#### CCC playbook
+
+CCC 的 branch 是拋棄式的，sandbox 也是拋棄式的，user 不在場。精神：**move fast, merge fast, fix fast**。
+
+- **PR scope 可以大、可以雜**。做任務時順手修相關的東西，不用 split PR。
+- **Commit 內部維持 atomic**（一個 commit 做一件事）——revert 時才好下刀。這是 CCC 放手做事的保險。
+- **Scope ceiling**：一般情況只修「當前任務路徑相關」的問題。**例外**：
+  - Production 炸了（Vercel 上線掛了）
+  - main CI broken（有 regression 溜過 pre-push）
+  - 這類緊急事件沒有 scope 之分，看到立刻順手修。
+- **Self-merge policy**（user 已授權）：
+  1. `git push -u origin claude/xxx`
+  2. 用 GitHub MCP 開 PR 到 main
+  3. **等 CI 全綠**後自己 `merge_pull_request`
+  4. 合完跟 user 回報 PR URL + 簡短 summary
+- **失敗處理**：Vercel build / Ralph Loop / validate-posts / CI 沒過：
+  1. 先試 forward fix（新 commit 修）
+  2. 一次不過就想想再試第二次
+  3. 還不過就 spawn opus subagent 救（最多 3 次 subagent attempt）
+  4. 全部失敗 → `git revert` 並跟 user report 發生什麼事
+- **品質 gate 全部保留**：不要 `--no-verify`、不要跳過 pre-commit / pre-push、不要關掉 Ralph Loop。這些是 CCC 能放手的前提。
+
+#### CC playbook
+
+CC 的環境不固定，user 可能在 main、可能在 worktree、可能在 feature branch。
+
+- **觀察環境再決定**：跑 `./scripts/detect-env.sh`，再看 `git worktree list`、`git branch --show-current`、`git status`。不要假設在 main。
+- User 在旁邊，大動作（framework / schema / infra / 刪文章）之前先問一下再動手。
+- 互動式的 sanity check 比自動化 gate 更重要——壞掉可以立刻喊停。
+- 其他跟 CCC 一樣：commit atomic、品質 gate 不能跳過、Ralph Loop 照跑。
+
 ### Solo-author branch policy
 
 這個 repo **只有 user 一個人**（human author + 幾個 AI agent 幫手）。所以：

--- a/OBSIDIAN_SETUP.md
+++ b/OBSIDIAN_SETUP.md
@@ -1,0 +1,220 @@
+# Obsidian Setup（iPhone + Mac + iCloud）
+
+> 用 Obsidian 當 gu-log 的「草稿編輯器」，**不取代** Astro / Vercel pipeline。iPhone 上寫草稿 → Mac 上 import → 跑 Ralph Loop → `git push`。
+
+## 為什麼這樣分工
+
+- **iPhone**：只負責寫草稿。純 markdown + Obsidian callout。iCloud Drive 自動同步，沒有 git、沒有 terminal、沒有 conflict。
+- **Mac**：負責把草稿 import 成 MDX（含 frontmatter、component、ticket ID）、跑品質 tribunal、push。
+- **線上**：`gu-log.vercel.app` 正式版。你可以在 iPhone 上同時開 Obsidian（看原始草稿）和 Vercel（看成品），比較 frontend 帶來的加值——字型、TOC、Solarized 主題、ClawdNote 的吐槽框 render、reading progress、系列導覽。
+
+## 一次性設定
+
+### 1. iCloud Drive：建草稿資料夾
+
+在 Mac 上：
+
+```
+~/Library/Mobile Documents/com~apple~CloudDocs/Obsidian/gu-log-drafts/
+```
+
+或從 Finder 打開 **iCloud Drive**，新建 `Obsidian/gu-log-drafts/`。
+
+**⚠️ 不要把整個 gu-log git repo 搬到 iCloud**。iCloud 會跟 `.git/` 吵架，還會產生一堆 `.icloud` 佔位檔。vault 跟 repo 分家，只靠 import script 串起來。
+
+### 2. Mac 上的 Obsidian
+
+1. 下載 https://obsidian.md 官方版
+2. 啟動 → `Open folder as vault` → 選 `iCloud Drive/Obsidian/gu-log-drafts/`
+3. Settings → Files & Links → **Default location for new notes**：`In the current folder`
+4. Community plugins → 開 → 裝 **Templater**（用來自動塞 frontmatter 骨架）
+
+### 3. iPhone 上的 Obsidian
+
+1. App Store 下載 **Obsidian** 免費版
+2. 首次開啟 → `Create new vault` → `Store in iCloud` → **一定要選同一個資料夾名**：`gu-log-drafts`
+3. 稍等幾秒，你在 Mac 寫的檔案會自動出現
+4. 確認方式：Mac 上建一個 `test.md`，iPhone 上 10 秒內應該看得到
+
+### 4. Templater 模板（選配但超推薦）
+
+在 vault 裡建一個 `_templates/` 資料夾，然後建 `_templates/sd-draft.md`：
+
+```markdown
+---
+series: SD
+title: "<% tp.file.title %>"
+summary: ""
+tags: []
+originalDate: <% tp.date.now("YYYY-MM-DD") %>
+---
+
+# <% tp.file.title %>
+
+（寫這裡）
+
+> [!clawd] Clawd 吐槽
+> （吐槽內容）
+```
+
+再建 `_templates/sp-draft.md`（SP 系列）：
+
+```markdown
+---
+series: SP
+title: ""
+summary: ""
+source: "@xxx on X"
+sourceUrl: "https://x.com/..."
+author: "@xxx"
+tags: []
+originalDate: <% tp.date.now("YYYY-MM-DD") %>
+---
+
+# 標題
+
+（翻譯內容）
+
+> [!clawd] Clawd 吐槽
+> （吐槽）
+```
+
+Settings → Templater → **Template folder location** 設成 `_templates/`。之後 iPhone 上新增筆記就可以選模板。
+
+## Workflow：從 iPhone 草稿到上線
+
+### 在 iPhone / Mac 寫草稿
+
+1. Obsidian 新建筆記，套用 Templater 模板（SD / SP / CP / Lv）
+2. 填 `title` / `summary` / `tags`
+3. 正文用 markdown 寫，**不要手動寫 `<ClawdNote>` component**——用 Obsidian callout 語法：
+
+   ```markdown
+   > [!clawd] Clawd 吐槽
+   > 這裡是吐槽內容第一行
+   > 第二行
+   ```
+
+   ```markdown
+   > [!shroomdog]
+   > ShroomDog 自己講話
+   ```
+
+4. 連結到其他文章用 wikilink：`[[sp-100-xxx]]`，import 時會自動轉成 `/posts/sp-100-xxx`
+
+### 在 Mac 上 import
+
+```bash
+# 預覽（不會寫檔也不會 bump counter）
+node scripts/obsidian-import.mjs "$HOME/Library/Mobile Documents/com~apple~CloudDocs/Obsidian/gu-log-drafts/my-draft.md" --dry-run
+
+# 正式 import
+node scripts/obsidian-import.mjs "$HOME/Library/Mobile Documents/com~apple~CloudDocs/Obsidian/gu-log-drafts/my-draft.md"
+```
+
+或一次匯入整個 vault：
+
+```bash
+node scripts/obsidian-import.mjs --all "$HOME/Library/Mobile Documents/com~apple~CloudDocs/Obsidian/gu-log-drafts/"
+```
+
+import 會自動做：
+
+- ✅ 產生 `src/content/posts/{series}-{N}-{date}-{slug}.mdx`
+- ✅ 依照 `scripts/article-counter.json` 拿下一個 ticket ID 並 bump
+- ✅ Obsidian callout → `<ClawdNote>` / `<ShroomDogNote>` 元件
+- ✅ Wikilink → `/posts/...` 連結
+- ✅ 自動加 frontmatter 必填欄位（`translatedBy`、`lang` 等）
+- ✅ 跑 `scripts/validate-posts.mjs` 確認沒爛
+
+### 跑品質 tribunal + push
+
+```bash
+./scripts/ralph-loop.sh             # Vibe / Fact / Librarian / FreshEyes
+git add scripts/article-counter.json src/content/posts/
+git commit -m "content(sd-20): ..."
+git push
+```
+
+Vercel 自動 deploy，幾分鐘後 `gu-log.vercel.app` 上線。
+
+## iPhone 上比較 Obsidian vs 網站
+
+這是這次改動最爽的副作用：**你可以在 iPhone 上同時開兩個 app**，對同一篇文章看兩種體驗。
+
+| 體驗 | Obsidian iOS | gu-log.vercel.app |
+|---|---|---|
+| 字型 | 系統預設 | Inter + Noto Sans TC |
+| 主題 | Obsidian 內建 | Solarized dark / light 切換 |
+| TOC | 手動靠 headings | 左側 auto-generated TOC + reading progress |
+| ClawdNote | 純 blockquote（callout 渲染） | 有框、有配色、有 persona |
+| 系列導覽 | 無 | Prev / Next + 系列章節 |
+| Wikilinks | 雙向圖、graph view | 轉成一般連結 |
+| Search | 全文（vault 內） | 全文（Pagefind） |
+| 分享 | 只能分享 markdown | 有 OG image、RSS、canonical URL |
+
+用這個當「品質 checklist」：**Obsidian 裡沒有的，就是你前端值得投資的地方**。
+
+## 常見問題
+
+**Q: iCloud 同步卡住？**
+- iPhone → Obsidian → Settings → Files & Links → 確認 vault path 對
+- Mac 上打開 Finder → iCloud Drive，看有沒有「下載中」的雲端圖示
+- 重開 Obsidian app 通常就好
+
+**Q: 草稿 import 後想重改怎麼辦？**
+- 改 vault 裡的 `.md` → 重新 `obsidian-import.mjs`？**不要**——counter 會再 bump。
+- 直接改 `src/content/posts/*.mdx` 比較乾脆。vault 裡的 draft 可以留作原始備份或直接刪掉。
+- 或者：import 前就用 `--dry-run` 確認無誤再正式跑。
+
+**Q: SD 系列不需要 `source` / `sourceUrl`？**
+- 對，SD 是原創。import script 會自動填 `source: "ShroomDog Lab"` / `sourceUrl: "https://gu-log.vercel.app/"`
+- SP / CP 必填，沒填會直接報錯
+
+**Q: 我想在 iPhone 上直接 commit、直接跑 validate？**
+- 別。iPhone 跑不動 node script，跑不動 ralph-loop。維持「iPhone = 寫 / Mac = 發布」分工。硬要在 iPhone 上做 git 只會讓你恨自己。
+
+**Q: Templater 太複雜，我想手打 frontmatter？**
+- 可以。最少欄位：`series` + `title` + `summary`（SD/Lv）；SP/CP 再加 `source` + `sourceUrl`。其餘 import script 會補。
+
+## 草稿 frontmatter 最小範例
+
+### SD（原創）
+
+```markdown
+---
+series: SD
+title: "我想寫的東西"
+summary: "這篇在講什麼"
+tags: [ai-agent]
+---
+
+正文開始。
+
+> [!clawd] Clawd 吐槽
+> 欸這個不錯喔
+```
+
+### SP（翻譯）
+
+```markdown
+---
+series: SP
+title: "翻譯後的中文標題"
+summary: "一句話摘要"
+source: "@karpathy on X"
+sourceUrl: "https://x.com/karpathy/status/xxxxx"
+author: "@karpathy"
+tags: [ai, llm]
+originalDate: 2026-04-10
+---
+
+翻譯內文。
+
+> [!clawd]
+> Clawd 的吐槽
+```
+
+---
+
+以上。有問題改這份文件或叫 Claude Code 幫你改 import script。這套是疊加式的——隨時想回純 VS Code 工作流，把 vault 資料夾留著當草稿區就好，什麼東西都不用刪。

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "format": "prettier --write \"src/components/**/*.{astro,js,ts}\" \"src/layouts/**/*.{astro,js,ts}\" \"src/pages/**/*.{astro,js,ts}\" \"src/config/**/*.{js,ts}\" \"src/styles/**/*.css\" \"scripts/**/*.{js,mjs,cjs,ts}\" \"*.{mjs,cjs,ts}\"",
     "format:check": "prettier --check \"src/components/**/*.{astro,js,ts}\" \"src/layouts/**/*.{astro,js,ts}\" \"src/pages/**/*.{astro,js,ts}\" \"src/config/**/*.{js,ts}\" \"src/styles/**/*.css\" \"scripts/**/*.{js,mjs,cjs,ts}\" \"*.{mjs,cjs,ts}\"",
     "validate:posts": "node scripts/validate-posts.mjs",
+    "obsidian:import": "node scripts/obsidian-import.mjs",
     "content:check": "pnpm run validate:posts && pnpm run build",
     "lockfile:check": "pnpm install --frozen-lockfile && git diff --exit-code -- pnpm-lock.yaml",
     "security:gate": "node scripts/security-gate.mjs",

--- a/scripts/detect-env.sh
+++ b/scripts/detect-env.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# detect-env.sh — 判斷這個 Claude Code instance 是 CC 還是 CCC
+#
+# CC  (Local Claude Code):  Mac 本地端，user 在旁邊互動式 iterate
+# CCC (Cloud Claude Code):  Claude Code 網頁版，Linux 沙箱，auto-branch
+#
+# 用法：
+#   ./scripts/detect-env.sh             # 印 mode (stdout) + 提示 (stderr)
+#   mode=$(./scripts/detect-env.sh)     # 只拿 mode 字串
+#
+# 第一件事：任何 Claude session 開場就跑一下這個，確認自己是誰、
+# 哪套 playbook 要套。完整 playbook 見 CLAUDE.md 的
+# "CC vs CCC: Who am I, and what can I do?" section。
+
+set -euo pipefail
+
+branch="$(git branch --show-current 2>/dev/null || echo 'unknown')"
+uname_s="$(uname -s)"
+cwd="$(pwd)"
+
+# CCC 判斷條件（三個都要中才算 CCC）：
+#   1. branch 開頭是 claude/（harness 自動建的 branch）
+#   2. 在 Linux 上（Mac 是 Darwin）
+#   3. cwd 在 /home/user/ 底下（Claude Code web 的 sandbox 路徑）
+ccc_branch=false
+ccc_os=false
+ccc_cwd=false
+[[ "$branch" == claude/* ]] && ccc_branch=true
+[[ "$uname_s" == "Linux" ]] && ccc_os=true
+[[ "$cwd" == /home/user/* ]] && ccc_cwd=true
+
+if $ccc_branch && $ccc_os && $ccc_cwd; then
+  mode=CCC
+else
+  mode=CC
+fi
+
+echo "$mode"
+
+# 提示訊息走 stderr，這樣 `mode=$(./scripts/detect-env.sh)` 只會拿到純 mode
+{
+  echo
+  echo "env: branch=$branch os=$uname_s cwd=$cwd"
+  if [[ "$mode" == "CCC" ]]; then
+    cat <<'TIPS'
+
+You are Cloud Claude Code (CCC). Playbook:
+  - Move fast, merge fast, fix fast — this branch is disposable
+  - PR scope can be wide; commits inside stay atomic (revert-friendly)
+  - Self-merge ONLY when all CI is green
+  - Forward fix first; after 3 failed tries (spawn opus subagents), revert
+  - Scope: touch related paths only, EXCEPT prod/CI emergencies (always fix)
+  - Quality gates (pre-commit, pre-push, Ralph Loop) are non-negotiable
+  - Full playbook: CLAUDE.md "CC vs CCC" section
+TIPS
+  else
+    cat <<'TIPS'
+
+You are Local Claude Code (CC). Playbook:
+  - Observe env first: git worktree list, current branch, git status
+  - User often uses worktrees — do NOT assume you're on main
+  - User is nearby; ask before major refactors or risky operations
+  - Full playbook: CLAUDE.md "CC vs CCC" section
+TIPS
+  fi
+} >&2

--- a/scripts/obsidian-import.mjs
+++ b/scripts/obsidian-import.mjs
@@ -1,0 +1,400 @@
+#!/usr/bin/env node
+// obsidian-import.mjs
+// ---------------------------------------------------------------------------
+// 把 Obsidian vault 裡的草稿 .md 匯入成 gu-log 的 MDX 文章。
+//
+// Vault 草稿的樣貌（iPhone / Mac 在 Obsidian 裡寫的東西）：
+//
+//   ---
+//   series: SD               # SD / SP / CP / Lv
+//   title: "文章標題"
+//   summary: "一兩句話摘要"
+//   source: "ShroomDog Lab"            # SD 可省；SP/CP 必填
+//   sourceUrl: "https://..."           # SD 可省；SP/CP 必填
+//   author: "@foo on X"                # 選填
+//   tags: [ai-agent, memory]           # 選填
+//   originalDate: 2026-04-11            # 選填，省略 = 今天
+//   ---
+//
+//   這裡寫正文。Clawd / ShroomDog 的吐槽框用 Obsidian callout 語法：
+//
+//   > [!clawd] Clawd 吐槽
+//   > 內容 1
+//   > 內容 2
+//
+//   > [!shroomdog]
+//   > ShroomDog 自己講話
+//
+//   連結：[[sp-100-slug]] → 會轉成 /posts/sp-100-slug
+//
+// 使用方式：
+//   node scripts/obsidian-import.mjs <path-to-draft.md>          # import 單一檔
+//   node scripts/obsidian-import.mjs --all <vault-dir>           # import 整個資料夾
+//   node scripts/obsidian-import.mjs <draft.md> --dry-run        # 只印結果不寫檔
+//
+// 匯入後：
+//   1. 產生 src/content/posts/{series}-{N}-{date}-{slug}.mdx
+//   2. 自動 bump scripts/article-counter.json
+//   3. 跑 scripts/validate-posts.mjs 驗證
+//   4. 印出下一步（git add / commit / ralph-loop）
+// ---------------------------------------------------------------------------
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execSync } from 'node:child_process';
+import matter from 'gray-matter';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const ROOT = path.resolve(__dirname, '..');
+const POSTS_DIR = path.join(ROOT, 'src/content/posts');
+const COUNTER_PATH = path.join(ROOT, 'scripts/article-counter.json');
+
+// ---------------------------------------------------------------------------
+// 工具
+// ---------------------------------------------------------------------------
+
+function today() {
+  // YYYY-MM-DD（以系統時間為準，Obsidian 草稿沒寫日期就用今天）
+  const d = new Date();
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+}
+
+function slugify(input) {
+  return String(input)
+    .toLowerCase()
+    .replace(/[^\w\s-]/g, '')
+    .trim()
+    .replace(/\s+/g, '-')
+    .slice(0, 60);
+}
+
+function readCounter() {
+  return JSON.parse(fs.readFileSync(COUNTER_PATH, 'utf-8'));
+}
+
+function writeCounter(counter) {
+  fs.writeFileSync(COUNTER_PATH, JSON.stringify(counter, null, 2) + '\n');
+}
+
+// ---------------------------------------------------------------------------
+// Callout 轉換：Obsidian callout → <ClawdNote> / <ShroomDogNote>
+// ---------------------------------------------------------------------------
+
+const CALLOUT_MAP = {
+  clawd: 'ClawdNote',
+  clawdnote: 'ClawdNote',
+  shroomdog: 'ShroomDogNote',
+  shroomdognote: 'ShroomDogNote',
+  sd: 'ShroomDogNote',
+};
+
+function convertCallouts(body) {
+  // Obsidian callout 語法：
+  //   > [!type] optional title
+  //   > line 1
+  //   > line 2
+  // 空行結束 block。
+  const lines = body.split('\n');
+  const out = [];
+  let i = 0;
+
+  const usedComponents = new Set();
+
+  while (i < lines.length) {
+    const line = lines[i];
+    const match = line.match(/^>\s*\[!(\w+)\](.*)$/);
+    if (match) {
+      const type = match[1].toLowerCase();
+      const component = CALLOUT_MAP[type];
+      if (component) {
+        usedComponents.add(component);
+        const content = [];
+        i++;
+        while (i < lines.length && lines[i].startsWith('>')) {
+          // 去掉 leading "> " 或 ">"
+          content.push(lines[i].replace(/^>\s?/, ''));
+          i++;
+        }
+        out.push(`<${component}>`);
+        // 去頭尾空行
+        while (content.length && content[0].trim() === '') content.shift();
+        while (content.length && content[content.length - 1].trim() === '') content.pop();
+        out.push(...content);
+        out.push(`</${component}>`);
+        out.push('');
+        continue;
+      }
+    }
+    out.push(line);
+    i++;
+  }
+
+  return { body: out.join('\n'), usedComponents };
+}
+
+// ---------------------------------------------------------------------------
+// Wikilink 轉換：[[foo]] → [foo](/posts/foo)
+// ---------------------------------------------------------------------------
+
+function convertWikilinks(body) {
+  return body.replace(/\[\[([^\]|]+)(\|([^\]]+))?\]\]/g, (_, target, _alias, label) => {
+    const text = label || target;
+    const slug = target.replace(/\.mdx?$/, '');
+    return `[${text}](/posts/${slug})`;
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Frontmatter 建構
+// ---------------------------------------------------------------------------
+
+function buildFrontmatter(draft, ticketId, _slug) {
+  const series = draft.series;
+  const isOriginal = series === 'SD' || series === 'Lv';
+  const originalDate = draft.originalDate || today();
+  const translatedDate = draft.translatedDate || today();
+
+  const fm = {
+    ticketId,
+    title: draft.title,
+    originalDate,
+    translatedDate,
+    source: draft.source || (isOriginal ? 'ShroomDog Lab' : undefined),
+    sourceUrl: draft.sourceUrl || (isOriginal ? 'https://gu-log.vercel.app/' : undefined),
+    lang: 'zh-tw',
+    summary: draft.summary,
+  };
+
+  if (draft.author) fm.author = draft.author;
+  if (draft.tags && draft.tags.length) fm.tags = draft.tags;
+
+  // SP/CP 需要 translatedBy；SD/Lv 給 Author pipeline
+  if (isOriginal) {
+    fm.translatedBy = {
+      model: draft.model || 'Opus 4.6',
+      harness: draft.harness || 'Claude Code',
+      pipeline: [
+        {
+          role: 'Author',
+          model: draft.model || 'Opus 4.6',
+          harness: draft.harness || 'Claude Code',
+        },
+      ],
+    };
+  } else {
+    // SP / CP：先給占位，使用者匯入後再照 detect-model.mjs 校正
+    fm.translatedBy = {
+      model: draft.model || 'Opus 4.6',
+      harness: draft.harness || 'Claude Code',
+      pipeline: [
+        {
+          role: 'Translator',
+          model: draft.model || 'Opus 4.6',
+          harness: draft.harness || 'Claude Code',
+        },
+      ],
+    };
+  }
+
+  if (draft.series_group) {
+    fm.series = draft.series_group;
+  }
+
+  // 清掉 undefined
+  for (const k of Object.keys(fm)) {
+    if (fm[k] === undefined) delete fm[k];
+  }
+  return fm;
+}
+
+// gray-matter 的 stringify 預設會做合理的 YAML；但我們要控制引號避免 title 被亂動
+function toYaml(obj, indent = 0) {
+  const pad = '  '.repeat(indent);
+  const lines = [];
+  for (const [k, v] of Object.entries(obj)) {
+    if (v === undefined || v === null) continue;
+    if (Array.isArray(v)) {
+      if (v.length === 0) continue;
+      if (typeof v[0] === 'object') {
+        lines.push(`${pad}${k}:`);
+        const itemPad = '  '.repeat(indent + 1);
+        for (const item of v) {
+          // Render item lines at indent+1, then strip that padding and re-attach
+          // dash to the first line / matching indent to continuation lines.
+          const rendered = toYaml(item, indent + 1).split('\n');
+          lines.push(`${itemPad}- ${rendered[0].slice(itemPad.length)}`);
+          for (const r of rendered.slice(1)) {
+            lines.push(`${itemPad}  ${r.slice(itemPad.length)}`);
+          }
+        }
+      } else {
+        lines.push(`${pad}${k}: [${v.map((x) => JSON.stringify(x)).join(', ')}]`);
+      }
+    } else if (typeof v === 'object') {
+      lines.push(`${pad}${k}:`);
+      lines.push(toYaml(v, indent + 1));
+    } else if (typeof v === 'string') {
+      // 統一用雙引號，避免冒號、引號打架
+      const esc = v.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+      lines.push(`${pad}${k}: "${esc}"`);
+    } else {
+      lines.push(`${pad}${k}: ${v}`);
+    }
+  }
+  return lines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// 主流程：處理單一 draft 檔
+// ---------------------------------------------------------------------------
+
+function importOne(draftPath, { dryRun = false } = {}) {
+  const raw = fs.readFileSync(draftPath, 'utf-8');
+  const parsed = matter(raw);
+  const draft = parsed.data;
+  let body = parsed.content;
+
+  if (!draft.series) {
+    throw new Error(`[${draftPath}] frontmatter 缺 series (SD / SP / CP / Lv)`);
+  }
+  if (!draft.title) {
+    throw new Error(`[${draftPath}] frontmatter 缺 title`);
+  }
+  if (!draft.summary) {
+    throw new Error(`[${draftPath}] frontmatter 缺 summary`);
+  }
+  const series = String(draft.series).toUpperCase();
+  if (!['SD', 'SP', 'CP', 'LV'].includes(series)) {
+    throw new Error(`[${draftPath}] series "${draft.series}" 不合法，必須是 SD / SP / CP / Lv`);
+  }
+  const seriesKey = series === 'LV' ? 'Lv' : series;
+
+  // SP / CP 必填 source / sourceUrl
+  if ((seriesKey === 'SP' || seriesKey === 'CP') && (!draft.source || !draft.sourceUrl)) {
+    throw new Error(`[${draftPath}] ${seriesKey} 系列必填 source + sourceUrl`);
+  }
+
+  // 1. 決定 ticket id
+  const counter = readCounter();
+  const n = counter[seriesKey].next;
+  const ticketId = `${seriesKey}-${n}`;
+
+  // 2. 決定檔名
+  const dateForSlug = (draft.originalDate || today()).replace(/-/g, '');
+  const slug = slugify(draft.slug || draft.title);
+  const filename = `${seriesKey.toLowerCase()}-${n}-${dateForSlug}-${slug}.mdx`;
+  const outPath = path.join(POSTS_DIR, filename);
+
+  // 3. Callout + wikilink 轉換
+  const converted = convertCallouts(body);
+  body = convertWikilinks(converted.body);
+
+  // 4. import 需要的 component
+  const imports = [];
+  if (converted.usedComponents.has('ClawdNote')) {
+    imports.push("import ClawdNote from '../../components/ClawdNote.astro';");
+  }
+  if (converted.usedComponents.has('ShroomDogNote')) {
+    imports.push("import ShroomDogNote from '../../components/ShroomDogNote.astro';");
+  }
+
+  // 5. 組 frontmatter
+  const fm = buildFrontmatter({ ...draft, series: seriesKey }, ticketId, slug);
+  const yaml = toYaml(fm);
+
+  const sections = [`---`, yaml, `---`, ``];
+  if (imports.length) {
+    sections.push(imports.join('\n'));
+    sections.push('');
+  }
+  sections.push(body.trimStart());
+  const finalContent = sections.join('\n').replace(/\n{3,}/g, '\n\n') + '\n';
+
+  if (dryRun) {
+    console.log(`\n=== DRY RUN: ${filename} ===\n`);
+    console.log(finalContent);
+    console.log(`\n[dry-run] 不會寫檔、不會 bump counter`);
+    return { filename, ticketId, dryRun: true };
+  }
+
+  // 6. 寫檔 + bump counter
+  if (fs.existsSync(outPath)) {
+    throw new Error(`[${draftPath}] 目標檔案已存在：${outPath}`);
+  }
+  fs.writeFileSync(outPath, finalContent);
+  counter[seriesKey].next = n + 1;
+  writeCounter(counter);
+
+  return { filename, ticketId, outPath };
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+function main() {
+  const args = process.argv.slice(2);
+  if (args.length === 0 || args.includes('--help') || args.includes('-h')) {
+    console.log(
+      `Usage:\n  node scripts/obsidian-import.mjs <draft.md> [--dry-run]\n  node scripts/obsidian-import.mjs --all <vault-dir> [--dry-run]\n`
+    );
+    process.exit(0);
+  }
+
+  const dryRun = args.includes('--dry-run');
+  const filtered = args.filter((a) => a !== '--dry-run');
+
+  let targets = [];
+  if (filtered[0] === '--all') {
+    const dir = filtered[1];
+    if (!dir) {
+      console.error('--all 需要指定 vault 資料夾');
+      process.exit(1);
+    }
+    targets = fs
+      .readdirSync(dir)
+      .filter((f) => f.endsWith('.md'))
+      .map((f) => path.join(dir, f));
+  } else {
+    targets = [filtered[0]];
+  }
+
+  const results = [];
+  for (const t of targets) {
+    try {
+      const r = importOne(t, { dryRun });
+      results.push({ ok: true, draft: t, ...r });
+      console.log(`✓ ${t} → ${r.filename || '(dry-run)'}`);
+    } catch (err) {
+      console.error(`✗ ${t}: ${err.message}`);
+      results.push({ ok: false, draft: t, error: err.message });
+    }
+  }
+
+  const imported = results.filter((r) => r.ok && !r.dryRun);
+  if (imported.length === 0) return;
+
+  // 驗證
+  console.log('\n--- Running validate-posts ---');
+  try {
+    execSync('node scripts/validate-posts.mjs', { cwd: ROOT, stdio: 'inherit' });
+  } catch {
+    console.error('\n⚠️  validate-posts 失敗，請檢查 frontmatter。已匯入的檔案仍保留。');
+    process.exit(1);
+  }
+
+  console.log('\n--- Next steps ---');
+  for (const r of imported) {
+    console.log(`  • ${r.ticketId}: src/content/posts/${r.filename}`);
+  }
+  console.log(`\n  git add scripts/article-counter.json src/content/posts/`);
+  console.log(
+    `  git commit -m "content(${imported[0].ticketId.toLowerCase()}): draft from obsidian"`
+  );
+  console.log(`  ./scripts/ralph-loop.sh    # 跑 tribunal`);
+  console.log(`  git push`);
+}
+
+main();


### PR DESCRIPTION
## Summary

三件事一起：Obsidian 草稿 pipeline、CC vs CCC mental model、solo-author workflow 文件化。

### 1. Obsidian draft pipeline（iPhone + Mac + iCloud）

- `scripts/obsidian-import.mjs`：Obsidian `.md` 草稿 → MDX 自動轉換
  - Callout (`> [!clawd]` / `> [!shroomdog]`) → `<ClawdNote>` / `<ShroomDogNote>` 元件（含 import 自動加）
  - Wikilink `[[slug]]` / `[[slug|alias]]` → `/posts/slug`
  - 依 `article-counter.json` 自動拿 ticket ID 並 bump
  - 自動補齊 `translatedBy` / `lang` / `source` 等必填 frontmatter
  - 支援 `--dry-run` 和 `--all <dir>`
  - 跑完自動 call `validate-posts.mjs`
- `OBSIDIAN_SETUP.md`：iPhone + Mac + iCloud 完整設定（含 Templater 範本、iPhone vs Vercel frontend 對照表）
- `pnpm run obsidian:import` alias
- **實測**：dry-run + 真實 import + validate 全綠

### 2. CC vs CCC playbook

Codify 兩種 Claude Code instance 的差別和行為規則：

- **CC** (Local): Mac 互動式，觀察環境（可能 main / worktree / feature branch）
- **CCC** (Cloud, 也就是我): Linux 沙箱，auto `claude/xxx` branch

**CCC playbook**：move fast / merge fast / fix fast。PR scope 可以大可以雜，但 commit 內維持 atomic 方便 revert。Self-merge only when CI green。Forward fix 優先，3 次失敗（含 opus subagent 救援）才 revert。Scope ceiling = 相關路徑，例外：prod/CI 緊急事件永遠順手修。品質 gate 全保留。

`scripts/detect-env.sh` 讓每個 session 開場跑一下就知道自己是 CC 還是 CCC。

### 3. Solo-author branch policy + Obsidian mental model

寫進 CLAUDE.md 的「Dev Workflow」section：

- **預設直接 main 開發**（單人 repo，feature branch 是 overhead）
- 例外清單：大規模重構、實驗性改動、多 commit atomic feature、user 指定 branch（e.g. web session）
- Commit discipline：一個 commit 一件事
- Draft 三個來源（Obsidian vault / 直接編 MDX / Clawd CP pipeline）全部最終都變 `src/content/posts/*.mdx`

## Commits

1. `feat(obsidian): add draft import pipeline for iPhone + Mac workflow` — import script + OBSIDIAN_SETUP.md + pnpm alias
2. `docs(claude): add solo-author branch policy + obsidian draft pipeline` — CLAUDE.md workflow section
3. `docs(claude): add CC vs CCC playbook + detect-env.sh` — CC/CCC mental model + detect script

## Test plan

- [x] `node scripts/obsidian-import.mjs /tmp/test.md --dry-run` → 正確 callout + wikilink 轉換，YAML pipeline 縮排正確
- [x] `node scripts/obsidian-import.mjs /tmp/test.md` → 真實 import + `validate-posts.mjs` 全綠（Zod schema 過）
- [x] `./scripts/detect-env.sh` → 在 sandbox 正確印 `CCC`
- [x] `git commit` → pre-commit hook 全過（eslint + prettier + validate）
- [x] `git push` → pre-push hook 全過
- [ ] User 在 Mac 上實測 iCloud vault workflow（等 user）

https://claude.ai/code/session_01A66K5yRrBHXn4VcHKcbH2p