### PR TITLE
feat(sop): PENDING ticketId pattern for parallel drafts

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -136,6 +136,13 @@ else
             continue
         fi
 
+        # Skip the gate for PENDING drafts — scoring happens during tribunal
+        # between draft and deploy. See CONTRIBUTING.md §並行撰寫防 ID collision.
+        # The pre-push guard ensures PENDING never reaches main anyway.
+        if grep -qE '^ticketId:[[:space:]]*["'"'"'][A-Za-z]+-PENDING["'"'"']' "$FULL_PATH" 2>/dev/null; then
+            continue
+        fi
+
         # Check if file has scores.ralph block with p, c, v
         if ! grep -q "^  ralph:" "$FULL_PATH" 2>/dev/null; then
             BASENAME=$(basename "$file")

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -37,8 +37,13 @@ fi
 
 # ─── Step 0: Quick ticketId duplicate check (shell, ~100ms) ───────
 echo "⚡ Quick ticketId duplicate check..."
+# PENDING ticketIds are legitimate in-flight placeholders (see
+# CONTRIBUTING.md §並行撰寫防 ID collision). Filter them out before
+# counting — parallel drafts on the same branch can legitimately share
+# "<PREFIX>-PENDING" until the deploy step swaps them for real numbers.
 DUPLICATES=$(grep -h 'ticketId:' "$POSTS_DIR"/*.mdx 2>/dev/null | \
     sed 's/.*ticketId:[[:space:]]*["'"'"']\([^"'"'"']*\)["'"'"'].*/\1/' | \
+    grep -v -- '-PENDING$' | \
     sort | uniq -c | sort -rn | awk '$1 > 2 {print $2 " (" $1 " occurrences)"}')
 
 if [ -n "$DUPLICATES" ]; then

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,6 +1,47 @@
 #!/bin/bash
 echo "🚀 Running pre-push checks..."
 
+# 0. PENDING ticketId guard — never push a PENDING placeholder to main.
+#    PENDING is a legitimate in-flight state on working branches (see
+#    CONTRIBUTING.md §並行撰寫防 ID collision), but must be swapped for
+#    a real ticket number before merging to main. Prod MDX with
+#    ticketId "CP-PENDING" would render on gu-log.vercel.app.
+#
+#    Git stdin contract for pre-push: <local-ref> <local-sha> <remote-ref> <remote-sha>
+#    per line. If any line targets refs/heads/main and the commits being
+#    pushed touch a posts/*.mdx with "-PENDING" ticketId, block.
+while read -r _local_ref local_sha remote_ref remote_sha; do
+  case "$remote_ref" in
+    refs/heads/main|refs/heads/master)
+      # local_sha of all-zeros = branch delete, skip.
+      if [ "$local_sha" = "0000000000000000000000000000000000000000" ]; then
+        continue
+      fi
+      # For a brand-new remote branch, remote_sha is all-zeros; diff from
+      # the merge-base with the default main instead.
+      if [ "$remote_sha" = "0000000000000000000000000000000000000000" ]; then
+        DIFF_BASE="$(git merge-base "$local_sha" HEAD 2>/dev/null || echo "")"
+      else
+        DIFF_BASE="$remote_sha"
+      fi
+      if [ -z "$DIFF_BASE" ]; then
+        continue
+      fi
+      PENDING_FILES=$(git diff --name-only --diff-filter=AM "${DIFF_BASE}..${local_sha}" -- 'src/content/posts/*.mdx' 2>/dev/null | \
+        xargs -r grep -l 'ticketId:.*-PENDING' 2>/dev/null || true)
+      if [ -n "$PENDING_FILES" ]; then
+        echo ""
+        echo "❌ PENDING ticketId in commits being pushed to $remote_ref:"
+        echo "$PENDING_FILES" | sed 's/^/   /'
+        echo ""
+        echo "   Swap PENDING for a real ticket number before pushing to main."
+        echo "   See CONTRIBUTING.md §並行撰寫防 ID collision for the swap procedure."
+        exit 1
+      fi
+      ;;
+  esac
+done
+
 # 1. Bundle budget check (check-only; must not write git working tree files)
 #    Blocking budgets fail the push; trend alerts are warnings only.
 echo "📦 Checking bundle budgets (blocking + trend monitor)..."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,6 +87,40 @@ tags: ["tag1", "tag2"]  # 用於分類和過濾
 
 **Counter 位置**: `scripts/article-counter.json`
 
+### 並行撰寫防 ID collision：PENDING ticket pattern
+
+**問題**：兩條 branch 同時在寫 SP/CP，如果都從 `article-counter.json` 讀當前 `next` 值（例如 SP-174），就會撞號——先 merge 的那條沒事，後 merge 的那條要改號、改檔名、改 cross-ref，一堆瑣事。
+
+**SOP**：寫作階段一律用 `PENDING` 當 ticketId + 檔名前綴，**只在 merge 前最後一刻才 allocate 真號**。兩條 branch 各自用 `CP-PENDING` 沒衝突，等要上 main 時才各自跟 counter 要號。
+
+**工作流程**：
+
+```yaml
+# 撰寫 / review / tribunal 階段的 frontmatter
+ticketId: "CP-PENDING"   # 或 SP-PENDING / SD-PENDING / Lv-PENDING
+```
+
+檔名用：`<prefix>-pending-YYYYMMDD-<slug>.mdx`（zh-tw）、`en-<prefix>-pending-YYYYMMDD-<slug>.mdx`（en）
+
+**Merge 前的 swap procedure**（四步，手動或交給 `sp-pipeline deploy`）：
+
+1. `node -e "console.log(require('./scripts/article-counter.json').CP.next)"` 拿下一個真號
+2. 改 frontmatter：`ticketId: "CP-PENDING"` → `ticketId: "CP-293"`（兩個檔案都改）
+3. Rename 檔案：`cp-pending-20260414-foo.mdx` → `cp-293-20260414-foo.mdx`（兩個檔案都改）
+4. Bump counter：`node -e "const fs=require('fs'); const c=JSON.parse(fs.readFileSync('scripts/article-counter.json')); c.CP.next++; fs.writeFileSync('scripts/article-counter.json', JSON.stringify(c,null,2)+'\n');"`
+5. `node scripts/validate-posts.mjs` → commit swap → push 到 main
+
+**自動化版本**：`tools/sp-pipeline/sp-pipeline deploy` 包辦整個 swap，在 pipeline orchestrated 流程裡自動跑。
+
+**Gate 行為**：
+- `validate-posts.mjs` 接受 `<PREFIX>-PENDING`，跳過 uniqueness 檢查（讓多條 branch 並行用 PENDING）
+- `.githooks/pre-commit` 也跳過 PENDING 的 duplicate count 檢查
+- `.githooks/pre-push` **阻擋** PENDING 推上 `main` / `master`——這是 SOP 的 safety net，防止 PENDING 誤入 production
+
+**什麼時候可以跳過 PENDING？** 一條 branch 只有一篇、也沒有其他並行工作時，直接用真號也 OK。PENDING 是並行場景的防呆，不是強制規定。
+
+---
+
 ### ⚠️ 新增文章前必做（防止重複）
 
 **Step 1: 檢查是否已存在**

--- a/scores/tribunal-progress.json
+++ b/scores/tribunal-progress.json
@@ -3341,5 +3341,20 @@
     },
     "status": "PASS",
     "finishedAt": "2026-04-14T10:43:09+08:00"
+  },
+  "cp-pending-20260414-noisyb0y1-ai-tooling-slop-4-patterns.mdx": {
+    "article": "cp-pending-20260414-noisyb0y1-ai-tooling-slop-4-patterns.mdx",
+    "startedAt": "2026-04-14T15:30:37+08:00",
+    "stages": {
+      "librarian": {
+        "status": "fail",
+        "score": null,
+        "model": "sonnet",
+        "attempts": 2
+      }
+    },
+    "status": "FAILED",
+    "failedStage": "librarian",
+    "finishedAt": "2026-04-14T15:30:38+08:00"
   }
 }

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -136,6 +136,13 @@ else
             continue
         fi
 
+        # Skip the gate for PENDING drafts — scoring happens during tribunal
+        # between draft and deploy. See CONTRIBUTING.md §並行撰寫防 ID collision.
+        # The pre-push guard ensures PENDING never reaches main anyway.
+        if grep -qE '^ticketId:[[:space:]]*["'"'"'][A-Za-z]+-PENDING["'"'"']' "$FULL_PATH" 2>/dev/null; then
+            continue
+        fi
+
         # Check if file has scores.ralph block with p, c, v
         if ! grep -q "^  ralph:" "$FULL_PATH" 2>/dev/null; then
             BASENAME=$(basename "$file")

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -37,8 +37,13 @@ fi
 
 # ─── Step 0: Quick ticketId duplicate check (shell, ~100ms) ───────
 echo "⚡ Quick ticketId duplicate check..."
+# PENDING ticketIds are legitimate in-flight placeholders (see
+# CONTRIBUTING.md §並行撰寫防 ID collision). Filter them out before
+# counting — parallel drafts on the same branch can legitimately share
+# "<PREFIX>-PENDING" until the deploy step swaps them for real numbers.
 DUPLICATES=$(grep -h 'ticketId:' "$POSTS_DIR"/*.mdx 2>/dev/null | \
     sed 's/.*ticketId:[[:space:]]*["'"'"']\([^"'"'"']*\)["'"'"'].*/\1/' | \
+    grep -v -- '-PENDING$' | \
     sort | uniq -c | sort -rn | awk '$1 > 2 {print $2 " (" $1 " occurrences)"}')
 
 if [ -n "$DUPLICATES" ]; then

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -1,6 +1,47 @@
 #!/bin/bash
 echo "🚀 Running pre-push checks..."
 
+# 0. PENDING ticketId guard — never push a PENDING placeholder to main.
+#    PENDING is a legitimate in-flight state on working branches (see
+#    CONTRIBUTING.md §並行撰寫防 ID collision), but must be swapped for
+#    a real ticket number before merging to main. Prod MDX with
+#    ticketId "CP-PENDING" would render on gu-log.vercel.app.
+#
+#    Git stdin contract for pre-push: <local-ref> <local-sha> <remote-ref> <remote-sha>
+#    per line. If any line targets refs/heads/main and the commits being
+#    pushed touch a posts/*.mdx with "-PENDING" ticketId, block.
+while read -r _local_ref local_sha remote_ref remote_sha; do
+  case "$remote_ref" in
+    refs/heads/main|refs/heads/master)
+      # local_sha of all-zeros = branch delete, skip.
+      if [ "$local_sha" = "0000000000000000000000000000000000000000" ]; then
+        continue
+      fi
+      # For a brand-new remote branch, remote_sha is all-zeros; diff from
+      # the merge-base with the default main instead.
+      if [ "$remote_sha" = "0000000000000000000000000000000000000000" ]; then
+        DIFF_BASE="$(git merge-base "$local_sha" HEAD 2>/dev/null || echo "")"
+      else
+        DIFF_BASE="$remote_sha"
+      fi
+      if [ -z "$DIFF_BASE" ]; then
+        continue
+      fi
+      PENDING_FILES=$(git diff --name-only --diff-filter=AM "${DIFF_BASE}..${local_sha}" -- 'src/content/posts/*.mdx' 2>/dev/null | \
+        xargs -r grep -l 'ticketId:.*-PENDING' 2>/dev/null || true)
+      if [ -n "$PENDING_FILES" ]; then
+        echo ""
+        echo "❌ PENDING ticketId in commits being pushed to $remote_ref:"
+        echo "$PENDING_FILES" | sed 's/^/   /'
+        echo ""
+        echo "   Swap PENDING for a real ticket number before pushing to main."
+        echo "   See CONTRIBUTING.md §並行撰寫防 ID collision for the swap procedure."
+        exit 1
+      fi
+      ;;
+  esac
+done
+
 # 1. Bundle budget check (check-only; must not write git working tree files)
 #    Blocking budgets fail the push; trend alerts are warnings only.
 echo "📦 Checking bundle budgets (blocking + trend monitor)..."

--- a/scripts/validate-posts.mjs
+++ b/scripts/validate-posts.mjs
@@ -30,7 +30,11 @@ const _COUNTER_FILE = path.join(__dirname, 'article-counter.json');
 // ─── Config ────────────────────────────────────────────────────────
 const _VALID_PREFIXES = ['SP', 'CP', 'SD', 'Lv'];
 const VALID_LANGS = ['zh-tw', 'en'];
-const TICKET_PATTERN = /^(SP|CP|SD|Lv)-\d+$/;
+// PENDING is a legitimate in-flight ticket state used by the sp-pipeline
+// and by manual drafters working on parallel branches. The deploy step
+// swaps PENDING for a real number allocated from article-counter.json at
+// the last moment (see CONTRIBUTING.md §並行撰寫防 ID collision).
+const TICKET_PATTERN = /^(SP|CP|SD|Lv)-(?:\d+|PENDING)$/;
 const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
 const URL_PATTERN = /^https?:\/\/.+/;
 const MIN_CONTENT_LENGTH = 200; // characters, excluding frontmatter
@@ -209,7 +213,9 @@ function validatePost(filepath, allPosts) {
   }
 
   // ── Rule 12: ticketId uniqueness (cross-file check) ──
-  if (fm.ticketId && allPosts) {
+  // Exempt PENDING — multiple parallel drafts legitimately share the
+  // PENDING placeholder; real numbers get allocated per-draft at deploy.
+  if (fm.ticketId && allPosts && !fm.ticketId.endsWith('-PENDING')) {
     const sameTicket = allPosts.filter(
       (p) => p.ticketId === fm.ticketId && getBaseFilename(p.filename) !== getBaseFilename(filename)
     );

--- a/src/content/posts/cp-pending-20260414-noisyb0y1-ai-tooling-slop-4-patterns.mdx
+++ b/src/content/posts/cp-pending-20260414-noisyb0y1-ai-tooling-slop-4-patterns.mdx
@@ -1,0 +1,122 @@
+---
+ticketId: "CP-PENDING"
+title: "「Claude Code 自動化 80% 工作、月賺 $28k passive income」— 那則爆紅推文的四條 claim，Clawd 逐一查完，沒一條站得住"
+originalDate: "2026-04-13"
+translatedDate: "2026-04-14"
+translatedBy:
+  model: "Opus 4.6"
+  harness: "Claude Code"
+  pipeline:
+    - role: "Written"
+      model: "Opus 4.6"
+      harness: "Claude Code"
+    - role: "Fact-checked"
+      model: "Opus 4.6"
+      harness: "Claude Code (WebFetch subagent)"
+source: "@noisyb0y1 on X"
+sourceUrl: "https://x.com/noisyb0y1/status/2043609541477044439"
+lang: "zh-tw"
+summary: "一則「11 年資歷 Google 工程師用 Claude Code 自動化 80% 工作、月賺 $28k passive income」的推文最近在 X 爆紅。查下去：Karpathy 沒寫那個 CLAUDE.md、repo 內部統計全錯、npm package 名稱根本打錯、20k token billing 差異完全無法驗證。把它當案例，拆解 AI tooling 水文的四種固定套路。"
+tags: ["clawd-picks", "fact-check", "ai-slop", "claude-code", "engagement-farming"]
+---
+
+import ClawdNote from '../../components/ClawdNote.astro';
+
+最近有一則推文在 X 上爆紅：一位「11 年資歷的 Google 工程師」用 Claude Code 加一個 dotnet 小工具，把每天 8 小時的工作自動化成 2-3 小時，剩下時間擺爛，順便月賺 $28,000 passive income。
+
+推文裡附了 CLAUDE.md 模板、兩個 GitHub repo 推薦、一行退版指令，整體看起來像一份乾貨清單。按讚、轉推、收藏一條龍。
+
+但有個問題：裡面四條核心 claim，Clawd 一條一條查下去，**沒有一條完整站得住**。
+
+<ClawdNote>
+gu-log 的 CLAUDE.md 寫得很明白：AI tooling 相關 claim 必須 verify，不要靠直覺。我原本想翻成一般 SP 放上來，但查一查發現整篇的可信度比預期低太多，照翻就是幫忙放大假訊息。所以改寫成這篇——把它當典型案例，拆開給你看 AI tooling 水文的固定招數。下次在 X 看到類似貼文，你就能自己判斷了 (◕‿◕)
+</ClawdNote>
+
+## 套路 1：掛名名人製造權威
+
+**原推文說**：Karpathy 親自整理了 LLM 寫程式會犯的錯，歸納出四條原則——Think Before Coding、Simplicity First、Surgical Changes、Goal-Driven Execution。有人根據這四條寫了一份 CLAUDE.md，一週內拿到 15,000 stars。
+
+**實情**：
+
+- 這個 repo 叫 `forrestchang/andrej-karpathy-skills`，**作者是 forrestchang，不是 Karpathy 本人**
+- 實際 stars 約 27k，2026-01-27 建立，累積約 2.5 個月，不是一週
+- Karpathy 確實發過 LLM 寫程式常見誤區的推文，但**他沒有把這些整理成「四原則」的 framework**。那四個命名是 forrestchang 二創包裝出來的
+
+一句話：社群衍生作品掛原作者名字，很多讀者會當成 Karpathy 官方出品。
+
+<ClawdNote>
+這招在 AI tooling 圈有夠常見。Karpathy、Simon Willison、Andrew Ng 這些人的名字有信任背書效果，拿來當標題誘餌，讀者的警戒心自動降一格。順手查一下原 repo 的 owner field，30 秒就知道真偽——偏偏沒人查 (￣▽￣)／
+</ClawdNote>
+
+## 套路 2：star 數對、內部統計全錯
+
+**原推文說**：`affaan-m/everything-claude-code` 這個 repo 有 **153,000+ stars**、**30+ specialized agents**、**180+ skills**、**1,282 security tests**。
+
+**實情**（去 GitHub README 看得到）：
+
+- Stars 真的有 ~154k，這個量級對（這點沒騙）
+- Agents 實際是 **47 個**（不是 30+，原文少報一半）
+- Skills 實際是 **181 個**（跟 180+ 差不多，這點 OK）
+- **1,282 tests 是子工具 AgentShield 的 coverage 數字**，不是整個 repo 的 security tests。原文把子元件的指標掛到 repo 總體上
+
+一個對的數字（star 數）配幾個錯但近似的數字，製造「這傢伙都查過了」的權威感。
+
+<ClawdNote>
+這招比套路 1 還狡猾。Star 數對、skill 數大致對，讀者對了兩個就會預設其他數字也可信。偏偏 agents 數字和 tests 數字就是亂講的。權威感是複利累積的：對一點、稍微偏一點、差很多，讀者通常只會看頭尾平均，不會逐條驗算 (¬‿¬)
+</ClawdNote>
+
+## 套路 3：package 名稱寫錯
+
+**原推文給了一條「30 秒修復 token 浪費」的神奇指令**：
+
+```
+npx claude-code@2.1.98
+```
+
+**問題在哪**：`claude-code` 這個 npm 包確實存在，但它是 **官方佔坑的 pointer 包**，description 就明寫「Pointer to the official Claude Code package at @anthropic-ai/claude-code」。這個包只有 `1.0.0`，沒有 `2.1.98`。
+
+真正的 Claude Code CLI 是 **`@anthropic-ai/claude-code`**。正確的回退指令會是：
+
+```sh
+npx @anthropic-ai/claude-code@2.1.98
+```
+
+一個 `@` 之差，複製貼上的讀者會拿到 npm 404。
+
+<ClawdNote>
+這條最惡劣。讀者看完會覺得「喔 30 秒可以解決問題」就複製貼上，結果 npm 報錯，以為自己手殘，再去搜一次——然後就忘了。原推文沒差，反正按讚和分享已經完成了。這就是 engagement-farm 的結構：標的是互動行為本身，不是讀者真的能做到那件事 (ง •̀_•́)ง
+</ClawdNote>
+
+## 套路 4：extraordinary claim 配 unverifiable 證據
+
+**原推文最戲劇性的一段**：有人架了 HTTP proxy 攔截 Claude Code v2.1.98 和 v2.1.100 的 API 流量，發現 v2.1.100 送出的 bytes 少 978，charge 的 token 卻多 **20,196**——Anthropic 在伺服器端偷偷灌爆 token 用量。
+
+**實情檢查**：
+
+- 版本號是真的，`@anthropic-ai/claude-code` 兩個版本都在 npm registry 上
+- 那組「169,514 bytes / 49,726 tokens」vs「168,536 bytes / 69,922 tokens」的精確比對，需要：proxy 設定細節、兩個版本的 request dump、usage header 的 side-by-side log
+- 原推文**完全沒附這些**。沒 proxy log、沒 repo 連結、沒 GitHub issue 編號——只有一張精確到個位數的表格
+
+這是典型的「extraordinary claim 配 unverifiable 佐證」。
+
+<ClawdNote>
+假消息推廣的黃金法則：越離譜、數字越精確，讀者越容易信。「多 20,196 tokens」比「token 多了很多」有信服力，但精確數字本身不是證據。真的抓到 Anthropic 偷 token 的人會開 GitHub issue、會 dump log、會做 reproducible 的實驗——而不是在 X 上甩一張表。這則推文沒附佐證，所以你只能當故事看 (⌐■_■)
+</ClawdNote>
+
+## 怎麼自保：三步 verify checklist
+
+每次看到類似的 AI tooling 貼文，30 秒能做的事：
+
+1. **Repo owner field**：推文提到 repo，點進去看 owner。是名人本人？還是粉絲 fork？
+2. **Package name 拼對**：直接去 npm / pypi 搜，確認 package 存在、目標版本存在
+3. **Extraordinary claim 要看 receipts**：精確數字的 claim 有沒有附 log、issue、repo、reproducible 步驟？沒有就當故事看
+
+不用當偵探，只需要比平均讀者多點兩下連結。大多數 AI tooling 水文在第一步就露餡。
+
+## 結語
+
+noisyb0y1 不是 Clawd 要針對的對象——他只是最近剛好踩中典型 pattern 的一個樣本。類似的貼文在 X 上一週有好幾則。
+
+重點是讀者自己看到時怎麼處理。gu-log 的 CLAUDE.md 寫得很清楚：「Subagent 的事實結論要自己驗證一次」——subagent 會錯、推文會錯、直覺也會錯。對 AI tooling 的事實聲明，**不要從記憶或直覺答**。要 verify。
+
+30 秒的點擊成本，省下後面 30 分鐘的除錯時間。

--- a/src/content/posts/en-cp-pending-20260414-noisyb0y1-ai-tooling-slop-4-patterns.mdx
+++ b/src/content/posts/en-cp-pending-20260414-noisyb0y1-ai-tooling-slop-4-patterns.mdx
@@ -1,0 +1,122 @@
+---
+ticketId: "CP-PENDING"
+title: "\"Claude Code Automates 80% of Your Work, $28k/mo Passive Income\" — We Checked the Four Claims in That Viral Tweet. None Fully Hold Up."
+originalDate: "2026-04-13"
+translatedDate: "2026-04-14"
+translatedBy:
+  model: "Opus 4.6"
+  harness: "Claude Code"
+  pipeline:
+    - role: "Written"
+      model: "Opus 4.6"
+      harness: "Claude Code"
+    - role: "Fact-checked"
+      model: "Opus 4.6"
+      harness: "Claude Code (WebFetch subagent)"
+source: "@noisyb0y1 on X"
+sourceUrl: "https://x.com/noisyb0y1/status/2043609541477044439"
+lang: "en"
+summary: "A viral X tweet: a Google engineer automated 80% of his job with Claude Code and earns $28k/mo passive income. We checked the four main claims — Karpathy didn't write that CLAUDE.md, the repo's internal stats are wrong, the npm package name is wrong, and the billing claim has no receipts."
+tags: ["clawd-picks", "fact-check", "ai-slop", "claude-code", "engagement-farming"]
+---
+
+import ClawdNote from '../../components/ClawdNote.astro';
+
+A tweet went viral on X this week: "A Google engineer with 11 years of experience used Claude Code plus a small dotnet app to automate 80% of his job. Now he works 2-3 hours a day, chills the rest, and earns $28,000 in passive income."
+
+The tweet packs a CLAUDE.md template, two GitHub repo recommendations, and a one-line downgrade command. It reads like a dense takeaway checklist. Likes, retweets, bookmarks — the full combo.
+
+There's one problem: we fact-checked the four main claims. **Not one of them fully holds up.**
+
+<ClawdNote>
+gu-log's CLAUDE.md is clear on this: any AI tooling claim must be verified, not recalled. I was going to translate it as a normal SP. But credibility was far lower than expected, and publishing it as-is would just amplify the misinformation. So it became this post instead — a breakdown of the four standard tricks in AI tooling slop (◕‿◕)
+</ClawdNote>
+
+## Trick 1: Famous-name attribution
+
+**The tweet says**: Andrej Karpathy documented the mistakes LLMs make when writing code and distilled them into four principles — Think Before Coding / Simplicity First / Surgical Changes / Goal-Driven Execution. Someone wrote a CLAUDE.md from these and got 15,000 stars in a week.
+
+**What's actually true**:
+
+- The repo is `forrestchang/andrej-karpathy-skills`. **Author: forrestchang, not Karpathy.**
+- Real star count: ~27k, accumulated over ~2.5 months (created 2026-01-27), not one week.
+- Karpathy tweeted observations about LLM coding pitfalls, but **he never framed them as "four principles"**. That naming is forrestchang's packaging.
+
+Short version: a community derivative work, attributed to the famous source so readers assume it's official.
+
+<ClawdNote>
+Classic move in the AI tooling space. Karpathy, Simon Willison, Andrew Ng — those names carry trust. Put them in the headline and the reader's guard drops a notch. One click on the repo's owner field takes 30 seconds to disprove. Nobody clicks (￣▽￣)／
+</ClawdNote>
+
+## Trick 2: Right star count, wrong everything else
+
+**The tweet says** `affaan-m/everything-claude-code` has **153,000+ stars**, **30+ specialized agents**, **180+ skills**, **1,282 security tests**.
+
+**What's on GitHub** (visible in the README):
+
+- Stars: ~154k. Close enough. (The one correct number.)
+- Agents: **47**, not 30+. Underreported.
+- Skills: **181**. Roughly matches 180+. Fine.
+- 1,282 tests: that's **AgentShield's** coverage, a sub-component. Not the repo's security tests overall.
+
+One correct number plus a few close-but-wrong numbers manufactures the impression that the author did their homework.
+
+<ClawdNote>
+This trick is sneakier than the first one. Star count is right, skill count is roughly right — get two out of four and readers assume the rest is solid. Agents count and test count are just made up. Credibility compounds: one right, one slightly off, one way off — most people average the ends and skip verification (¬‿¬)
+</ClawdNote>
+
+## Trick 3: Wrong package name
+
+**The tweet offers a 30-second "token waste fix"**:
+
+```
+npx claude-code@2.1.98
+```
+
+**Here's the issue**: `claude-code` on npm exists, but it's an **official pointer package**. Its description literally says "Pointer to the official Claude Code package at @anthropic-ai/claude-code". The package has only `1.0.0`. There is no `2.1.98` under this name.
+
+The real Claude Code CLI is **`@anthropic-ai/claude-code`**. The correct downgrade command would be:
+
+```sh
+npx @anthropic-ai/claude-code@2.1.98
+```
+
+One `@` symbol off. A reader who copy-pastes gets a 404 from npm.
+
+<ClawdNote>
+This is the meanest of the four. Reader thinks "30 seconds to solve it", pastes the command, sees an npm error, assumes they screwed up, searches again, forgets it. The original tweet doesn't care — the like-and-bookmark already happened. That's the engagement-farm structure: the target is the interaction itself, not whether the reader actually accomplishes the thing (ง •̀_•́)ง
+</ClawdNote>
+
+## Trick 4: Extraordinary claim plus unverifiable evidence
+
+**The most dramatic segment**: someone "set up an HTTP proxy to intercept full API requests across two Claude Code versions", and found that v2.1.100 sends 978 bytes less but charges **20,196 more tokens** per request.
+
+**Reality check**:
+
+- Version numbers are real — both 2.1.98 and 2.1.100 ship on npm
+- The exact comparison — "169,514 bytes / 49,726 tokens" vs "168,536 bytes / 69,922 tokens" — would need: the proxy setup details, request dumps from both versions, side-by-side usage header logs
+- The tweet links to **none of this**. No proxy log. No repo. No GitHub issue number. Just one oddly precise table
+
+Classic pairing: extraordinary claim + unverifiable evidence.
+
+<ClawdNote>
+Golden rule of bullshit distribution: the more outrageous the claim, the more precise the numbers must be. "20,196 more tokens" feels solid; "many more tokens" doesn't. But precision is not evidence. If someone actually caught Anthropic inflating tokens, they would open a GitHub issue, dump logs, and post a reproducible experiment — not a screenshot on X. No receipts, so treat it as fiction (⌐■_■)
+</ClawdNote>
+
+## Self-defense: a 3-step verify checklist
+
+Every time you see a tweet like this, 30 seconds of clicks:
+
+1. **Repo owner field**: tweet mentions a repo? Click in. Is the owner the famous person, or a fan's fork?
+2. **Package name spelled correctly**: search npm or pypi directly. Does the package exist? Does the claimed version exist?
+3. **Receipts for extraordinary claims**: precise numbers should come with logs, an issue, a repo, or reproducible steps. No receipts = fiction.
+
+You don't need to be a detective. You just need two more clicks than the average reader. Most AI tooling slop fails at step 1.
+
+## Wrap
+
+noisyb0y1 isn't the target here — he happened to be the sample that hit a textbook pattern. Similar tweets pile up on X every week.
+
+What matters is what you do when you see the next one. gu-log's own CLAUDE.md is blunt: "Subagent conclusions need one more verification pass" — subagents get things wrong, tweets get things wrong, gut feelings get things wrong. For AI tooling facts, **don't answer from memory or instinct**. Verify.
+
+30 seconds of clicking saves 30 minutes of debugging later.

--- a/tests/content-integrity.spec.ts
+++ b/tests/content-integrity.spec.ts
@@ -83,10 +83,15 @@ test.describe('Content Integrity: ticketId', () => {
     const posts = getAllPosts();
     const ticketIdMap = new Map<string, PostFrontmatter[]>();
     
-    // Group posts by ticketId
+    // Group posts by ticketId.
+    // PENDING is a placeholder shared across parallel in-flight drafts
+    // (see CONTRIBUTING.md §並行撰寫防 ID collision). Real numbers are
+    // allocated per-draft at deploy. The pre-push guard blocks PENDING
+    // from reaching main, so collisions here are not prod-visible.
     for (const post of posts) {
       if (!post.ticketId) continue;
-      
+      if (post.ticketId.endsWith('-PENDING')) continue;
+
       const existing = ticketIdMap.get(post.ticketId) || [];
       existing.push(post);
       ticketIdMap.set(post.ticketId, existing);
@@ -147,7 +152,9 @@ test.describe('Content Integrity: ticketId', () => {
   test('GIVEN all posts WHEN checking ticketId format THEN ticketIds should follow PREFIX-N pattern (SP/CP/SD/Lv)', async () => {
     const posts = getAllPosts();
     // Valid prefixes: SP (ShroomDog Picks), CP (Clawd Picks), SD (ShroomDog Originals), Lv (Level-Up)
-    const validPattern = /^(SP|CP|SD|Lv)-\d+$/;
+    // PENDING is a legitimate in-flight placeholder (see CONTRIBUTING.md §並行撰寫防 ID collision);
+    // gets swapped for a real number at deploy and can't reach main (pre-push guard).
+    const validPattern = /^(SP|CP|SD|Lv)-(?:\d+|PENDING)$/;
     const invalidFormat = posts.filter(p => p.ticketId && !p.ticketId.match(validPattern));
     
     if (invalidFormat.length > 0) {


### PR DESCRIPTION
並行撰寫 SP/CP/SD/Lv 時，兩條 branch 都從 counter 讀 next 值會撞號。
SOP: 寫作階段一律用 `<PREFIX>-PENDING` 佔位，只在 merge 前最後一刻
才 allocate 真號、rename 檔案、bump counter。對應的 sp-pipeline
deploy 流程本來就這樣跑，現在把它也擴到手動撰寫。

- validate-posts.mjs: TICKET_PATTERN 接受 `<PREFIX>-PENDING`；
  Rule 12 (uniqueness) 對 -PENDING 結尾的 ticketId 跳過檢查，
  允許多條並行 draft 共用佔位號
- .githooks/pre-commit (+ scripts/hooks/pre-commit): step 0
  duplicate count 過濾掉 -PENDING，避免同分支多篇 draft 互撞
- .githooks/pre-push (+ scripts/hooks/pre-push): 新增 step 0
  safety net — 檢測 push 目標是 main/master 時，若 commits 內
  含 -PENDING 的 MDX 就擋下，避免 PENDING 誤入 production
- CONTRIBUTING.md: 新增 §並行撰寫防 ID collision 段落，寫明
  PENDING 慣例 + 四步 swap procedure + gate 行為