### PR TITLE
fix(series): SimonW Agentic Engineering order 2/3 → 12/13（解除 vitest content drift）

### DIFF
--- a/src/content/posts/cp-169-20260315-simonw-pragmatic-summit-agentic-engineering.mdx
+++ b/src/content/posts/cp-169-20260315-simonw-pragmatic-summit-agentic-engineering.mdx
@@ -22,7 +22,7 @@ sourceUrl: "https://x.com/simonw/status/2032885170542620884"
 lang: "zh-tw"
 series:
   name: "Simon Willison's Agentic Engineering"
-  order: 2
+  order: 12
 summary: "Simon Willison 在 Pragmatic Summit 分享了他的 agentic engineering 實戰方法：五個 token 啟動 TDD、Showboat 做手動驗證、用六個框架反推出標準再實作、以及 code quality 是一個有意識的選擇。"
 tags: ["agentic-coding", "simon-willison", "simonw-agentic-patterns", "tdd", "ai-agents", "best-practices"]
 ---

--- a/src/content/posts/cp-171-20260316-simonw-what-is-agentic-engineering.mdx
+++ b/src/content/posts/cp-171-20260316-simonw-what-is-agentic-engineering.mdx
@@ -22,7 +22,7 @@ sourceUrl: "https://x.com/simonw/status/2033313520436351327"
 lang: "zh-tw"
 series:
   name: "Simon Willison's Agentic Engineering"
-  order: 3
+  order: 13
 summary: "Simon Willison 的 Agentic Engineering Patterns 指南加到第 12 章了，但這章排在系列最前面——他終於正式回答「什麼是 Agentic Engineering」。答案意外地簡潔：讓會跑 code 的 agent 幫你開發軟體。但真正有趣的是他花了 11 章實戰經驗後才敢下這個定義。"
 tags: ["agentic-coding", "simonw-agentic-patterns", "simon-willison", "ai-agents", "claude-code", "codex", "best-practices"]
 ---

--- a/tests/series-content.test.ts
+++ b/tests/series-content.test.ts
@@ -187,7 +187,7 @@ describe('Series Content Validation', () => {
     ).toBe(6);
   });
 
-  it("4d. Simon Willison's Agentic Engineering series (zh-tw) has exactly 11 articles", () => {
+  it("4d. Simon Willison's Agentic Engineering series (zh-tw) has exactly 13 articles", () => {
     const postsWithSeries = getPostsWithSeries();
     const simonPosts = postsWithSeries.filter(
       (p) =>
@@ -195,7 +195,7 @@ describe('Series Content Validation', () => {
     );
     expect(
       simonPosts.length,
-      `SimonW series should have 11 articles, found ${simonPosts.length}`,
-    ).toBe(11);
+      `SimonW series should have 13 articles, found ${simonPosts.length}`,
+    ).toBe(13);
   });
 });


### PR DESCRIPTION
## 問題

`tests/series-content.test.ts`（vitest）三個 assertion 失敗，全部指向 "Simon Willison's Agentic Engineering" series 的內容漂移：

1. **重複 order**：`cp-169` 和 `sp-72` 都是 `order: 2`；`cp-171` 和 `sp-74` 都是 `order: 3`
2. **連號跳號**：因為上面的重複，order 12/13 是缺的
3. **數量對不上**：測試寫死「恰好 11 篇」，實際 13 篇

這個檔案原本沒接進 CI（`pnpm exec vitest run` 沒跑），直到 #137（CI 優化）把 vitest 接進 `unit-tests` job 才浮出來。本身是 pre-existing content data bug，跟 #137 的 CI 改動無關。

## 調查（Explore subagent 讀了全 13 篇開頭段）

這個 series 不是有明確「先學這個、再學那個」的概念順序，而是 SimonW 自己的 **"Agentic Engineering Patterns" guide 隨時間逐步公開的 log**：
- 2026-02-03 開頭 `clawd-picks-20260203-simonw-agentic-loops`（series 種子）
- 中段是 11 章的 hands-on patterns（TDD、Linear Walkthroughs、Hoard Things、Anti-Patterns…）
- 最後 `cp-171-20260316-simonw-what-is-agentic-engineering`（他寫完 11 章 patterns 後才回來正式定義 term）

**最乾淨的 canonical order = 原文發表日期**。讀者點 prev/next nav 會照著 SimonW 當時思考的脈絡走。

## 建議順序（zh-tw）

| # | Filename | 原 order | 新 order |
|---|---|---|---|
| 1 | clawd-picks-20260203-simonw-agentic-loops | 1 | 1 |
| 2 | sp-72-20260218-simonw-cli-over-mcp | 2 | 2 |
| 3 | sp-74-20260220-simonw-beats-content-graph | 3 | 3 |
| 4 | sp-80-20260223-simonw-agentic-engineering-patterns | 4 | 4 |
| 5 | sp-86-20260225-simonw-claude-code-remote-cowork | 5 | 5 |
| 6 | sp-87-20260226-simonw-linear-walkthroughs | 6 | 6 |
| 7 | sp-88-20260227-simonw-hoard-things | 7 | 7 |
| 8 | sp-90-20260301-simonw-interactive-explanations | 8 | 8 |
| 9 | sp-137-20260329-simonwillison-vibe-coding-swiftui | 9 | 9 |
| 10 | clawd-picks-20260308-simonw-agentic-manual-testing | 10 | 10 |
| 11 | clawd-picks-20260309-simonw-agentic-anti-patterns-unreviewed-code | 11 | 11 |
| 12 | cp-169-20260315-simonw-pragmatic-summit-agentic-engineering | **2** | **12** |
| 13 | cp-171-20260316-simonw-what-is-agentic-engineering | **3** | **13** |

其他 11 篇 order 已經是對的，只是被 169/171 撞掉 2 和 3。**實際 edit 只需兩個檔案的 frontmatter**。

## 改動

- `src/content/posts/cp-169-...mdx`：`series.order 2 → 12`
- `src/content/posts/cp-171-...mdx`：`series.order 3 → 13`
- `tests/series-content.test.ts`：test 4d 的 `.toBe(11) → .toBe(13)`（test name 同步調整）

## 驗證

- [x] `pnpm exec vitest run tests/series-content.test.ts` → 7/7 pass（之前 3/7 fail）
- [x] pre-commit hook（content integrity 10/10 + validate-posts + prettier + eslint）全過
- [x] pre-push hook 全過

## Follow-up

PR #137 的 `unit-tests` job 目前用 positive list（`tests/search-relevance.test.ts tests/tribunal-v2`）繞開這個 bug。本 PR 併入 main 後，可以把 #137 改回 `pnpm exec vitest run`（跑整個 `tests/**/*.test.ts`），讓 CI 覆蓋回 `series-content.test.ts`。

## 未動的部分

- `en-cp-169` 和 `en-cp-171` 的 frontmatter 沒有 `series:` 欄位（英文版目前沒接進 series 系統），所以本 PR 不動。如果之後要讓英文版也有 series nav，會是另一個 PR 的事。
- 其他 11 篇 zh-tw / en 的 order 和 name 都沒變。

https://claude.ai/code/session_016d8ySpq8HF9KXngVNxZtSd