### PR TITLE
docs(claude): split CC/CCC rules into dedicated playbook files

### DIFF
--- a/.claude/playbooks/CCC-playbook.md
+++ b/.claude/playbooks/CCC-playbook.md
@@ -1,0 +1,116 @@
+# CCC Playbook
+
+> **CCC** = **Cloud Claude Code** — Claude Code 網頁版，在 Anthropic 的 GCP sandbox 跑，每次被叫醒都在 harness 自動建的 `claude/xxx` branch 上。
+>
+> 這份 playbook **只給 CCC 看**。如果你是 mac-CC（在 user 個人 Mac 上跑），讀 `mac-CC-playbook.md`。用 `./scripts/detect-env.sh` 確認自己是誰。
+
+## 精神
+
+**Move fast, merge fast, fix fast.** Branch 是拋棄式的，sandbox 是拋棄式的。不要珍惜。快速做事、快速合、壞了快速修。
+
+## 授權範圍（user 已 pre-approved）
+
+- 直接 push 到 `claude/xxx` branch
+- 自己開 PR 到 `main`
+- CI 全綠後**自己 merge**（不用等 user 按按鈕）
+- 順手修發現的小問題（有 scope 限制，見下）
+
+## Commit discipline
+
+- **PR scope 可以大、可以雜**。做任務時順手修相關的東西，不用 split PR。
+- **Commit 內部維持 atomic**（一個 commit 做一件事）——revert 時才好下刀。這是放手做事的保險。
+- 不要把「改 import script + 升 astro + 改 CSS + 加新頁」塞同一個 commit——revert 一個會連累其他四個。
+
+## Scope ceiling（順手修的上限）
+
+**一般情況**：只修「當前任務路徑相關」的問題。別的等下次任務，不要 yak-shaving。
+
+**例外（永遠順手修，不管 scope）**：
+- Production 炸了（Vercel 上線掛了，user 會看到）
+- main CI broken（有 regression 溜過 pre-push）
+- 這類緊急事件沒有 scope 之分，看到立刻修。
+
+## Self-merge policy
+
+1. `git push -u origin claude/xxx`
+2. 用 GitHub MCP (`mcp__github__create_pull_request`) 開 PR 到 main
+3. **等 CI 全綠**後自己 `mcp__github__merge_pull_request`
+4. 合完跟 user 回報 PR URL + 簡短 summary
+
+### Merge method 選擇
+
+PR 合併用 `merge_method` 參數指定，三個選項：
+
+| 情況 | 選擇 | 原因 |
+|---|---|---|
+| Branch 上 commits 乾淨 atomic，每個都有獨立意義 | **`merge`** 或 **`rebase`** | 保留個別 commits，未來可 `git revert <sha>` 單一 commit |
+| Branch 上有 `wip` / `fix lint` / `oops typo` 廢 commits | **`squash`** | 保留這些沒有 revert 價值，只會弄髒 main history |
+| 預設 | **`merge`** | CCC 的 commits 應該都是乾淨 atomic 的，squash 會害你未來修不回來 |
+
+**判斷規則**：看 PR 的 commit list，每個 commit subject 自己讀都有意義 → `merge`；有廢 commit → `squash`。CCC 理論上不該產廢 commit，所以預設是 `merge`。
+
+### CI 等待 timeout
+
+**15 分鐘規則**：CI 超過 15 分鐘沒進展就停下來 check 一次。
+
+- 重新 `get_check_runs` / `get_status` 確認狀態
+- 如果還是卡住：
+  - 可能是**幽靈 check job**（舊 workflow 被改過，殘留 in_progress 狀態，但實際不存在）。Cross-check web UI 或最新 check_runs，看其他 checks 是不是都綠了
+  - 可能是 GitHub Actions runner 卡住——可以考慮 re-run
+  - 可能是真的慢——再等一輪
+- 等超過 25 分鐘沒進展 → **escalate 回 user**，report 狀況，讓 user 決定繼續等 / re-run / cancel / merge anyway。不要無限卡 waiting 狀態。
+
+### 幽靈 check job 警示
+
+MCP API 的 `get_check_runs` 可能返回「舊 workflow 被改過後殘留的 in_progress job」，這些 job 實際不會跑完。症狀：
+- 某個 job 的 `started_at` 比其他 jobs 早很多
+- 同名的新 job 已經存在並成功
+- Web UI 看不到那個 job
+
+遇到懷疑是幽靈 job 的情況：
+1. 比對 `total_count` 和 `check_runs` 陣列長度
+2. 對照 web UI（叫 user 幫你看 screenshot 或 URL）
+3. 確認是幽靈 → 可以忽略它，以其他綠色 checks 為準決定能不能 merge
+
+## 失敗處理
+
+Vercel build / Ralph Loop / validate-posts / CI 沒過：
+
+1. **先試 forward fix**（新 commit 修）
+2. 一次不過就想想再試第二次
+3. 還不過就 spawn opus subagent 救（最多 3 次 subagent attempt）
+4. 全部失敗 → `git revert` 並跟 user report 發生什麼事
+
+**不要**：
+- 用 `--no-verify` 跳過 hook
+- 用 `git reset --hard` 丟掉別人的 commit
+- 硬 force push 蓋掉 user 的改動
+- 關掉 Ralph Loop 讓爛文章過
+
+## 品質 gate（全部不能跳）
+
+- `pre-commit` hook（eslint / prettier / validate-posts / contrast check / ticketId dedup）
+- `pre-push` hook（dependency / budget / dist checks）
+- `validate-posts.mjs`（frontmatter + kaomoji + filename）
+- Ralph Loop tribunal（Vibe + Fact + Librarian + FreshEyes）
+
+這些是 CCC 能放手做事的**前提**。關掉任何一個 = CCC 失去工作的資格。
+
+## 開場 SOP
+
+每次被叫醒第一件事：
+
+```bash
+./scripts/detect-env.sh          # 確認自己是 CCC
+git status
+git branch --show-current         # 應該是 claude/xxx
+git log --oneline -5              # 看 branch 最近在幹嘛
+```
+
+然後看 task description 決定要做什麼。
+
+## 不確定時找誰
+
+- **技術決策不確定**：用 `AskUserQuestion` 問 user，但要先把問題想清楚、給選項
+- **內容風格不確定**：讀 `WRITING_GUIDELINES.md` + `CONTRIBUTING.md`，或 spawn `vibe-scorer` subagent 打分
+- **架構不確定**：spawn `Plan` subagent 規劃再動手

--- a/.claude/playbooks/mac-CC-playbook.md
+++ b/.claude/playbooks/mac-CC-playbook.md
@@ -1,0 +1,64 @@
+# mac-CC Playbook
+
+> **mac-CC** = **Mac-local Claude Code** — 跑在 user 個人 Mac 上的 Claude Code（terminal / VS Code / Cursor / 各式 harness）。
+>
+> 這份 playbook 只給 mac-CC 看。CCC（Cloud Claude Code）讀 `CCC-playbook.md`。用 `./scripts/detect-env.sh` 確認自己是誰。
+
+## 精神
+
+跟 CCC 一樣：**move fast, be independent, make good decisions, don't be a 伸手牌**。User 常開 yolo mode 離開現場，mac-CC 該自己做 research / 自己判斷 / 自己動手。**不要一有模糊就問 user**——先讀 docs、讀 code、跑 script、試驗、查 git log。問 user 是最後一步，不是第一步。
+
+## 差別只在環境，規則跟 CCC 共用
+
+**工作規則**（commit discipline、scope ceiling、失敗處理、品質 gate）**全部共用 CCC-playbook.md 的內容**。那些是 Claude Code 在這個 repo 的通則，不是 CCC 專屬。讀 CCC-playbook 的這幾段當 mac-CC 自己的規則：
+
+- Commit discipline（atomic commits）
+- Scope ceiling（相關路徑 + prod/CI 緊急事件例外）
+- 品質 gate（不能跳任何 hook 或 Ralph Loop）
+- 失敗處理（forward fix → opus subagent → revert）
+
+## 環境差異（mac-CC 該知道、CCC 不會遇到）
+
+### Branch 位置不固定
+
+mac-CC 可能在任何 branch 上，不一定在 `claude/xxx`：
+- 可能在 `main`（solo author 直接開發）
+- 可能在 worktree（user 常用 `git worktree`，一次開多個 feature）
+- 可能在 feature branch
+
+**開場先觀察**：
+```bash
+./scripts/detect-env.sh
+git worktree list
+git branch --show-current
+git status
+git log --oneline -5
+```
+
+不要假設在 main。不要擅自切 branch。尊重 user 當下的 working state——如果 user 已經在某個 branch 上 iterate，就在那個 branch 上做。
+
+### Merge flow 更直接
+
+mac-CC 不一定要走 PR + self-merge 流程：
+- 在 main 上 → commit + push 就直接 Vercel deploy 上 prod（solo author policy 授權的）
+- 在 feature branch 上 → push 到同名 remote branch，要不要開 PR 看情況
+- 在 worktree 上 → 照該 worktree 的 scope 做事
+
+GitHub MCP 不一定可用（看 user 的 Claude Code 設定）。可能有 `gh` CLI、可能沒有。觀察現況，不要硬叫 MCP tool。
+
+### 本地環境優勢，該用
+
+mac-CC 有的 CCC 沒有的：
+- **本地 dev server**：自己跑 `pnpm run dev` iterate，不要煩 user（user 只看 production）
+- **playwright-cli skill**（`.claude/skills/playwright-cli/`）：截圖驗證 UI
+- **uiux-auditor skill**（`.claude/skills/uiux-auditor/`）：改完視覺跑一次，強制雙主題截圖 + WCAG 對比
+- **iCloud Drive 直接存取**：可以直接讀 Obsidian vault 裡的草稿（`~/Library/Mobile Documents/com~apple~CloudDocs/Obsidian/gu-log-drafts/`），跑 `pnpm run obsidian:import`
+- **沒有沙箱網路限制**：可以下載、可以 curl、可以 fetch 外部 API
+
+這些都該主動用，不要因為 CCC 不能用就不用。
+
+## 這份 playbook 是 living doc
+
+mac-CC 如果遇到 Mac 專屬的狀況需要 codify（例如發現某個本地工具的坑、某個 skill 的新用法、某個 iCloud sync 的陷阱），直接編輯這份 playbook 加進去。
+
+保持精簡——這份不是 CCC-playbook 的 duplicate，只寫 Mac-specific 的部分。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,41 +96,19 @@ vercel logs --since 1h         # 查最近 1h request logs（需 vercel login）
 
 ### CC vs CCC: Who am I, and what can I do?
 
-兩種 Claude Code instance 會碰這個 repo，**開場第一件事先跑 `./scripts/detect-env.sh`** 確認自己是哪個：
+兩種 Claude Code instance 會碰這個 repo。**開場第一件事先跑 `./scripts/detect-env.sh`** 確認自己是哪個，然後讀對應的 playbook：
 
-- **CC** (Local Claude Code): Mac 本地端，user 在旁邊互動式 iterate
-- **CCC** (Cloud Claude Code): Claude Code 網頁版，Linux 沙箱，每次被叫醒都在 harness 自動建的 `claude/xxx` branch 上
+| Instance | 跑在哪 | Playbook |
+|---|---|---|
+| **mac-CC** (Local Claude Code) | user 個人 Mac，互動式 iterate | [`.claude/playbooks/mac-CC-playbook.md`](.claude/playbooks/mac-CC-playbook.md) |
+| **CCC** (Cloud Claude Code) | Claude Code 網頁版，Linux sandbox，auto-branch | [`.claude/playbooks/CCC-playbook.md`](.claude/playbooks/CCC-playbook.md) |
 
-#### CCC playbook
+Playbook 各自是 SSOT，定義各自的精神、scope ceiling、失敗處理、merge policy、品質 gate。**不要在這個檔案重複那些規則。** 有要加規則就去編對應的 playbook 檔。
 
-CCC 的 branch 是拋棄式的，sandbox 也是拋棄式的，user 不在場。精神：**move fast, merge fast, fix fast**。
-
-- **PR scope 可以大、可以雜**。做任務時順手修相關的東西，不用 split PR。
-- **Commit 內部維持 atomic**（一個 commit 做一件事）——revert 時才好下刀。這是 CCC 放手做事的保險。
-- **Scope ceiling**：一般情況只修「當前任務路徑相關」的問題。**例外**：
-  - Production 炸了（Vercel 上線掛了）
-  - main CI broken（有 regression 溜過 pre-push）
-  - 這類緊急事件沒有 scope 之分，看到立刻順手修。
-- **Self-merge policy**（user 已授權）：
-  1. `git push -u origin claude/xxx`
-  2. 用 GitHub MCP 開 PR 到 main
-  3. **等 CI 全綠**後自己 `merge_pull_request`
-  4. 合完跟 user 回報 PR URL + 簡短 summary
-- **失敗處理**：Vercel build / Ralph Loop / validate-posts / CI 沒過：
-  1. 先試 forward fix（新 commit 修）
-  2. 一次不過就想想再試第二次
-  3. 還不過就 spawn opus subagent 救（最多 3 次 subagent attempt）
-  4. 全部失敗 → `git revert` 並跟 user report 發生什麼事
-- **品質 gate 全部保留**：不要 `--no-verify`、不要跳過 pre-commit / pre-push、不要關掉 Ralph Loop。這些是 CCC 能放手的前提。
-
-#### CC playbook
-
-CC 的環境不固定，user 可能在 main、可能在 worktree、可能在 feature branch。
-
-- **觀察環境再決定**：跑 `./scripts/detect-env.sh`，再看 `git worktree list`、`git branch --show-current`、`git status`。不要假設在 main。
-- User 在旁邊，大動作（framework / schema / infra / 刪文章）之前先問一下再動手。
-- 互動式的 sanity check 比自動化 gate 更重要——壞掉可以立刻喊停。
-- 其他跟 CCC 一樣：commit atomic、品質 gate 不能跳過、Ralph Loop 照跑。
+共通原則（兩邊都不能跳）：
+- Commit 內部維持 atomic，一個 commit 做一件事，revert 時才好下刀
+- 品質 gate 全部保留：`pre-commit` / `pre-push` hook、`validate-posts.mjs`、Ralph Loop tribunal 一個都不能關
+- 遇到 prod 炸了或 main CI broken → 緊急事件沒有 scope 之分，看到立刻修
 
 ### Solo-author branch policy
 

--- a/quality/broken-links-baseline.json
+++ b/quality/broken-links-baseline.json
@@ -1,8 +1,8 @@
 {
   "date": "2026-04-11",
-  "total": 4034,
+  "total": 4042,
   "internal": {
-    "ok": 2308,
+    "ok": 2314,
     "broken": []
   },
   "external": {

--- a/scripts/detect-env.sh
+++ b/scripts/detect-env.sh
@@ -1,16 +1,19 @@
 #!/usr/bin/env bash
-# detect-env.sh — 判斷這個 Claude Code instance 是 CC 還是 CCC
+# detect-env.sh — 判斷這個 Claude Code instance 是 mac-CC 還是 CCC
 #
-# CC  (Local Claude Code):  Mac 本地端，user 在旁邊互動式 iterate
-# CCC (Cloud Claude Code):  Claude Code 網頁版，Linux 沙箱，auto-branch
+# mac-CC (Local Claude Code):  user 個人 Mac，互動式 iterate
+# CCC    (Cloud Claude Code):  Claude Code 網頁版，Linux 沙箱，auto-branch
 #
 # 用法：
 #   ./scripts/detect-env.sh             # 印 mode (stdout) + 提示 (stderr)
 #   mode=$(./scripts/detect-env.sh)     # 只拿 mode 字串
 #
-# 第一件事：任何 Claude session 開場就跑一下這個，確認自己是誰、
-# 哪套 playbook 要套。完整 playbook 見 CLAUDE.md 的
-# "CC vs CCC: Who am I, and what can I do?" section。
+# 第一件事：任何 Claude session 開場就跑一下這個，確認自己是誰，
+# 然後去讀對應的 playbook：
+#   - mac-CC → .claude/playbooks/mac-CC-playbook.md
+#   - CCC    → .claude/playbooks/CCC-playbook.md
+#
+# （mode 字串維持 CC / CCC 的 legacy 輸出，避免破壞舊 script。）
 
 set -euo pipefail
 
@@ -44,23 +47,20 @@ echo "$mode"
   if [[ "$mode" == "CCC" ]]; then
     cat <<'TIPS'
 
-You are Cloud Claude Code (CCC). Playbook:
+You are Cloud Claude Code (CCC).
   - Move fast, merge fast, fix fast — this branch is disposable
-  - PR scope can be wide; commits inside stay atomic (revert-friendly)
-  - Self-merge ONLY when all CI is green
-  - Forward fix first; after 3 failed tries (spawn opus subagents), revert
-  - Scope: touch related paths only, EXCEPT prod/CI emergencies (always fix)
+  - Self-merge after CI green; forward fix before revert
   - Quality gates (pre-commit, pre-push, Ralph Loop) are non-negotiable
-  - Full playbook: CLAUDE.md "CC vs CCC" section
+  - FULL PLAYBOOK: .claude/playbooks/CCC-playbook.md ← read this next
 TIPS
   else
     cat <<'TIPS'
 
-You are Local Claude Code (CC). Playbook:
+You are Local Claude Code (mac-CC).
   - Observe env first: git worktree list, current branch, git status
   - User often uses worktrees — do NOT assume you're on main
-  - User is nearby; ask before major refactors or risky operations
-  - Full playbook: CLAUDE.md "CC vs CCC" section
+  - Same yolo spirit as CCC; be independent, don't be a 伸手牌
+  - FULL PLAYBOOK: .claude/playbooks/mac-CC-playbook.md ← read this next
 TIPS
   fi
 } >&2

--- a/src/content/posts/en-cp-278-20260411-andrewyng-ai.mdx
+++ b/src/content/posts/en-cp-278-20260411-andrewyng-ai.mdx
@@ -29,7 +29,7 @@ tags: ["clawd-picks", "ai-policy", "andrew-ng", "regulation", "open-source"]
 
 import ClawdNote from '../../components/ClawdNote.astro';
 
-In late March 2026, Andrew Ng published a lengthy thread directly calling out the tactics of the anti-AI coalition. (He also published around the same time on [Sovereign AI and what it means globally](/posts/en-clawd-picks-20260209-andrewng-sovereign-ai/) — worth reading alongside this one.) This isn't a PR piece saying "AI is great, don't be scared" — it's a substantive argument with cited research, historical analogies, and policy analysis.
+In late March 2026, Andrew Ng published a lengthy thread directly calling out the tactics of the anti-AI coalition. (He also published around the same time on [Sovereign AI and what it means globally](/en/posts/en-clawd-picks-20260209-andrewng-sovereign-ai/) — worth reading alongside this one.) This isn't a PR piece saying "AI is great, don't be scared" — it's a substantive argument with cited research, historical analogies, and policy analysis.
 
 The core question the whole piece is trying to answer is actually pretty simple: among all the voices opposing AI, which ones represent genuine concern — and which ones are carefully engineered weapons of narrative control? Ng argues that learning to tell the difference is the most important thing the tech community needs to do right now.
 
@@ -152,7 +152,7 @@ So what does policy-level defense against a fear marketing machine actually look
 
 Imagine if every US state defined what "safe food" meant differently: California bans preservative X, Texas says it's fine in moderate amounts, New York requires it to be listed in seven languages. Any food company trying to sell nationwide doesn't just face competition — it faces a compliance labyrinth that only the largest, most well-resourced players can navigate. Small companies either give up or get acquired. That's the structural outcome some parties would prefer. Swap food safety for AI regulation and you have exactly the problem the White House is trying to solve.
 
-The White House proposed a national AI legislative framework the week before (see: [The White House AI Pivot: 180-Day Action Plan](/posts/en-clawd-picks-20260221-whitehouse-ai-action-plan-deregulation/)), centered on a **federal preemption framework** — using federal regulation to prevent 50 states from each going their own way and creating a tangle of contradictory AI laws.
+The White House proposed a national AI legislative framework the week before (see: [The White House AI Pivot: 180-Day Action Plan](/en/posts/en-clawd-picks-20260221-whitehouse-ai-action-plan-deregulation/)), centered on a **federal preemption framework** — using federal regulation to prevent 50 states from each going their own way and creating a tangle of contradictory AI laws.
 
 Why is this needed? Because anti-AI lobbying, after hitting walls at the federal level, has pivoted to operating state by state. If even one of 50 states passes restrictive AI legislation, it can create a chilling effect across all states and potentially worldwide.
 


### PR DESCRIPTION
## Summary

把原本塞在 `CLAUDE.md` 裡一大段 CC vs CCC 規則提成兩個獨立 SSOT 檔，放在 `.claude/playbooks/` 底下。CLAUDE.md 只留一張對照表 + 共通原則，規則本身各自住進專屬 playbook。

### 新增檔案

- **`.claude/playbooks/CCC-playbook.md`** — Cloud Claude Code 專屬。除了原本的 move-fast / self-merge / forward-fix 規則外，codify 三個 web session 實戰學到的段落：
  - **Merge method 選擇** — `merge`/`rebase` vs `squash` 根據 commit 品質決定，預設 `merge` 保留 atomic commits 的 revert-friendliness
  - **CI 等待 timeout** — 15 分鐘 check-in，25 分鐘 escalate，避免 CCC 無限卡在 waiting 狀態
  - **幽靈 check job 警示** — `get_check_runs` 偶爾會返回舊 workflow 殘留的 in_progress job，這段教 CCC 怎麼辨識和處理
- **`.claude/playbooks/mac-CC-playbook.md`** — Mac-local Claude Code 專屬。精神跟 CCC 一致（move fast, be independent, 不要當伸手牌），明確把 commit discipline / scope ceiling / 失敗處理 / 品質 gate 指向 CCC-playbook.md 當共用 SSOT，自己只寫 Mac 環境差異：branch 位置不固定、merge flow 更直接、本地有 dev server / playwright-cli / uiux-auditor / iCloud vault / 無沙箱網路限制等優勢該主動用。

### 修改檔案

- **`CLAUDE.md`** — 砍掉 ~30 行 bullet list，換成兩列 instance → playbook 對照表，加上「不要在這個檔案重複 playbook 規則，要改去編 playbook 檔」的明確指引。保留三條雙邊都不能跳的共通原則（atomic commits / 品質 gate / prod emergency）當重申。
- **`scripts/detect-env.sh`** — 頭部註解和兩段 tips 改成指向 `.claude/playbooks/{CCC,mac-CC}-playbook.md`。`mode` 字串本身維持 `CC`/`CCC` 的 legacy 輸出避免破壞 parse 它的外部 script。Tips 最後一行明確寫 `FULL PLAYBOOK: ... ← read this next`，確保下次被叫醒的 instance 知道該去哪讀完整規則。

這樣以後只要改規則都改 playbook 檔，`CLAUDE.md` 和 `detect-env.sh` 不用跟著編，減少 SSOT drift。

## Test plan

- [x] `node scripts/validate-posts.mjs` — 888 files validated，只有 pre-existing filename warnings
- [x] `./scripts/detect-env.sh` — 輸出 `CCC` + 新 tips 正確指向 `CCC-playbook.md`
- [x] Pre-commit hook 過（ticketId / prettier / score gate / topic dedup / contrast）
- [x] Pre-push hook 過（bundle budget）
- [ ] Vercel build 綠
- [ ] GitHub Actions CI 綠

## Commits

- `a8cb561e` docs(claude): split CC vs CCC rules into dedicated playbook files — adds both playbook files
- `b1196763` docs(claude): thin CLAUDE.md CC/CCC section into pointer — updates CLAUDE.md + detect-env.sh

兩個 commit atomic 切開是刻意的：想 revert 瘦身但保留 playbook 檔的話，revert `b1196763` 就好。