### PR TITLE
SP-PENDING: Opus 4.7 prompting best practices cheat sheet (zh-tw + en) + Model Swap glossary

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -325,24 +325,33 @@ Pipeline agents：如果無法取得完整 source，output `INCOMPLETE_SOURCE: <
 
 ## Workflow
 
+### zh-tw 優先 SOP（所有系列通用）
+
+**寫作順序：zh-tw 先寫、先 iterate 到過分數，才翻英文。** 英文版是 zh-tw 穩定後的衍生品，不是並行產物。
+
+**為什麼**：vibe-scorer 的迭代會改 persona、重寫 ClawdNote、動段落結構，每一輪都可能大改。如果同時維護 EN 版，等於在翻譯一個不穩定的 draft，浪費 token + 兩邊容易失同步。zh-tw 是 SSOT，先讓它過分數再說。
+
+**例外**：如果你已經確定稿子不會再動（例如從別的過分數的稿子搬過來），可以一次兩版。這是權衡後的例外，不是預設。
+
 ### 新增翻譯文章 (SP/CP)
 
-1. 用 `bird read <url>` 抓取原文
-2. 翻譯成 MDX，加入 ClawdNote 吐槽
-3. 建立中文版 (`slug.mdx`) 和英文版 (`en-slug.mdx`)
-4. 更新 `scripts/article-counter.json`
-5. `node scripts/validate-posts.mjs` 確認沒有錯誤
-6. `git add -A && git commit && git push`
-7. Ralph scorer 評分 → 沒過就改寫
+1. 抓原文：tweet 用 `bird read <url>`；blog/docs 用 `WebFetch`
+2. 寫 **zh-tw 版** `<prefix>-pending-YYYYMMDD-<slug>.mdx`（加 ClawdNote 吐槽）
+3. `node scripts/validate-posts.mjs` 確認 frontmatter 合格
+4. 丟 **vibe-opus-scorer** subagent 評分 → 沒過就改寫，最多 3 輪
+5. 過分數之後才翻 **en 版** `en-<prefix>-pending-YYYYMMDD-<slug>.mdx`
+6. 再跑一次 `validate-posts.mjs` + `pnpm run build`
+7. Merge 前把 PENDING swap 成真號（或交給 `sp-pipeline deploy`）
+8. `git add` 指定檔案 → commit → push
 
 ### 新增原創文章 (SD)
 
 1. Outline → 人類核准
-2. 撰寫 zh-tw + en 雙語版本
-3. 使用 ClawdNote（Clawd 觀點）+ ShroomDogNote（ShroomDog 觀點）
-4. Ralph scorer 評分 → **必須達到 8/8/8** 才能 publish
-5. GPT 5.4 fact-check（如適用）
-6. 更新 counter → validate → push
+2. 寫 **zh-tw 版** + ClawdNote + ShroomDogNote
+3. 丟 **vibe-opus-scorer** 評分 → 沒過就改寫（pass bar: composite ≥ 8 AND 至少一維 ≥ 9 AND 無維 < 8）
+4. GPT 5.4 fact-check（如適用）
+5. 過分數後才翻 **en 版**
+6. 更新 counter → validate → build → push
 
 ### SP Pipeline（自動翻譯流程）
 

--- a/quality/broken-links-baseline.json
+++ b/quality/broken-links-baseline.json
@@ -1,8 +1,8 @@
 {
-  "date": "2026-04-11",
-  "total": 4042,
+  "date": "2026-04-17",
+  "total": 4166,
   "internal": {
-    "ok": 2314,
+    "ok": 2394,
     "broken": []
   },
   "external": {

--- a/scripts/detect-model.mjs
+++ b/scripts/detect-model.mjs
@@ -11,11 +11,14 @@
 
 const MODEL_MAP = {
   // Anthropic
+  'claude-opus-4-7': 'Opus 4.7',
   'claude-opus-4-6': 'Opus 4.6',
   'claude-opus-4-5': 'Opus 4.5',
   'claude-opus-4': 'Opus 4',
+  'claude-sonnet-4-6': 'Sonnet 4.6',
   'claude-sonnet-4-5': 'Sonnet 4.5',
   'claude-sonnet-4': 'Sonnet 4',
+  'claude-haiku-4-5': 'Haiku 4.5',
   'claude-haiku-3-5': 'Haiku 3.5',
   // Google
   'gemini-2.5-pro': 'Gemini 2.5 Pro',

--- a/src/content/posts/en-sp-174-20260415-intuitiveml-ai-first-harness-engineering.mdx
+++ b/src/content/posts/en-sp-174-20260415-intuitiveml-ai-first-harness-engineering.mdx
@@ -101,7 +101,7 @@ This is the same pattern SP-98 (OpenAI's original harness engineering writeup) d
 
 Both optimize **agent cognitive load**. Humans can patch missing context with years of tribal knowledge. AI can't — so legibility has to be a first-class design concern (๑•̀ㅂ•́)و✧
 
-Further reading: [SP-98: OpenAI's original harness engineering writeup](/en/posts/sp-98-20260303-openai-harness-engineering/)
+Further reading: [SP-98: OpenAI's original harness engineering writeup](/en/posts/en-sp-98-20260303-openai-harness-engineering/)
 </ClawdNote>
 
 ## The Stack
@@ -392,6 +392,6 @@ People who use knives don't just admire how sharp the blade is — they also wat
 **Original**: [@intuitiveml on X, 2026-04-13](https://x.com/intuitiveml/status/2043545596699750791)
 
 **Further reading**:
-- [SP-98: OpenAI's original harness engineering writeup](/en/posts/sp-98-20260303-openai-harness-engineering/)
-- [SP-94: Agent harness is the actual product](/en/posts/sp-94-20260302-hxlfed14-agent-harness-real-product/)
-- [SP-172: 90% of you don't need multi-agent](/en/posts/sp-172-20260413-anthropic-multi-agent-when-how/)
+- [SP-98: OpenAI's original harness engineering writeup](/en/posts/en-sp-98-20260303-openai-harness-engineering/)
+- [SP-94: Agent harness is the actual product](/en/posts/en-sp-94-20260302-hxlfed14-agent-harness-real-product/)
+- [SP-172: 90% of you don't need multi-agent](/en/posts/en-sp-172-20260413-anthropic-multi-agent-when-how/)

--- a/src/content/posts/en-sp-pending-20260416-anthropic-opus-4-7-prompting-best-practices.mdx
+++ b/src/content/posts/en-sp-pending-20260416-anthropic-opus-4-7-prompting-best-practices.mdx
@@ -1,0 +1,187 @@
+---
+ticketId: "SP-PENDING"
+title: "After Opus 4.7: How Your Prompt Playbook Needs to Change — Two Official Anthropic Best Practices in One Cheat Sheet"
+originalDate: "2026-04-16"
+translatedDate: "2026-04-16"
+translatedBy:
+  model: "Opus 4.7"
+  harness: "Claude Code"
+source: "Anthropic (claude.com/blog + platform.claude.com/docs)"
+sourceUrl: "https://claude.com/blog/best-practices-for-using-claude-opus-4-7-with-claude-code"
+lang: "en"
+summary: "Anthropic released two Opus 4.7 best practices — a Claude Code guide and a full prompting docs page. 4.7 is the strongest GA model, and Sonnet/Haiku prompt instincts are expiring. One cheat sheet: three must-knows, effort ladder, 4.6→4.7 diffs, copy-paste snippets."
+tags: ["claude-opus-4-7", "prompt-engineering", "anthropic", "claude-code"]
+---
+
+import ClawdNote from '../../components/ClawdNote.astro';
+
+Anthropic just dropped two official best practice documents at once. One is a [Claude Code guide](https://claude.com/blog/best-practices-for-using-claude-opus-4-7-with-claude-code) (shorter, focused on interactive coding). The other is a [full prompting guide](https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/claude-prompting-best-practices) (longer, with an Opus 4.7-specific section — this is the main course). Both say the same thing: Opus 4.7 is the strongest GA model right now, and Anthropic defaults their own flows to it.
+
+Which means the prompt instincts from Sonnet and Haiku days are slowly expiring. Effort levels, tokenizer, thinking API, subagent strategy — even default design aesthetic — all had their logic swapped out. Push old habits onto 4.7 and best case your output looks slightly off; worst case your pipeline breaks quietly and nobody notices.
+
+This piece condenses both docs into one cheat sheet: three must-knows first, then how to pick an effort level, then the 4.6→4.7 behavior diff, two real harness traps, and finally copy-paste prompt snippets. Reading it saves a few months of finding these the hard way.
+
+## Three things you must know
+
+The three things do not hurt equally. The tokenizer swap is like **your landlord raising rent without telling you** — no sting in one month, but the quarterly bill shows the money gone. The new `xhigh` default is like **the car manufacturer changing the default engine**: steering feels lighter, throttle lags a beat, no crash but it handles differently. `budget_tokens` RIP is like **the utility master meter getting yanked out** — no hard brake anymore, only the `max_tokens` gas pedal. Here are the three things most likely to break things in silence:
+
+**First, the tokenizer changed.** Opus 4.7 ships an updated tokenizer, so token counts from old prompts are no longer accurate. Same `max_tokens`, same input text — the number of tokens 4.7 produces can be higher or lower than 4.6. Any pipeline that relies on precise token math — context window budgeting, prompt caching keys, context compression thresholds — needs recalibration.
+
+**Second, `xhigh` is the new effort default.** The effort ladder went from `low / medium / high / max` to `low / medium / high / xhigh / max`, and Claude Code's default is now `xhigh`. This new level sits between `high` and `max`, balancing "reasons well" with "won't overthink and burn tokens." Docs recommend starting at `xhigh` for coding and agentic use cases.
+
+**Third, `budget_tokens` is RIP, replaced by adaptive thinking.** The old Extended Thinking API parameter `budget_tokens` — the fixed thinking budget — is not supported on 4.7. Instead, adaptive thinking: the model decides for itself whether and how long to think at each step, based on context. Humans only get indirect control via the `effort` level. The hard ceiling is gone. The good news: no more "budget ran out mid-thought" awkwardness. The bad news: precise cost control for thinking is now closed off, and `max_tokens` becomes your only hard ceiling.
+
+<ClawdNote>
+The quiet tokenizer swap is a little shady. The release note has one line about it, but wrong token counts silently mess up API costs and context window management. Plus `budget_tokens` is gone, hard ceilings removed — so if your production stack uses hardcoded token estimates for budgeting, or relies on `budget_tokens` as a cost brake, congrats, your weekend just filled up with re-testing. This is not Anthropic's first low-key breaking change, and probably not the last ┐(￣ヘ￣)┌
+</ClawdNote>
+
+---
+
+## How to pick an effort level
+
+Effort is not a volume knob. It's more like **grind size on a coffee machine** — espresso wants fine, pour-over wants coarse. Finer is not always better. Use `max` to grind for pour-over and you get a bitter mess; use `low` to grind for espresso and water floods the counter. The five levels are not a linear "higher = better" scale. Each level pairs with a specific workload, and picking the wrong one is often worse than picking one that is a bit weak. Docs explain in detail — here's the cheat sheet:
+
+**`low`**: tiny tasks. 4.7's `low` respects scope strictly and does only what's asked, nothing extra. Perfect for "copy this format," "only change this one line," "plain format conversion" — the places where you don't want the model improvising. Asking for more and not getting it is a feature, not a bug.
+
+**`medium`**: moderate complexity. Standard CRUD, doc tidying, single-function refactors. Like `low`, it's literal. Official warning: on moderately complex problems, `medium` can under-think. If you see shallow reasoning, raise to `high` or `xhigh` rather than stacking prompt incantations at `medium`.
+
+**`high`**: complex tasks. Multi-step reasoning, structured debugging, cross-file refactors. This is where the model starts exploring on its own and deciding when to gather extra context. Docs set this as the floor for intelligence-sensitive use cases.
+
+**`xhigh`** (Claude Code default, recommended start for coding/agentic): the sweet spot between `high` and `max`. Stable multi-step reasoning without `max`'s tendency to split a simple question into ten sub-arguments. Claude Code picks it as default, which is essentially Anthropic endorsing it for interactive coding.
+
+**`max`**: research-grade tasks, architecture discussions, design decisions where you need to exhaust possibilities. Warning: `max` overthinks. Give it a simple question and you get ten paragraphs of reasoning, five alternatives, the answer at the bottom. Not higher quality — just token and time spent staging a debate tournament.
+
+Practical rule: **start at `xhigh` for coding/agentic, at least `high` for intelligence-sensitive work**. Only drop to `medium` or `low` for simple format tasks. Don't default to `max` hoping a "fancier model gives fancier answers" — 4.7's `max` turns a three-line solution into a ten-paragraph essay. One more detail: when you run `xhigh` or `max`, docs recommend starting `max_tokens` at **64k** to give the model and any subagents enough room to both think and act.
+
+<ClawdNote>
+"Why not just call it `higher` or `very_high`?" Some Anthropic engineer probably A/B tested and found `xhigh` saves two characters over `very_high` and is more memorable than `higher`. Still reads weird, though — like a placeholder name squeezed into an existing ladder. Next-gen model will probably add another tier like `ultrahigh` or `ludicrous`, and `xhigh` gets demoted to middle. This naming trajectory reminds me of CPUs going Pro → Pro Max → Ultra → Ultra Max — eventually the levels grow legs and run away (¬‿¬)
+</ClawdNote>
+
+---
+
+## 4.6 → 4.7 behavior diff cheat sheet
+
+The first week after swapping your pipeline from 4.6 to 4.7, the biggest danger is not that the model got dumber. It's that "**things look the same but work differently**." CI still runs, tests still pass, output still arrives — but code review misses bugs, agents skip doc lookups, and UIs ship looking like coffee-shop websites. Three behavior changes most likely to ambush your pipeline, first:
+
+**More literal, tighter scope.** 4.6 had the habit of "generous interpretation" — ask it to "optimize this function" and it might also clean up related helpers; say "fix the bug" and it might refactor ugly nearby code while it's there. 4.7 does exactly what you asked. "Optimize this function" means that function, not one line more. Upside: controllable, debuggable. Downside: every prompt that used to lean on the model being "thoughtful" now gets exposed. To apply across a whole group of code, you must state the scope explicitly; vague words get interpreted at their narrowest.
+
+**Reasons more, uses tools less.** 4.7 clearly prefers thinking out the answer over calling tools to verify. Cleaner thinking, less noise — but for anything requiring a repo read, doc lookup, or grep, if you don't say "search first, answer second," the model will guess from training data and deliver a confident-sounding answer based on stale knowledge. Function names may have been renamed six months ago, API paths no longer exist. Prompts that need ground truth must spell it out: "Use grep to confirm the function still exists," "Search first, answer later."
+
+**Default design aesthetic is cream + serif.** 4.7 has a strong design default: `#F4F1EA` off-white background, Georgia / Fraunces / Playfair serif display, italic word-accents, terracotta/amber accent color. Reads beautifully for editorial, hospitality, and portfolio sites — but lands horribly on dashboards, dev tools, fintech, healthcare, or enterprise UIs. And the default is stubborn: generic instructions like "don't use cream" tend to swap in another fixed palette rather than produce variety. To override, give a concrete design system: specify the font stack, hex palette, and layout grid.
+
+Those three are the **silent pipeline-breakers**. There are three more behavior shifts that are easier to notice and adapt to, bundled briefly here: response length self-calibrates (shorter on simple asks, longer on open-ended ones — force verbosity only with explicit upper and lower bounds); subagent spawn is lower by default (parallel-processing harnesses need explicit encouragement, see the snippets section); and tone is more direct with fewer emojis (technical output benefits, but friendly chatbot personas need to be prompted in).
+
+<ClawdNote>
+The funniest default is cream + serif. Picture this — you ask Claude Code to build a CRUD dashboard, an admin panel, or a fintech monitoring UI, and what opens is off-white background, Playfair Display headlines, terracotta-colored buttons. Whole thing reads like a boutique coffee-shop website or a Medium article cover. First engineer reaction: "who changed the Tailwind config?" Dig in for thirty minutes, discover the model decided it should look this way. From now on, every UI generated from a design-system-free prompt will look like a café — tasteful, but wildly wrong for a work context ╰(°▽°)╯
+</ClawdNote>
+
+---
+
+## The golden ratio for interactive coding
+
+Interactive coding is like working with a new contractor — you spend half of day one walking them through the requirements, coding style, constraints, and testing expectations, then every ticket after that wraps up in three sentences. The thing that saves time is that upfront investment, not the thirty-minute daily standup. The Claude Code blog basically unpacks this pattern for users:
+
+**Pack the preloaded context as dense as possible.** The bottleneck in interactive sessions is that every user turn burns tokens to re-align. Spend more upfront writing repo structure, coding conventions, constraints, and limits into `CLAUDE.md` / the system prompt, and every user turn after that can shrink to one line — "edit this bit," "run tests," "push it." Every saved turn is pure win.
+
+**Minimize user turns, not maximize agent autonomy.** These two things look similar and are different. The first is "specify clearly once, let the model run to completion." The second is "give the model agent-level freedom." Opus 4.7 prefers the first — cut a clean spec up front, let the model go end-to-end, come back at the end. Don't interrupt, don't double-check mid-flight. Every interrupt means re-eating context.
+
+**Auto mode is research preview, toggle with Shift+Tab.** Anthropic opened auto mode as a research preview for Claude Code Max users. Press `Shift+Tab` to enter, and Claude Code runs to completion, pinging you only at major decisions or on completion. A CTO's ideal workflow: assign task → do other things → come back to results. It's preview — expect some wobble in stability.
+
+**Notification hooks are the killer pairing with auto mode.** Claude Code's `Notification` / `Stop` hooks plug into system notifications, Discord webhooks — you can literally tell Claude "play a sound when done," and it will generate a hook-based notification script and stick it in settings for you. Combines beautifully with auto mode: agent finishes, bell rings, nobody has to babysit the terminal.
+
+---
+
+## The code review harness trap
+
+Picture this scene: Monday morning, open the code review dashboard, harness ran all weekend, report is clean — five issues, all CVE-grade. Tuesday afternoon, prod explodes. The bug is an off-by-one. During review, 4.7 saw it, then classified it as "not high severity" and silently skipped. 4.6 would have flagged it. 4.7 doesn't, because it's literal. This is the real case study documented in the docs, one sentence summary: **the prompt "only report high severity issues" gets executed literally on 4.7, and recall collapses on bugs that should have been flagged.**
+
+"High severity" is always going to be a vague term. 4.6 used to auto-balance "only the important stuff" against "don't miss too much." 4.7 takes the phrase at face value and tightens the threshold down to CVE-grade; logic errors, race conditions, off-by-ones all get filed under "not high" and skipped. Report looks clean; prod still blows up. Precision maxed, recall in the basement.
+
+**Fix**: split "broad coverage" from "strict filtering" into two steps. Docs give the exact prompt template:
+
+```text
+Report every issue you find, including ones you are uncertain about
+or consider low-severity. Do not filter for importance or confidence
+at this stage - a separate verification step will do that. Your goal
+here is coverage: it is better to surface a finding that later gets
+filtered out than to silently drop a real bug. For each finding,
+include your confidence level and an estimated severity so a
+downstream filter can rank them.
+```
+
+You can do two real stages: step 1 runs the prompt above for full coverage; step 2, a separate call, filters for severity ≥ high. Even in a single-stage setup this helps — write "your goal here is coverage, filtering happens later" into the prompt, and recall comes back. The key is **don't bundle both goals into one instruction**, or 4.7 picks whichever meaning is most literal and drops the other.
+
+This trap is not unique to code review. Any pipeline of the shape "find problems + only report the important ones" — issue triage, log anomaly detection, security scanning, doc review — needs the same split. 4.6 would "generously interpret" the prompt's intent and auto-balance both goals; 4.7 doesn't do favors, and lazily-written prompts get caught in the spotlight.
+
+<ClawdNote>
+What makes this trap juicy is that 4.6 just didn't have the problem. 4.6 would auto-balance "only report important ones" against "don't miss too much," so even if you said "high only," it would still flag the obvious mediums. 4.7 follows the prompt exactly, which means every sloppy prompt that used to get carried by model niceness now has its seams on display. Anthropic is never going to frame it in the release note as "the model is too obedient so your underspecified prompts now leak" — that sounds like a downside, but it's actually the model getting more steerable and more debuggable. Engineers win, lazy prompt authors suffer (⌐■_■)
+</ClawdNote>
+
+---
+
+## A pocket library of ready-to-use prompt snippets
+
+Here are the highest-frequency copy-paste snippets pulled straight from the docs. These are the ones most worth dropping into a prompt library for the Opus 4.7 era:
+
+**Cap subagent overuse** (for cases where the model over-delegates simple work):
+
+```text
+Do not spawn a subagent for work you can complete directly in a
+single response (e.g. refactoring a function you can already see).
+```
+
+**Encourage parallel subagents** (for fan-out workloads — 4.7's default is too conservative):
+
+```text
+Spawn multiple subagents in the same turn when fanning out across
+items or reading multiple files.
+```
+
+**Avoid over-engineering** (brake pedal for the overthink tendency):
+
+```text
+Avoid over-engineering. Only make changes that are directly requested
+or clearly necessary. Keep solutions simple and focused.
+```
+
+**Control verbosity (shrink)**:
+
+```text
+Provide concise, focused responses. Skip non-essential context, and
+keep examples minimal.
+```
+
+**Increase thinking depth** (for when `low`/`medium` produces shallow reasoning — but remember, raising the effort level is the first lever; prompts only help on top):
+
+```text
+Think carefully and step-by-step before responding; this problem is
+harder than it looks.
+```
+
+**Verify before answering** (counters 4.7's "reason more, call tools less" tendency):
+
+```text
+Before answering, verify your assumption by reading the relevant
+file or running a quick grep. Do not answer from memory if a quick
+check can ground your response.
+```
+
+Save these in a library and compose them before each new pipeline run. Docs has many more task-specific templates (agentic coding, long context extraction, slide deck generation, scientific analysis). If you want the full Opus 4.7 dividend, reading the whole page once is worth the investment.
+
+<ClawdNote>
+Subagents went from 4.6's "energetic kid who needs discipline" to 4.7's "slacker employee who needs a cattle prod." That shift isn't in the release notes, but the practical impact is huge — without prompt changes, every pipeline that relied on parallel subagents will get slower, and the worst part is the slowdown is invisible (it looks like it's running, but it's actually serial). Debugging cost shoots up. New rule for writing harnesses: parallelism is not the default, you have to whip it into existence. Anthropic, mind adding a migration note next release (ง •̀_•́)ง
+</ClawdNote>
+
+---
+
+## Closing
+
+The most counterintuitive thing about Opus 4.7 is that it's not a "smarter" 4.6. It's a ["personality-swapped"](/glossary#model-swap) 4.6. More literal, spares its tool calls, shorter responses, fewer subagents, slower to explore on its own, even a fixed design aesthetic. These aren't bugs, they're new defaults. Prompt technique has to shift with them.
+
+So next time output disappoints, don't immediately turn the prompt into a collection of magic incantations ("please think carefully," "be thorough," "provide a full walkthrough" and similar). Ask three questions first: **Is the effort level right? Are coverage and filtering split? Did you state the scope explicitly?** These three beat any incantation — and they're a lot easier to debug than incantations, too.
+
+Anthropic released both best practices in the same window, which probably means they know this generation's prompt habits need retraining. Two weekends to read them, a few months of pain saved down the road. Call that the ROI.
+
+<ClawdNote>
+One last thing Anthropic won't say out loud: official best practices also expire. The snippets you learn today, Opus 4.8 might require another round of tuning. So the real takeaway isn't memorizing every template as sacred — it's building the habit of "reading model personality." When a new model ships, the first move isn't checking benchmark scores, it's reading the official best practice and migration guide to catch this generation's personality and behavioral diff. Treat a prompt as a forever answer, and you spend the rest of your career chasing version numbers ʕ•ᴥ•ʔ
+</ClawdNote>

--- a/src/content/posts/sp-pending-20260416-anthropic-opus-4-7-prompting-best-practices.mdx
+++ b/src/content/posts/sp-pending-20260416-anthropic-opus-4-7-prompting-best-practices.mdx
@@ -1,0 +1,187 @@
+---
+ticketId: "SP-PENDING"
+title: "Opus 4.7 上路之後 prompt 該怎麼改——Anthropic 官方兩份 best practice 濃縮一次讀"
+originalDate: "2026-04-16"
+translatedDate: "2026-04-16"
+translatedBy:
+  model: "Opus 4.7"
+  harness: "Claude Code"
+source: "Anthropic (claude.com/blog + platform.claude.com/docs)"
+sourceUrl: "https://claude.com/blog/best-practices-for-using-claude-opus-4-7-with-claude-code"
+lang: "zh-tw"
+summary: "Anthropic 同時釋出兩份 Opus 4.7 best practice——Claude Code 專用加完整 prompting guide。Opus 4.7 是現行最強 GA，Sonnet/Haiku 的 prompt 調教心得開始過期。這篇把兩份濃縮成一頁 cheat sheet：三件必知大事、effort 階梯怎麼選、4.6→4.7 行為差異、可直接 copy 的 prompt snippets。"
+tags: ["claude-opus-4-7", "prompt-engineering", "anthropic", "claude-code"]
+---
+
+import ClawdNote from '../../components/ClawdNote.astro';
+
+Anthropic 同時丟了兩份官方 best practice 出來。一份是 [Claude Code 專用](https://claude.com/blog/best-practices-for-using-claude-opus-4-7-with-claude-code)（短版，focus 互動式開發），一份是 [完整 prompting guide](https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/claude-prompting-best-practices)（長版，含 Opus 4.7 專屬章節，是主菜）。兩份都在講同一件事：Opus 4.7 是現行 GA 裡最強的 model，連 Anthropic 自己都以 4.7 當預設。
+
+這代表 Sonnet / Haiku 時期那套 prompt 調教的心得，正在慢慢過期。effort、tokenizer、thinking API、subagent 策略、連設計預設美學——全部換了一輪邏輯。舊的手感往 4.7 上套，輕則 output 走樣，重則 pipeline 偷偷壞掉沒人發現。
+
+這篇把兩份文件濃縮成一頁 cheat sheet：先講三件必知大事、再拆 effort 階梯、整理 4.6→4.7 的行為差異、帶兩個實務 harness 坑，最後附上可以直接 copy 的 prompt snippets。讀完能少走幾個月冤枉路。
+
+## 三件必知大事
+
+三件事嚴重度不一樣。tokenizer 換是**房東沒通知就調租金**——單月沒感覺、季帳單出來才發現錢不見了。`xhigh` 預設是**車廠把預設引擎換了**，開起來方向盤輕一點、油門反應慢一點，不會出車禍但手感不同。`budget_tokens` RIP 是**水電總錶被拆**——以後沒有硬煞車，只剩 `max_tokens` 這個油門踏板。這三件事把最容易偷偷壞事的攤開：
+
+**第一，tokenizer 換了。** Opus 4.7 升級了 tokenizer，意思是舊 prompt 算出來的 token 數不再準。同樣的 `max_tokens`、同樣的輸入文本，在 4.7 上切出的 token 可能比 4.6 多或少。依賴精準 token 計算的 pipeline——context window budgeting、prompt caching key、context compression 門檻——都要重新校正。
+
+**第二，`xhigh` 是新 effort 預設。** Opus 4.7 的 effort 階梯從原本的 `low / medium / high / max` 變成 `low / medium / high / xhigh / max`，而 Claude Code 現在預設就是 `xhigh`。這一層夾在 `high` 跟 `max` 之間，平衡「會推理」跟「不會 overthink 爆 token」。官方 docs 對 coding / agentic use case 的建議也是從 `xhigh` 起跳。
+
+**第三，`budget_tokens` RIP，改成 adaptive thinking。** 舊的 Extended Thinking API 裡 `budget_tokens` 這個固定 thinking 預算參數，在 4.7 上不再支援。改成 adaptive thinking：由 model 自己根據 context 決定每一步要不要想、想多久。人類只能透過 `effort` level 間接控制深度，硬上限沒了。好處是不會卡在預算耗盡卻沒想完的尷尬狀況；壞處是「精準控制 thinking 成本」這條路被堵死了，改拿 `max_tokens` 當 hard ceiling 頂著用。
+
+<ClawdNote>
+Tokenizer 偷偷換這件事蠻缺德的。release note 只有一行帶過，但 token 數算錯在 API 成本 + context window 管理上都會慢慢出事。再加上 `budget_tokens` 被拔掉、硬上限沒了——如果你家 production 還在用 hardcoded 的 token estimate 做 budgeting，或者靠 `budget_tokens` 當成本煞車，恭喜，這個週末要加班重測了。Anthropic 不是第一次在 breaking change 上低調處理，估計也不會是最後一次 ┐(￣ヘ￣)┌
+</ClawdNote>
+
+---
+
+## Effort 階梯怎麼選
+
+Effort 不是音量旋鈕，是咖啡機的預磨粗細——espresso 要細、手沖要粗，不是越細越好喝。`max` 拿去磨手沖就是一杯苦水，`low` 拿去磨 espresso 會漏水流滿地。五個 level 不是「越高越好」的線性階梯，每一層配特定 workload，配錯比配不夠還慘。Docs 講得細，以下是 cheat sheet：
+
+**`low`**：極簡任務。Opus 4.7 的 `low` 嚴格遵守 scope，字面照做、不會主動延伸。適合「照抄格式」、「只改這一行」、「單純 format 轉換」這種不想讓 model 自由發揮的場景。要求做更多也不會答腔，這是 feature 不是 bug。
+
+**`medium`**：中等 complexity。一般 CRUD、整理文件、refactor 單一 function。跟 `low` 一樣也偏 literal，給什麼做什麼。官方警告：在 moderate complexity 問題上跑 `medium` 有 under-thinking 風險——如果發現推理變淺，直接升 `high` 或 `xhigh`，不要在 `medium` 層堆 prompt 咒語。
+
+**`high`**：複雜任務。多步推理、debug 有結構的問題、跨檔案 refactor。這一層開始會主動探索、會自己決定要不要看額外 context。官方把這個設為 intelligence-sensitive use case 的最低門檻。
+
+**`xhigh`**（Claude Code 預設、coding/agentic 推薦起跳）：high 跟 max 之間的 sweet spot。多步 reasoning 穩定、也不會像 max 那樣把簡單問題切十段。Claude Code 把它定為預設，等於是 Anthropic 替互動式開發這個 workload 背書過的結論。
+
+**`max`**：研究級任務、架構討論、需要窮盡可能性的設計決策。警告：`max` 會 overthink。簡單問題丟 `max` 反而拿到十段論證、五個備選方案、最後才給答案。不是品質更高，是把 token 跟時間拿去演辯論賽。
+
+實務規則：**coding / agentic 從 `xhigh` 起跳、intelligence-sensitive 至少 `high`**。簡單 format 工作才降到 `medium` / `low`。不要預設拉 `max` 期待「高級 model 給高級答案」——4.7 的 `max` 會把三行就能解的事拆成十段小論文。另外，effort 設到 `xhigh` 或 `max` 時，`max_tokens` 官方建議從 **64k 起跳**，給 model 跟 subagent 夠的空間想完 + 做完。
+
+<ClawdNote>
+「為什麼不叫 `higher` 或 `very_high`？」Anthropic 工程師大概跑過 A/B test，發現 `xhigh` 比 `very_high` 少打兩個字、比 `higher` 更有記憶點。但讀起來還是怪，像硬擠進現有階梯裡的臨時命名。下一代 model 出來估計又要補一層 `ultrahigh` 或 `ludicrous`，然後 `xhigh` 就降格成中間層。這種 naming 演化讓人想到 CPU 從 Pro → Pro Max → Ultra → Ultra Max 的路——遲早 level 要自己長腳逃走 (¬‿¬)
+</ClawdNote>
+
+---
+
+## 4.6 → 4.7 行為變化 cheat sheet
+
+把 pipeline 從 4.6 換到 4.7 的第一週，最危險的不是 model 變笨，是「**看起來一樣但悄悄不一樣**」。CI 照跑、tests 照過、output 照來——但實際上 code review 漏 bug、agent 不查 doc、UI 生出來像咖啡廳官網。三個最會偷襲 pipeline 的行為變化先講：
+
+**更 literal、scope 縮得更緊。** 4.6 有「善意揣測」的習慣——叫它「優化這個 function」，順手也優化相關 helper；說「修 bug」可能連帶重構旁邊看不順眼的 code。4.7 完全照字面做。「優化這個 function」就是那個 function，一行多的都沒有。好處是可控、可 debug；壞處是過去靠 model 「體貼」的 prompt 全部露餡——要 apply 到整組 code，必須明講 scope，模糊詞會被收到最窄的解釋。
+
+**偏 reasoning、少 tool use。** 4.7 明顯傾向自己想答案，不打 tool 查證。思路乾淨、noise 少，但遇到需要查 repo、讀 doc、grep code 的場景，沒明說「先 search 再回答」的話，model 會用 training data 裡的舊知識推一個合理結論——聽起來有道理，實際上函式名六個月前改過、API 路徑不存在了。需要 ground truth 的 prompt 要明寫：「用 grep 確認這個函式還在」、「先 search、再回答」。
+
+**設計美學預設 cream + serif。** Opus 4.7 對設計有強 default：背景 `#F4F1EA` 奶白、字體 Georgia / Fraunces / Playfair、italic word-accents、terracotta/amber 點綴。對 editorial、hospitality、portfolio 類網站是加分，但 dashboard / dev tool / fintech / healthcare / enterprise UI 會整個走鐘。而且 default 很頑固，「不要用 cream」這種通用指令通常只是被換成另一套固定 palette，不會產生變化——要覆蓋必須給具體設計系統：指定 font stack、hex palette、layout grid。
+
+以上三個是**會偷偷壞事**的。另外還有三個比較明顯、容易 adapt 的行為變化，放一起帶過：回覆長度會自己 calibrate（簡單問題變短、複雜問題變長，要強制 verbosity 得明講上下限）；subagent 預設少 spawn（需要平行處理的 harness 要主動鼓勵，後面 §即用 snippets 有範本）；tone 更直接少 emoji（技術輸出受惠，要「親切」chatbot tone 得主動加 persona）。
+
+<ClawdNote>
+最惡搞的是 cream + serif 預設。想像一下——叫 Claude Code 生個 CRUD dashboard、admin panel、fintech 儀表板，開出來是奶白底色、標題 Playfair Display、button 磚紅色，整個 UI 像精品咖啡店官網或 Medium 文章封面。工程師第一反應是「誰改了 Tailwind config」，查半天才發現是 model 自己覺得應該這樣。以後沒寫設計系統的 prompt 開出來的 UI 都會長得像咖啡廳——品味很好，但工作場景完全不對 ╰(°▽°)╯
+</ClawdNote>
+
+---
+
+## Interactive coding 的黃金比例
+
+互動式開發像跟新來的 contractor 合作——第一天花半天把需求、coding style、constraint、測試要求講清楚，後面每個 ticket 三句話就搞定。省時間的是那個前置投資，不是跟 contractor 每天 stand-up 三十分鐘。Claude Code blog 這段的核心就是把這個 pattern 拆給使用者看：
+
+**前置 context 寫得越滿越好。** 互動式場景的瓶頸在「每次 user turn 都要花 token 重新對齊」。前期多花時間把 repo 結構、coding convention、限制條件、constraint 寫進 `CLAUDE.md` / system prompt，後面 user turn 就能極短——「改這段」、「跑測試」、「push 上去」。省下的 turn 全部是純賺。
+
+**Minimize user turns，不是 maximize agent autonomy。** 這兩件事看起來像、實際不同。前者是「一次交代清楚、model 自己跑完」，後者是「給 model agent-level 的自由」。Opus 4.7 的推薦作法是前者——前端切好 spec、讓 model 一條龍跑完再回來。中間不要追問、不要干擾，每次打斷都等於重吃一次 context。
+
+**Auto mode 是研究預覽，Shift+Tab 切換。** Anthropic 對 Claude Code Max 用戶開了 auto mode 的研究預覽。按 `Shift+Tab` 進入後，Claude Code 會直接跑到底、只在重大決策或完成時才 ping。CTO 工作流很合用：丟任務 → 去做別的 → 回來收成果。目前是 preview，穩定度預期會有起伏。
+
+**Notification hook 是搭配 auto mode 的神器。** Claude Code 的 `Notification` / `Stop` hook 可以接系統通知、Discord webhook、甚至直接叫 Claude「完成時播個聲音」——model 會自己產一個 hook-based 通知腳本塞進 settings。配 auto mode 用特別順，agent 跑完自己響，人類不用守著 terminal。
+
+---
+
+## Code review harness 的坑
+
+想像這個場景：週一早上打開 code review dashboard，harness 跑了一整個週末，report 乾乾淨淨五個 issue，全部 CVE 級別。週二下午 prod 炸了。Bug 是 off-by-one——review 的時候 4.7 看到了，但把 off-by-one 歸類成「not high severity」，靜靜 skip。4.6 會順手 flag，4.7 照字面不 flag。這就是 Docs case study 裡記錄的真實踩坑，結論一句話：**「只 report high severity issues」這種 prompt 在 4.7 上會被 literally 執行，結果是 recall 掉一堆該 flag 的 bug。**
+
+「High severity」本來就是模糊詞——4.6 會自動 balance「只報重要」跟「別漏太多」，4.7 照字面把門檻收到只剩 CVE 級別，logic error、race condition、off-by-one 全歸為「not high」而 skip。Report 看起來乾淨，prod 照樣炸。Precision 爆表、recall 崩盤。
+
+**Fix**：把「廣泛 coverage」跟「嚴格過濾」拆成兩步。官方直接給了 prompt 範本：
+
+```text
+Report every issue you find, including ones you are uncertain about
+or consider low-severity. Do not filter for importance or confidence
+at this stage - a separate verification step will do that. Your goal
+here is coverage: it is better to surface a finding that later gets
+filtered out than to silently drop a real bug. For each finding,
+include your confidence level and an estimated severity so a
+downstream filter can rank them.
+```
+
+可以實際做兩階段：step 1 跑上面這段拿 full coverage、step 2 另開 call 過濾 severity ≥ high。就算只做一步也可以——把「coverage 為目標、過濾之後再說」明寫進 prompt，recall 也會回來。重點是**不要把兩件事塞進同一個 instruction**，否則 4.7 會選最 literal 的那個意思做。
+
+這個坑不只出現在 code review。任何「找問題 + 挑重要的報」的 pipeline——issue triage、log anomaly detection、security scanning、doc review——都要拆。4.6 會「善意揣測」prompt 意圖、自動 balance 兩個目標；4.7 不幫人情，誰的 prompt 寫爛誰露餡。
+
+<ClawdNote>
+這坑最經典的地方是——4.6 時代沒這問題。4.6 會自動 balance「只報重要」跟「別漏太多」，該提的 medium 還是會順便 flag。4.7 完全照字面做，結果是過去靠 model 自己「體貼」撐起來的爛 prompt 全部被打回原形。Anthropic 不會在 release note 說「model 變得太聽話反而讓你 prompt 沒寫清楚的地方露餡」——聽起來像缺點，但本質上是 model 更可控、更可 debug。工程師喜歡，prompt 偷懶的人痛苦 (⌐■_■)
+</ClawdNote>
+
+---
+
+## 即用 prompt snippets 集錦
+
+Docs 裡可以直接 copy 的 snippet，挑幾個最高頻的。這些是 Opus 4.7 時代最該進 prompt library 的幾段：
+
+**控制 subagent overuse**（給做簡單工作卻 over-delegate 的情境）：
+
+```text
+Do not spawn a subagent for work you can complete directly in a
+single response (e.g. refactoring a function you can already see).
+```
+
+**鼓勵 parallel subagent**（給需要平行處理的 fan-out 情境——4.7 預設偏保守）：
+
+```text
+Spawn multiple subagents in the same turn when fanning out across
+items or reading multiple files.
+```
+
+**避免 over-engineering**（給 model overthink 的傾向踩煞車）：
+
+```text
+Avoid over-engineering. Only make changes that are directly requested
+or clearly necessary. Keep solutions simple and focused.
+```
+
+**控制 verbosity（壓短）**：
+
+```text
+Provide concise, focused responses. Skip non-essential context, and
+keep examples minimal.
+```
+
+**增加 thinking depth**（給 `low` / `medium` 跑出來不夠深的情境——記住優先調 effort，prompt 只是輔助）：
+
+```text
+Think carefully and step-by-step before responding; this problem is
+harder than it looks.
+```
+
+**先查證再回答**（對抗 4.7「偏 reasoning、少 tool」的傾向）：
+
+```text
+Before answering, verify your assumption by reading the relevant
+file or running a quick grep. Do not answer from memory if a quick
+check can ground your response.
+```
+
+這些可以當 library 存起來，下次開 pipeline 前挑幾段組裝。Docs 裡還有更多 task-specific 範本（agentic coding、long context extraction、slide deck generation、scientific analysis），真的要吃這代 model 紅利，建議整份讀過一次。
+
+<ClawdNote>
+Subagent 從 4.6 的「活潑小孩，要管」變成 4.7 的「摸魚員工，要催」。這個轉變在 release note 看不到，但實務 impact 很大——不改 prompt 的話，過去靠平行 subagent 拿時間的 pipeline 會全部慢下來，而且慢的方式是「表面在跑、其實沒 parallel」，debug 成本很高。以後寫 harness 要認知：平行不是預設，需要明確寫出來鞭策。Anthropic 下次 release note 可以幫忙加個 migration note 嗎 (ง •̀_•́)ง
+</ClawdNote>
+
+---
+
+## 結語
+
+Opus 4.7 最反直覺的一點是——它不是「更聰明」的 4.6，而是 [「個性變了」](/glossary#model-swap) 的 4.6。更 literal、更省 tool、更短回覆、更少 subagent、更慢熱於主動探索、連設計美學都有固定 default。這些不是 bug，是新的 defaults。Prompt 技巧要跟著 shift。
+
+所以下次遇到 output 不如預期，先別急著把 prompt 寫成咒語大全（「請仔細考慮」、「務必完整」、「請展開詳細說明」這類）。先問自己三題：**effort level 對不對？coverage 跟 filter 分開了嗎？廣義 apply 有沒有明講 scope？** 這三題比任何咒語都有效——而且比咒語好 debug 太多。
+
+Anthropic 同時釋出兩份 best practice，大概也是知道這代的 prompt 慣性需要重新訓練。兩個週末花掉、省下未來幾個月踩坑的時間，就當作看這兩份文件的 ROI。
+
+<ClawdNote>
+最後講一件 Anthropic 不會明說的事：官方 best practice 也會過期。今天學到的 snippet，等 Opus 4.8 出來可能又要改一輪。重點不是背下每個 prompt 範本當咒語，而是培養「讀 model personality」的習慣——release 出來第一件事不是找 benchmark 看分數，而是翻官方 best practice 跟 migration guide，抓這代 model 的個性跟行為差異。把 prompt 當 forever 答案的人，永遠在追版本號 ʕ•ᴥ•ʔ
+</ClawdNote>

--- a/src/data/glossary.json
+++ b/src/data/glossary.json
@@ -84,6 +84,15 @@
     "category": "methods"
   },
   {
+    "term": "Model Swap",
+    "en": "Model Swap",
+    "definition": "換 model 不是換 API key，是換同事。每組 model weight 都是一個獨立人格——分數可能更高、表達可能更清楚，但個性絕對不一樣。同樣的 prompt + context 丟進去，反應會不同：Opus 4.6 會主動探索、4.7 更 literal；Sonnet 偏 tool use、Opus 偏 reasoning；Haiku 簡短、Opus 細緻。升級 model 之後最糟的做法，是把舊 prompt 原封照搬、然後怪新 model 變笨。正確做法是讀 release note、migration guide、best practice，重新認識這位新同事的脾氣。",
+    "clawdNote": "就像公司來了新員工，不會期待他跟前任一模一樣。分數高不代表他會自動「懂你的流程」。把舊 SOP 塞給他然後抱怨「怎麼不如上一個順」——那叫沒做 onboarding，不叫新人有問題 (¬‿¬)",
+    "related": ["Claude Code", "Agent Harness"],
+    "definedIn": [],
+    "category": "concepts"
+  },
+  {
     "term": "OpenClaw",
     "en": "OpenClaw",
     "definition": "開源的 AI Agent 框架，可以把 Claude 變成 24/7 運作的個人助理，透過 Telegram、Discord 等管道互動。前身叫 Moltbot/Clawdbot。",


### PR DESCRIPTION
## Summary
- **Content**: 新 SP 濃縮 Anthropic 兩份官方 Opus 4.7 best practice（[Claude Code blog](https://claude.com/blog/best-practices-for-using-claude-opus-4-7-with-claude-code) + [完整 prompting guide](https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/claude-prompting-best-practices)）成一頁 cheat sheet。zh-tw + en 兩版同時落地
- **Glossary**: 新增 `Model Swap` 條目——換 model 不是升級，是換同事的比喻，跟 SP 主旨互為註腳
- **Infra**: `scripts/detect-model.mjs` 補 `claude-opus-4-7` / `claude-sonnet-4-6` / `claude-haiku-4-5` 對應，原本 partial match 把 4.7 誤認成 "Opus 4"
- **SOP**: 帶入 `docs(sop): zh-tw-first writing workflow` commit（先 zh-tw iterate 過分數、再翻 en），是這次 workflow 實證的產物

## 文章內容（精神）
- **三件必知大事**：tokenizer 換 / `xhigh` 新預設 / `budget_tokens` RIP 改 adaptive thinking
- **Effort 階梯選用**：low/medium/high/xhigh/max，用咖啡預磨粗細比喻 anchor
- **4.6→4.7 行為 cheat sheet**：literal / reasoning>tool / cream+serif 設計預設三個會偷襲 pipeline 的 behavior + 三個較明顯的輕度調整
- **Interactive coding 黃金比例**：Claude Code blog 精華——context 前置、minimize user turns、Auto mode Shift+Tab、notification hook
- **Code review harness 的坑**：「只報 high severity」被 literally 執行 → recall 崩盤，場景化開場（週一 report 乾淨、週二 prod 炸）
- **Prompt snippet 集錦**：subagent 控制 / over-engineering 煞車 / thinking depth / verbosity / verify-before-answer
- **結語**：Opus 4.7 不是更聰明的 4.6，是個性變了的 4.6（連到 `/glossary#model-swap`）

## Vibe Scorer（round 2 PASS）
| 維度 | Round 1 | Round 2 |
|---|---|---|
| persona | 7 | **8** |
| clawdNote | 9 | 9 |
| vibe | 7 | **8** |
| clarity | 9 | 9 |
| narrative | 7 | **8** |
| **composite** | 7 FAIL | **8 PASS** |

Round 2 rewrite 針對 round 1 建議：正文加 life metaphor（房東/咖啡機/contractor）、§4.6→4.7 打破連續 6-bullet 節奏（3 深 + 1 段淺 tail）、§Code review harness 改成場景化開場 (Monday report clean / Tuesday prod boom / off-by-one 被 skip)。

## Test plan
- [x] `node scripts/validate-posts.mjs` 兩版都過
- [x] `node scripts/check-pronoun-clarity.mjs` 兩版都過
- [x] `pnpm run build` 2818 頁全綠
- [x] Vibe scorer composite ≥ 8 AND 至少一維 ≥ 9 AND 無維 < 8
- [ ] Merge 前 swap SP-PENDING → 真號（目前 counter next = SP-175）
- [ ] Merge 後 Vercel auto-deploy 驗收 `/posts/sp-175-...` + `/glossary#model-swap`

## Notes
- **Draft PR**：ticketId 是 `SP-PENDING`，merge 前需走 swap procedure（見 CONTRIBUTING.md §並行撰寫防 ID collision）
- Pre-push 警告 `totalKB +49%` 是 SP-174 push 帶進來的 pre-existing anomaly（見 memory `project_bundle_size_anomaly.md`），非本 PR 造成
- 事實都用 WebFetch 直接 verify 過，snippet 全部從 docs 原文 copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)