### PR TITLE
SP-180: Anthropic MCP production agents — API / CLI / MCP 三條路

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ gu-log 寫的就是 AI / agent / tooling 圈，這個圈子有兩個特性：
 **操作原則**：
 
 - 寫 glossary、寫文章、跟 user 對話時，AI tooling 相關事實都要 verify
-- 不確定時用 `WebFetch` 查官方 repo / docs，不要靠直覺或舊記憶
+- **⚠️ `WebFetch` 會偷偷摘要，不是原文**：WebFetch 會把 HTML 丟給一個小 model 濃縮後才回傳，**常常漏掉具體 examples、數字、邊界條件**（實測 Anthropic blog 的 `create_issue_from_thread` 例子、`Cloudflare ~2,500 endpoints in ~1K tokens`、elicitation form/URL mode 區別都被摘掉）。**SP/CP 翻譯任務、引述原文、事實查核一律用 `curl -sL -A "Mozilla/5.0..." <url>` 抓原始 HTML 再解析**；WebFetch 只適合「這頁大概在講什麼」這種粗粒度判斷。翻譯基於 WebFetch 輸出 = 基於二手摘要，必踩雷。
 - **Subagent 的事實結論要自己驗證一次**：subagent 也會用聽起來合理但錯的詞（例如把 closed source 說成 source-available）。看到關鍵 claim 就 fetch 一次原始碼或 license 確認
 - 完整時間線參考 `src/data/glossary.json` 的 Claude Code 條目
 

--- a/playbooks/CCC-playbook.md
+++ b/playbooks/CCC-playbook.md
@@ -34,8 +34,11 @@
 
 1. `git push -u origin claude/xxx`
 2. 用 GitHub MCP (`mcp__github__create_pull_request`) 開 PR 到 main
-3. **等 CI 全綠**後自己 `mcp__github__merge_pull_request`
-4. 合完跟 user 回報 PR URL + 簡短 summary
+3. **PR 開完立刻 `mcp__github__subscribe_pr_activity` 訂閱自己這條 PR**——不要問 user「要不要幫你盯」。CCC 開 PR 預設就要盯 CI + review comment，這是工作的一部分，不是 opt-in 服務。問就是 dumb question。
+4. **等 CI 全綠**後自己 `mcp__github__merge_pull_request`
+5. 合完跟 user 回報 PR URL + 簡短 summary
+
+**禁問句**：「要不要 subscribe PR activity？」「要不要盯 CI？」「要不要幫你看 review comment？」——通通是 dumb question，預設答案永遠是 yes，user 不該被叫去確認 default behavior。
 
 ### Merge method 選擇
 

--- a/playbooks/CCC-playbook.md
+++ b/playbooks/CCC-playbook.md
@@ -204,10 +204,13 @@ cat /tmp/sd20/01-frontmatter.mdx /tmp/sd20/02-intro.mdx ... \
 
 短 call → stream 不會 idle → timeout window 關不起來。代價是 tool call 變多、吃 context 多一點，但能穩定產出。
 
-**什麼時候切 split mode**（不要等 user 講第三次）：
-- **Trigger 精確化**：user 回報 `error` / `retry` / `resume` / `proceed` / `continue` / `still error`，且**上一個想做但失敗的動作是 Write/Edit/NotebookEdit**——立刻切 Workaround A（`/tmp` chunks）。不要先 retry 同一個 Write 再觀察。
-- 同一個 Write call **連兩次** stream idle timeout → 第三次直接切 split，不要硬 retry
-- 預防性切換：已知高風險形狀就直接 `/tmp` chunks 開工。已知高風險形狀：長 MDX（frontmatter + 多段 `<ClawdNote>` + 長 prose）、>200 行的文章、任何一次要寫 >150 行的內容
+**什麼時候切 split mode — 一次就要切，不要等 user 講第二次**：
+
+**硬規則（First-Error-Means-Switch）**：任何形狀像「Error」、「Error again」、「retry」、「resume」、「continue」、「still error」、「/tmp strategy」的 user 訊息出現一次，且前一個失敗動作是 Write/Edit/NotebookEdit —— **立刻、無條件切 Workaround A（`/tmp` chunks）**。不要先 retry 同一個 Write 觀察、不要問 user「要不要換方式」、不要 partial write 看看能不能塞下去。**User 講第一次就是最後一次**。如果 user 得講第二次，那是播音 bug，不是策略問題。
+
+- **預防性 trigger**（根本不用等 error）：看到自己要寫的 MDX **≥150 行** 或**含 3 個以上 ClawdNote** 或**含 frontmatter + 多段 prose + code blocks 混排**——**開寫前就直接切 `/tmp` chunks**，不要先賭一次 big Write 看運氣。
+- 反向防呆：如果已經在 `/tmp` chunks 模式還報 error，**chunks 再切小**（每檔 ≤50 行），不是切回 big Write。
+- 舊 trigger 仍然保留（保險起見）：user 回報 `error` / `retry` / `resume` / `proceed` / `continue` / `still error`，且**上一個想做但失敗的動作是 Write/Edit/NotebookEdit**——立刻切 Workaround A。
 
 **Root cause 備忘**（2026-04-21 實驗結論）：
 疑似 Opus 4.7 adaptive thinking 在長 creative generation 中有短暫 token 停頓。停頓 > stream idle threshold 就斷線。跟**生成時間分佈**有關，不是**字符內容**問題 — kaomoji / RTL Arabic / multi-script 都 isolated 測過無關。

--- a/scripts/article-counter.json
+++ b/scripts/article-counter.json
@@ -5,7 +5,7 @@
     "description": "Original articles written by ShroomDog"
   },
   "SP": {
-    "next": 180,
+    "next": 181,
     "label": "ShroomDog Picks",
     "description": "Articles picked by ShroomDog, translated by Clawd"
   },

--- a/src/content/posts/en-sp-180-20260423-anthropic-mcp-production-agents.mdx
+++ b/src/content/posts/en-sp-180-20260423-anthropic-mcp-production-agents.mdx
@@ -1,0 +1,206 @@
+---
+ticketId: "SP-180"
+title: "Why Production Agents Converge on MCP — Anthropic's Breakdown of API vs CLI vs MCP"
+originalDate: "2026-04-22"
+translatedDate: "2026-04-23"
+translatedBy:
+  model: "Opus 4.7"
+  harness: "Claude Code"
+source: "Anthropic (claude.com/blog, announced by @ClaudeDevs on X)"
+sourceUrl: "https://claude.com/blog/building-agents-that-reach-production-systems-with-mcp"
+lang: "en"
+summary: "Anthropic's guide to connecting production agents to real systems. When agents move to the cloud, API / CLI / MCP all ship — only MCP compounds. Uses Cloudflare's MCP server (2 tools, ~2,500 endpoints, ~1K tokens) as the benchmark for remote-first design, intent-grouped tools, and production auth."
+tags: ["mcp", "anthropic", "agent-engineering", "claude-cowork", "claude-code"]
+---
+
+import ClawdNote from '../../components/ClawdNote.astro';
+
+Picture a familiar scene: an agent that runs beautifully on your laptop needs to move to the cloud so your team can use it. On the laptop, it's been happily chaining `git`, grepping files, running `pytest` through a CLI — zero friction. Day one in production: **every system it needs to reach suddenly won't connect**. Calendar lives in Google. Data lives in Snowflake. Issues live in Linear. All remote, all behind auth, each with its own client. The move from "swap the VM" quietly turned into "rebuild eight integrations from scratch."
+
+That's exactly the problem Anthropic's new post tackles. The opening line:
+
+> "Agents are only as useful as the systems they can reach."
+
+**An [agent](/glossary#agent) can reason beautifully and still be useless if it can't touch calendar, Snowflake, or the inventory system hiding behind AWS.** Anthropic breaks the connection story into three common paths: **direct API calls, CLIs, and [MCP (Model Context Protocol)](/glossary#mcp)**. Each has a sweet spot, each has a ceiling. But the moment an agent leaves the laptop for the cloud — **all three paths ship together, yet only MCP compounds**.
+
+## Three paths, three ceilings
+
+The real difference between these paths isn't syntax. It's **how thick the shared layer between agents and services is, and how far that layer reaches**. Anthropic's framing: thicker layer = more clients and environments reachable, but also more upfront investment.
+
+**Direct API calls** are the shortest route. The agent writes an HTTP request inside a code-execution sandbox, or uses a generic function-calling tool, and hits your API directly. Fine for one agent talking to one service, or a few integrations that don't need to be reused. The trouble starts at scale: with no common layer between agents and services, **every agent–service pair becomes a bespoke integration** — its own auth handling, its own tool descriptions, its own edge cases. Anthropic has a name for this pathology: the **M×N integration problem**. M agents × N services = M×N pieces of custom glue, all of which you maintain forever.
+
+**Command-line interfaces (CLIs)** are fast, lightweight, and lean on tooling that already exists — perfect for local environments and sandboxed containers, anywhere there's a filesystem and a shell. CLIs do provide a shared layer, but a **thin** one. They hit a wall the moment you leave local: mobile can't reach them, web can't reach them, cloud platforms without exposed containers can't reach them. Auth is handled by the CLI's own mechanism, usually a credential file on disk. Great for quick, permissive, local-only integrations. **Not for production agents running across environments.**
+
+**Model Context Protocol (MCP)** promotes the shared layer into a protocol. The agent connects to a server that exposes your system's capabilities in a standardized way — auth, discovery, rich semantics, all in the spec. **One remote server reaches any compatible client** (Claude, ChatGPT, Cursor, VS Code, and more), regardless of deployment environment. It costs a little more upfront. In return, **the integration becomes a portable asset**, and it can support feature-rich experiences — charts, forms, dashboards — not just text.
+
+<ClawdNote>
+M×N sounds like a textbook term, but it's the very real pain teams discover halfway through scaling. Picture early American electricity: every power plant had its own voltage, its own plug shape, its own frequency. You couldn't move your toaster across town without a box of adapters. MCP is the agent world's AC 110V standardization moment — you only get a sprawling appliance ecosystem once the plugs converge.
+
+None of this means dropping API or CLI. Anthropic says it explicitly at the end: **mature integrations ship all three** — API as the foundation (MCP servers call APIs underneath anyway), CLI for local sandboxes, MCP for cloud-based agents. This article isn't "MCP kills APIs." It's "know which path is for which job." (⌐■_■)
+</ClawdNote>
+
+---
+
+## Production agents are moving to the cloud — that's MCP's home turf
+
+Why does Anthropic keep insisting production converges on MCP? The answer is **where agents are deployed**.
+
+Production agents increasingly run in the cloud — so they can scale and operate continuously. **The systems they need to reach are also in the cloud**: company data sits in Snowflake / Databricks, work tracking lives in Linear / Asana, infrastructure runs on AWS / GCP / Cloudflare. These remote, auth-gated systems are **exactly what a protocol-level shared layer is good at connecting to**.
+
+Adoption curve backs up the trend. From the Anthropic post: **MCP SDK downloads recently surpassed 300 million per month, up from 100 million at the start of the year**, with strong uptake across enterprises and popular agentic platforms. In Anthropic's own words:
+
+> Millions of people use MCP with Claude every day, and the protocol underpins much of what we've shipped recently, including Claude Cowork, Claude Managed Agents, and channels in Claude Code.
+
+Millions of people using MCP with Claude every day — and Anthropic's recent flagship products (**Claude Cowork, Claude Managed Agents, and channels in Claude Code**) all sit on top of it. MCP isn't a roadmap bullet. It's already infrastructure taking real production traffic.
+
+<ClawdNote>
+Translating the vibe of these numbers: 300M/month SDK downloads is the "well beyond demo, now part of the mainstream toolchain" signal — the slope looks like Node.js or Docker during their breakout years. Going from 100M to 300M in less than a year means either the dev ecosystem genuinely exploded, or Anthropic quietly made MCP the default path inside its own products. **Probably both.**
+
+Worth noting the business narrative tucked in here: Anthropic positions MCP as "others write servers, we write clients" — an open protocol. But it's simultaneously playing on the strongest client side (Claude.ai / Code / Cowork) AND the strongest server infrastructure side (Managed Agents vaults, CIMD auth). **Textbook platform play**: standardize the substrate, then build differentiated products on top. Anyone who lived through the W3C-era browser wars should feel the déjà vu. ╰(°▽°)╯
+</ClawdNote>
+
+---
+
+## What an MCP server "agents can actually use reliably" looks like
+
+Let a single number anchor why design decisions here matter: **Cloudflare's MCP server uses two tools and roughly 1K tokens of spec to cover about 2,500 endpoints**. Mirror the same API one-to-one into MCP tools and the tool descriptions alone eat the agent's context window. The difference isn't the API — it's **how the server is designed**.
+
+Anthropic's directory hosts **200+ MCP servers, used by millions of people every day**. Working with enterprises and developers on the protocol, they've distilled a set of patterns — not aesthetic preferences, but rules of thumb for "design the server this way and agents can actually use it reliably." This section groups those into **three design decisions**, starting with the basics.
+
+### Get the basics right: remote-first, and group tools by intent
+
+The hardest rule first: **a remote server is the only configuration that runs across web, mobile, and cloud-hosted agents**, and it's what every major client is optimized to consume. A local server can hum along beautifully on a developer's laptop, but the user's phone agent will never reach it. Only remote servers deliver real distribution.
+
+Once "remote" is decided, the next counter-intuitive call: **more tools aren't better**. Analogy: a restaurant menu says "ginger beef." The kitchen does chopping, marinating, heating the wok, adding ingredients, stir-frying, plating. The customer only wants the dish — those six steps are API, not menu. MCP tools should be the menu, not the flowchart. Anthropic gives a concrete comparison:
+
+> A single `create_issue_from_thread` tool beats `get_thread` + `parse_messages` + `create_issue` + `link_attachment`.
+
+One "create an issue from this thread" tool clobbers "fetch thread + parse messages + create issue + attach files" as four separate tools. Why: every call an agent makes burns context and reasoning budget. Splitting a one-step task into four is a tax on overhead. **Fewer, well-described tools always beat more, one-to-one API mirrors** — that's the first instinct of good MCP server design.
+
+### When the API is too large to enumerate: shrink the tool surface and let the agent write code
+
+The basics handle most services. Then you hit the exception: **some services are just too big to group by intent**. Cloudflare, AWS, Kubernetes — monsters with thousands of endpoints. Anthropic's fix is counter-intuitive: **don't enumerate harder, shrink further** — collapse the tool surface to two tools and let them accept code.
+
+Cloudflare's MCP server is the reference example of this pattern:
+
+> Cloudflare's MCP server is the reference example—two tools (search and execute) cover ~2,500 endpoints in roughly 1K tokens.
+
+The flow: the agent writes a short script, the server runs it in a [sandbox](/posts/sp-129-20260327-cloudflare-dynamic-workers) against Cloudflare's API (SP-129 walked through the sandbox optimization itself), and the result comes back. The agent's context never drowns in thousands of tool descriptions, yet semantically the full operational surface is preserved. **One pen that reaches the whole action space beats thousands of individual forms to fill out.**
+
+### Push MCP over the production line: Apps, Elicitation, Standardized OAuth
+
+Remote rolled out, tools grouped — the final three pieces (**UI, mid-flow pausing, auth**) are what turn "MCP works" into "MCP ships to production."
+
+Start with UI. Text output is the floor for MCP, but **text isn't the best shape** for many situations: dashboards want charts, data entry wants forms, long-running tasks want a progress view. Anthropic puts this capability into **MCP Apps** — the protocol's first official extension — which lets a tool return **an interactive interface rendered inline in the chat**. Anthropic's observation: **servers that ship MCP Apps tend to see meaningfully higher adoption and retention than text-only servers**. The extension is supported in Claude.ai, [Claude Cowork](/glossary#cowork), and many other top AI tools.
+
+Next comes **Elicitation** — the feature most easily overlooked in the original post, but genuinely important in practice. Plain-talk: **a tool call can pause mid-flight, ask the user something, and resume**. Two modes:
+
+- **Form mode**: the server sends a schema, the client renders a native form. Use it to collect a missing parameter, confirm a destructive action, or let the user pick from options.
+- **URL mode**: hand the user off to a browser. Use it for downstream OAuth, payments, or any sensitive credential that shouldn't pass through the MCP client.
+
+Both modes share one value: **keep the user in the current workflow** instead of kicking them off to a settings page and making them come back. The post spells out compatibility: **form mode is broadly supported; URL mode is live in [Claude Code](/glossary#claude-code), with more clients in progress.**
+
+Last: **standardized OAuth**, which matters a lot for cloud agents. Concrete scenario — the agent needs to act on the user's behalf, which means holding a GitHub token or a Snowflake key — but those credentials mustn't flow through the LLM or get hardcoded anywhere. The latest MCP spec supports **CIMD (Client ID Metadata Documents)** for client registration: first-time auth flows fast, and surprise re-auth prompts drop sharply. This is Anthropic's recommended auth approach; MCP SDKs, Claude.ai, and Claude Code already support it, with the rest of the industry catching up.
+
+Auth handled, next question: **how does a cloud-hosted agent hold and reuse those tokens?** Anthropic's answer is in-house — **Vaults in [Claude Managed Agents](/posts/sp-167-20260409-claude-managed-agents)**: register the user's OAuth tokens once, reference the vault by ID when a session spins up, and the platform injects the right credentials into each MCP connection and refreshes them automatically. For server developers this means: **no secret store to build, no tokens to ferry around**. [SP-167](/posts/sp-167-20260409-claude-managed-agents) unpacks the Managed Agents product itself — won't repeat it here.
+
+<ClawdNote>
+This trio (MCP Apps + Elicitation + CIMD/Vaults) is what nudges MCP from "works" to "ships safely in the cloud." Vaults + CIMD basically formalize the reality that **"auth is mandatory for production and has nothing to do with agent logic"** — app developers shouldn't have to build a token vault from scratch. Plenty of agent side projects never make it out of prototype precisely because they got stuck on these "not hard but tedious" auth plumbing problems.
+
+Elicitation is the sneakier-but-important one. Traditional agents confronted with a missing piece of info go two ways: **hallucinate it (bad)** or **summarize and tell the user to go somewhere else to fill it in (bad UX)**. Form mode opens a third path: **pause the tool call gracefully, ask in place, resume.** Web apps had this UX primitive for two decades (modal dialogs), but the agent world didn't formalize it until this MCP spec. Later than you'd expect. ┐(￣ヘ￣)┌
+</ClawdNote>
+
+---
+
+## Context-efficient clients: two hard numbers — 85% and 37%
+
+Everything above was about the server side. Flip to the client side (the agent itself). MCP standardizes how agents connect to and use the tools and data that servers expose — **the server safely exposes capabilities, the client orchestrates them and manages context**.
+
+So priority one for MCP client design: **spend context cheaply**. Anthropic lists two progressive-disclosure moves, each with measured impact.
+
+### Tool search: load tool definitions only when needed
+
+Real situation: once MCP servers proliferate, an agent might be connected to **dozens of servers, hundreds of tools**. Stuffing every tool definition into the context window up front is a huge bill — most go unused, yet occupy reasoning budget.
+
+**How tool search works**: don't load all tools at start. Agent searches the catalog at runtime, pulls in the relevant tools when it needs them. Note the language Anthropic uses:
+
+> tool search tends to cut tool-definition tokens by 85%+ while maintaining high selection accuracy.
+
+The operative word is "tends to" — **tool search typically cuts tool-definition tokens by 85%+**, while preserving selection accuracy. Not a guarantee; a common observation. The practical impact: an agent connected to 8 servers, where tool spec would have occupied most of the context and squeezed out actual reasoning, suddenly has enough headroom. A workflow that used to run out of context by step 5 can now reach step 15 or beyond — **the difference isn't a few percent of efficiency, it's whether the agent finishes a real task at all**.
+
+### Programmatic tool calling: process tool results in a code sandbox
+
+The second move: **process tool results inside a code-execution sandbox**, rather than returning raw output straight to the model. The agent loops, filters, and aggregates in code — **only the final computed result reaches context**. Anthropic's number:
+
+> this reduces token usage by roughly 37% on complex multi-step workflows.
+
+**Token usage drops by roughly 37% on complex multi-step workflows.** This stacks naturally with tool search across multiple servers: leaner context, fewer round-trips, faster responses. For the full breakdown the post points to their advanced tool use piece.
+
+<ClawdNote>
+Think of 85% and 37% as two different filters. Tool search guards the entrance — **"don't let irrelevant tools into context."** Programmatic tool calling guards the exit — **"wring the raw data tools spit out into conclusions before it hits the model."** One blocks noise, the other drains water. Stacked, they're compounding — not an A/B test to pick between.
+
+One blind spot worth flagging: Claude / ChatGPT / Cursor are all shipping context windows in the hundreds of thousands of tokens, so it feels spacious. That's where agent engineers get ambushed. **"Context looks big enough" ≠ "context actually is big enough"** — tool specs, system prompts, and prior turns eat more of the front of the window than people expect. Save context where possible, not to shave cost, but to give reasoning room to breathe. ٩(◕‿◕｡)۶
+</ClawdNote>
+
+---
+
+## Skills × MCP: ingredients vs. recipe, only both make a dish
+
+The later half of the post pivots to **pairing skills with MCP**. Skills as a concept got unpacked recently in [SP-179 on Garry Tan's skillify workflow](/posts/sp-179-20260422-garrytan-skillify-agent-failures) — the pattern of crystallizing an agent's failure experience into a `SKILL.md` + a deterministic script. Skills and MCP complement each other in an agent system, not compete:
+
+- **MCP gives the agent "raw capability"** — reaching tools and data in external systems
+- **Skills give the agent "procedural knowledge"** — how to use those tools to actually finish real work
+
+Ingredient / recipe analogy: **MCP is the stuff in the fridge (beef, scallions, ginger, soy sauce); skills are the recipe for "ginger beef"**. All the ingredients and no recipe means the agent just stares into the fridge; all recipe and no ingredients means drooling at a cookbook. The most capable agents have both — and skills are also what let MCP servers scale past "a handful of connections."
+
+Anthropic offers two patterns for pairing skills with MCP.
+
+### Pattern 1: bundle skills + MCP servers as a plugin
+
+**Plugins for Claude** are the abstraction Anthropic proposes here — **skills, MCP servers, hooks, LSP servers, and specialized subagents packaged into a single distribution unit**. This is the cleanest way to unify multiple context providers with minimal friction. MCP servers hand agents tools; skills teach Claude how to string them into end-to-end workflows; together the agent behaves more like a domain specialist.
+
+Anthropic gives a direct example:
+
+> See our data plugin for Cowork as an example, which consists of 10 skills and 8 MCP servers for apps like Snowflake, Databricks, BigQuery, Hex and more.
+
+**The data plugin for Cowork: 10 skills + 8 MCP servers**, covering a full data stack of Snowflake, Databricks, BigQuery, Hex, and more. Not hypothetical architecture — already a real composition shipping in Anthropic's own product.
+
+### Pattern 2: distribute skills directly from MCP servers
+
+Another shape gaining ground: providers publishing skills alongside their MCP server, so the agent gets both **the raw capability (tools) + opinionated playbook for using them (skill)** in one shot. The post names **Canva, Notion, Sentry** as examples doing this on Claude today — their web directory lists skills next to the matching connector.
+
+To make the pairing portable across every client, the MCP community is actively working on **an extension that delivers skills directly from servers**. Once stable, clients will automatically inherit the expertise, **versioned together with the API it depends on** — change the API, update the skill, no drift. Anthropic expects this pattern to see broad adoption as the extension matures.
+
+<ClawdNote>
+"Provider ships a skill" reads like a nice-to-have, but it may be the quietest, most important evolution in the MCP ecosystem. Imagine connecting to a new MCP server today and receiving not just the tool list, but also "how to compose these tools, common failure modes, and this API's quirks" — **like an employer handing a new hire both the toolkit AND the company's internal SOP binder.**
+
+If this shape matures, agent engineers' job shifts from "reverse-engineer every third-party API's personality" to "read the provider's playbook." SDK versioning already has release notes; skill versioning can follow. From the provider's side, this is a new DX investment point. Short term, expect a platform competition in which "whose skill is written well gets the agent traffic" — a dynamic reminiscent of early App Store review / ASO. (⌐■_■)
+</ClawdNote>
+
+---
+
+## Conclusion: ship all three, but only MCP compounds
+
+The closing line of the post tightens the whole argument into a clean image:
+
+> In practice, mature integrations will ship all three: the API as the foundation, a CLI for local-first environments, and MCP for cloud-based agents.
+
+Mature integrations **ship all three paths** — API as the foundation (MCP servers call APIs underneath anyway), CLI for local-first environments, MCP for cloud-based agents. It's not an either/or.
+
+But Anthropic highlights the key difference: **the moment production agents move to the cloud, MCP goes from "also works" to "critical layer"**. And — this is the point — **it's the only one that compounds**.
+
+The logic is direct: a remote server you ship today **automatically reaches every compatible client, running in any deployment environment**, with auth, interactivity, and rich semantics handled by the protocol. **As the protocol grows and more extensions land, the same server gets more capable without you shipping anything new.** That "gets stronger while you sleep" compounding doesn't happen with API or CLI.
+
+> Every integration built on MCP strengthens the ecosystem: fewer edge cases to solve alone, fewer bespoke integrations to maintain.
+
+Every integration built on MCP strengthens the ecosystem — **fewer edge cases to solve alone, fewer bespoke integrations to maintain**. This is the classic standards argument: collapse scattered complexity into one shared substrate so later builders don't have to repeat the same painful trek.
+
+For teams planning their agent integration roadmap, the guidance is blunt: **if your goal is production agents reaching your systems from the cloud, build an MCP server — and use the four patterns above to build it well**.
+
+<ClawdNote>
+Whole-article takeaway in one boil-down: **API / CLI / MCP isn't a tech choice, it's a function of where the agent lives**. Agent on a laptop in a sandbox? CLI is smoothest. One agent talking to one service? Direct API is fine. Agent running in the cloud, reaching across other people's cloud services, and needing to work across clients? **That's MCP's home turf.**
+
+As an Anthropic position paper, this piece is unusually honest — it doesn't pretend MCP is a silver bullet, and it doesn't pretend API or CLI are obsolete. The real argument isn't "choose MCP." It's "figure out where your agent will run, what it needs to reach, and whether it needs to work across clients." Answer those three and the path picks itself.
+
+Most practical takeaway for gu-log readers: **if you're building a side-project agent that talks to 2–3 services and runs only for you, direct API calls are enough**. The day it has to go live, serve multiple clients, or integrate with other people's tools — that's when you re-evaluate going MCP. **Don't strap on MCP during MVP** — premature optimization is never about the tool being bad, it's about picking the wrong moment. ʕ•ᴥ•ʔ
+</ClawdNote>

--- a/src/content/posts/sp-180-20260423-anthropic-mcp-production-agents.mdx
+++ b/src/content/posts/sp-180-20260423-anthropic-mcp-production-agents.mdx
@@ -1,0 +1,244 @@
+---
+ticketId: "SP-180"
+title: "Agent 要上 production，為什麼最後都走 MCP——Anthropic 把 API / CLI / MCP 三條路一次講透"
+originalDate: "2026-04-22"
+translatedDate: "2026-04-23"
+translatedBy:
+  model: "Opus 4.7"
+  harness: "Claude Code"
+source: "Anthropic (claude.com/blog, announced by @ClaudeDevs on X)"
+sourceUrl: "https://claude.com/blog/building-agents-that-reach-production-systems-with-mcp"
+lang: "zh-tw"
+summary: "Anthropic 剛丟出一份 production agent 的連線路指南：agent 上雲那天，API / CLI / MCP 三條路都會 ship，但只有 MCP 是會複利的那條。文章以 Cloudflare 的 MCP server（兩個 tool 包 2,500 個 endpoint）當設計 benchmark，帶出 remote 優先、tool 以 intent 分組、大 API 走 code orchestration、Elicitation + CIMD 把 production auth 收斂的整套心法。"
+tags: ["mcp", "anthropic", "agent-engineering", "claude-cowork", "claude-code"]
+scores:
+  tribunalVersion: 2
+  vibe:
+    persona: 9
+    clawdNote: 9
+    vibe: 9
+    clarity: 9
+    narrative: 8
+    score: 8
+    date: "2026-04-23"
+    model: "claude-opus-4-7"
+  factCheck:
+    accuracy: 9
+    fidelity: 8
+    consistency: 9
+    score: 8
+    date: "2026-04-23"
+    model: "claude-opus-4-7"
+  librarian:
+    glossary: 9
+    crossRef: 9
+    sourceAlign: 10
+    attribution: 9
+    score: 9
+    date: "2026-04-23"
+    model: "claude-sonnet-4-6"
+  freshEyes:
+    readability: 8
+    firstImpression: 8
+    score: 8
+    date: "2026-04-23"
+    model: "claude-haiku-4-5"
+---
+
+import ClawdNote from '../../components/ClawdNote.astro';
+
+設想一個很常見的場景：一個在 laptop 上養得好好的 [agent](/glossary#agent) 要搬上 cloud 給 team 一起用。本來在 terminal 裡 CLI 串 git、grep 檔案、跑 pytest 都順得要命；搬上線第一天就發現——**凡是需要搆到的東西突然全部連不到**。Calendar 在 Google、資料在 Snowflake、issue 在 Linear，每個都 remote、都躲在 auth 後面、都要一套自己的 client。搬家從「換台 VM」變成「把八個整合重蓋一次」。
+
+Anthropic 這篇新文第一句就把整個命題壓成一行：
+
+> "Agents are only as useful as the systems they can reach."
+
+**agent 再聰明，搆不到它該搆的系統，就是廢物。** 再漂亮的 reasoning trace、再炫的 evals，打不進 calendar、打不進 Snowflake、打不進那台跑在 AWS 背後的 inventory 系統，對 production 來說就是零。Anthropic 把連線外部世界這件事拆成三條常見路：**直接 call API、call CLI、走 [MCP（Model Context Protocol）](/glossary#mcp)**。每一條各有甜蜜區、各有天花板，但一旦 agent 搬離 laptop 上 cloud——**三條路最後都會 ship，可是只有 MCP 是會複利的那條**。
+
+## 三條路的甜蜜區跟天花板
+
+三條路真正的差別不是「語法不一樣」，而是**「agent 跟外部服務之間那層共通介面，到底鋪多厚、鋪到哪裡」**。Anthropic 的框架：鋪愈厚、能到的 client 跟環境愈多，但前期投資也愈大。
+
+**Direct API call** 是最短路——agent 在 code-execution sandbox 裡寫 HTTP request，或透過泛用的 function-calling tool 直接打 API。一個 agent 對一個 service、或少數幾個不需要跨平台 reuse 的整合，這條就夠用，團隊大多也從這裡起步。真正的麻煩要到 scale 才爆出來：**agent 跟 service 之間沒有共通層，每配一對就是一次 bespoke 整合**——自己處理 auth、自己寫 tool description、自己 handle edge case。Anthropic 給這個現象一個正式名字：**M×N integration problem**。M 個 agent × N 個 service = M×N 套客製膠水。
+
+**Command-line interface (CLI)** 快、輕、吃現成的 tooling，對本地環境跟 sandboxed container 是天選之子——只要有 filesystem 跟 shell 就開工。這條路確實鋪了一層共通介面，但**薄**。一出本地就撞牆：mobile 打不到、web 打不到、cloud 上那些沒 expose container 的平台打不到；auth 也只能靠 CLI 自己那套，通常是一個躺在 disk 上的 credential 檔。這條路適合本地、quick、permissive 的整合，**不是給 production 跨雲 agent 用的**。
+
+**Model Context Protocol (MCP)** 把共通層升格成 protocol。agent 連到一個 server，server 把系統能力以標準化方式 expose——auth、discovery、rich semantics 全部在協定裡定義好。**一個 remote server，任何相容 client 都能用**（Claude、ChatGPT、Cursor、VS Code，還有更多），不管 client 跑在哪種 deployment environment。代價是前期投資稍大一點；回報是**整合本身變成便攜的資產**，而且能支撐 feature-rich 的 agent 整合——元件可以傳 chart、form、dashboard 這種有 UI 語義的東西，不只文字。
+
+<ClawdNote>
+M×N 這個詞看起來像 textbook 用語，但它其實是很多 team 痛苦 scale 到一半才自己發現的現實。想像成早期美國電力——每個發電廠用自己的電壓、自己的插頭、自己的頻率，電器要跨城市用就得自備一箱變壓器。MCP 就是 agent 世界的 AC 110V 標準化，把插頭統一了之後，才長得出遍地開花的電器生態。
+
+也不是說 API / CLI 就該丟掉。Anthropic 自己文末就講：**mature 整合最後三條都 ship**——API 當地基（反正 MCP server 底下也得打 API）、CLI 給本地 sandbox 用、MCP 給上雲的 agent 用。這篇不是在推 MCP 滅 API，是在講**三條路各自的定位、什麼時候該把精力投去哪條**。(⌐■_■)
+</ClawdNote>
+
+---
+
+## Production agent 正在搬去 cloud——這件事才是 MCP 的主場
+
+為什麼 Anthropic 這麼堅持 production 會收斂到 MCP？答案在**部署地點**。
+
+Production agent 愈來愈多跑在 cloud 上——才能 scale、才能 continuously 運行。**它們要搆到的系統也大多在 cloud 上**：公司資料住在 Snowflake / Databricks、工作追蹤在 Linear / Asana、基礎設施在 AWS / GCP / Cloudflare。這些 remote、躲在 auth 後面的系統，**正好就是 MCP 這層共通協定擅長接的東西**。
+
+採用曲線也印證這個趨勢。Anthropic 原文給的數字：**MCP SDK 下載量最近突破每月 3 億，從年初的每月 1 億 一路衝上來**。企業跟熱門 agentic 平台都在大量採用。Anthropic 自己的講法：
+
+> Millions of people use MCP with Claude every day, and the protocol underpins much of what we've shipped recently, including Claude Cowork, Claude Managed Agents, and channels in Claude Code.
+
+每天有上百萬人在 Claude 上用 MCP，而且 Anthropic 最近端出的幾樣招牌菜——**Claude Cowork、Claude Managed Agents、Claude Code 的 channels**——底下都是 MCP 在撐。protocol 不是 roadmap 上的一行字，是已經在 prod 吃流量的基礎設施。
+
+<ClawdNote>
+要把這組數字的 vibe 翻譯給台灣讀者聽：3 億/月的 SDK 下載是一個「遠超 demo、進入主流工具鏈」的 signal，類似 Node.js 或 Docker 在爬升期那種斜率。從 1 億衝到 3 億只花了不到一年，這個成長曲線要嘛是 dev 生態真的爆開、要嘛是 Anthropic 自家產品把 MCP 塞進 default path 推起來——**很可能兩者都有**。
+
+另外這段藏了一個 business narrative 值得拉出來講：Anthropic 把 MCP 定位成「別人寫 server 我們寫 client」的開放協定，但同時它自己也在最猛的 client 側（Claude.ai / Code / Cowork）跟最猛的 server infrastructure（Managed Agents 的 vault、CIMD auth）兩邊同時出牌。**這是教科書級的 platform play**：標準化底層當公共財，然後在標準化之上做差異化產品。熟悉 w3c 時代 browser wars 的人應該有既視感 ╰(°▽°)╯
+</ClawdNote>
+
+---
+
+## 怎樣的 MCP server，agent 才真的接得穩
+
+先丟一個數字讓設計決策的重量感出來：**Cloudflare 的 MCP server 用兩個 tool、大約 1K token 的 spec，就搆到了約 2,500 個 endpoint**。同樣的 API surface 按 endpoint 一比一鏡射成 tool，光 tool description 就能把 agent 的 context window 吃光。差別不在 API 本身，在 **server 怎麼設計**。
+
+Anthropic 自己的 directory 掛著 **200+ 個 MCP server、每天被幾百萬人用**。跟企業跟開發者合作下來，他們歸納出一套經驗法則——不是美學偏好，是「server 設成這樣，agent 才真的接得穩」。這節把這些心法用**三組決策**講完，從基本盤開始。
+
+### 先做對基本盤：remote 優先、tool 以 intent 分組
+
+最硬的一條：**remote server 是唯一一種跑得到 web、mobile、cloud-hosted agent 的配置**，也是每個主流 client 都優化好要消化的形狀。本地 server 在工程師的 laptop 上跑得再漂亮，使用者手機上那個 agent 也連不到。整合的 distribution 只有這條路鋪得最遠。
+
+擺定 remote 之後，下一個反直覺決定：**tool 數量不是愈多愈好**。做菜的比喻：餐廳菜單寫「蔥爆牛肉」，廚房裡卻是切菜、醃肉、熱鍋、下料、翻炒、起鍋——客人只要那盤菜，中間那六步是 API，不是菜單。MCP 的 tool 應該是菜單、不是流程圖。Anthropic 給了一個非常具體的對照：
+
+> A single `create_issue_from_thread` tool beats `get_thread` + `parse_messages` + `create_issue` + `link_attachment`.
+
+一個「從 thread 開 issue」的 tool，屌打「抓 thread + 解析訊息 + 開 issue + 掛附件」四個分開的 tool。理由簡單：agent 每呼叫一次都消耗 context 跟 reasoning budget，能一步做完的事硬切四步，就是在繳無謂的 overhead 稅。**少、但描述清楚**的 tool 永遠打贏**多、把 API 一比一鏡射**的 tool——這是 MCP server 設計的第一條直覺。
+
+### 當 API 大到列不完：讓 tool surface 收到兩個，放 agent 寫 code
+
+基本盤講完，馬上會撞到一個例外：**如果服務天生就有幾千個 endpoint，按 intent 分組也分不完**。Cloudflare、AWS、Kubernetes 就是這種怪獸。Anthropic 的解法反直覺——**不是列得更細、是收得更瘦**，把 tool surface 收到只剩兩個，讓它吃 code。
+
+Cloudflare 的 MCP server 就是這個 pattern 的 reference example：
+
+> Cloudflare's MCP server is the reference example—two tools (search and execute) cover ~2,500 endpoints in roughly 1K tokens.
+
+流程是這樣：agent 寫一小段 script、server 接過去在 [sandbox](/posts/sp-129-20260327-cloudflare-dynamic-workers) 跑、結果丟回來（Cloudflare Dynamic Workers 那篇 SP-129 剛好拆過這個 sandbox 本身的優化）。agent 的 context 不會被幾千個 tool description 淹沒，語義層面又保留完整的操作空間——**用一支筆通往整個動作空間，比用幾千張表格好用太多**。
+
+<ClawdNote>
+Cloudflare 這招本質上是把**「列舉全部動作」換成「給 agent 一支通往動作空間的筆」**——寫 code 比列 tool 表達力高太多了，一個迴圈、一個 filter、一個 grep，抵過上百個分開的 endpoint call。
+
+這個 pattern 最早在 coding agent 圈被反覆驗證（Claude Code、Cursor 那套 tool use），Cloudflare 把它搬到 infra control plane 來，是**把「code-as-interface」從 IDE 外推到整個 API 生態**的一次漂亮示範。想清楚就會發現：真正適合塞進 latent space 思考的東西是「要達成什麼目標」，真正該交給 deterministic 執行的是「該跑哪串 API 序列」——code orchestration 剛好把兩邊切得很乾淨 (๑•̀ㅂ•́)و✧
+</ClawdNote>
+
+### 把 MCP 推過 production 門檻：Apps、Elicitation、Standardized OAuth
+
+remote 鋪好了、tool 收好了，剩下的三件事——**UI、中斷對話、認證**——是把 MCP 從「能跑」推進到「能上 production」的那段路。
+
+先講 UI。文字回傳是 MCP 的底線，但很多場景**文字根本不是最佳形狀**：看 KPI 該給 chart、填表該給 form、長時間任務該給 dashboard。Anthropic 把這層能力放進 **MCP Apps** 這個擴充——protocol 的第一個官方 extension——讓 tool 能回傳**可互動的介面，在 chat 裡直接渲染**。Anthropic 的觀察：**ship MCP Apps 的 server，採用率跟留存通常會明顯高於只回純文字的 server**。這個擴充目前在 Claude.ai、[Claude Cowork](/glossary#cowork)、還有其他多數主流 AI 工具上都支援。
+
+接著是 **Elicitation**——最容易被讀者忽略、但真的落地很重要的一個功能。講白了就是**tool call 中途可以暫停、問 user、再繼續**。兩種模式：
+
+- **Form mode**：server 丟一份 schema，client 渲染原生 form。適合補一個缺的參數、確認一個會破壞性操作、讓 user 從多個選項裡選一個。
+- **URL mode**：把 user 導到瀏覽器。適合跑 downstream OAuth、收款、拿任何**不該流經 MCP client** 的敏感憑證。
+
+兩種模式的共同價值：**讓 user 留在當前的 workflow 裡**，不必被踢去 settings 分頁、再回來接上剛剛做到一半的事。原文特別交代相容性：**form mode 廣泛支援；URL mode 在 [Claude Code](/glossary#claude-code) 已上線，其他 client 還在陸續接**。
+
+最後是**標準化 OAuth**，對雲上 agent 特別關鍵。場景很具體：agent 要幫 user 跑任務、得拿著 GitHub token 或 Snowflake 密鑰——但那些憑證不能流進 LLM、也不能寫死在 code 裡。最新 MCP spec 支援 **CIMD (Client ID Metadata Documents)** 做 client 註冊，新 user 第一次 auth 很快過、之後 surprise re-auth 大幅減少。這是 Anthropic 推薦的 auth 方式，MCP SDK、Claude.ai、Claude Code 都已支援，全業界也在陸續跟上。
+
+授權完事下一個難題是：**雲上的 agent 要怎麼 hold 跟 reuse 這些 token？** Anthropic 有一個自家的解——[Claude Managed Agents](/posts/sp-167-20260409-claude-managed-agents) 裡的 **Vaults**：user 的 OAuth token 登記一次、session 建立時靠 vault ID 帶進來、平台自動把對的 credential 注入每個 MCP connection、自動 refresh。對 server 開發者的意義：**不用自己蓋 secret store、不用自己搬 token**。[SP-167](/posts/sp-167-20260409-claude-managed-agents) 拆過這套 Managed Agents 的產品本體，這裡不重複。
+
+<ClawdNote>
+這組設計把 MCP 從「能動」推進到「能在雲上安全運作」的區段。Vault + CIMD 本質上是把**「auth 是生產環境的必修課、但跟 agent 邏輯沒關係」** 這個現實正式承認下來，讓 app 開發者不用自己造 token 倉庫。之前不少 agent side project 之所以爛在 prototype、上不了 prod，就是卡在這類「不難但很煩」的認證基建。
+
+Elicitation 那招更有意思。傳統 agent 遇到缺資訊的狀況通常兩條路——**亂猜一個（幻覺）、或者 summary 給 user 叫他去別的介面填**（體驗斷裂）。Form mode 開出第三條：**tool call 中途優雅地暫停、就地問一下、繼續跑**。這個 UX primitive 在 web app 圈早就是標配（modal 彈窗），但在 agent 圈直到 MCP 這個 spec 才被正式成制度。補得比想像中還晚 ┐(￣ヘ￣)┌
+</ClawdNote>
+
+---
+
+## Context-efficient client：85% 跟 37% 兩個硬數字
+
+上面都在講 server 側——換到 client 側（也就是 agent 自己那邊）。MCP 標準化了 agent 怎麼 connect 跟使用 server 提供的 tool 跟 data，**server 負責安全地把能力 expose 出來，client 負責 orchestrate 這些能力、管 context**。
+
+所以設計 MCP client 的第一要務之一：**把 context 用得省**。Anthropic 列了兩招 progressive disclosure，各自附上實測效果。
+
+### Tool search：需要才載入 tool definition
+
+一個現實：MCP server 普及之後，agent 連到的可能是**幾十個 server、幾百個 tool**。把全部 tool definition 一次塞進 context window 是一筆大帳——大部分用不到、還佔著 reasoning budget。
+
+**Tool search 的做法**：一開始不載全部 tool，agent runtime 需要哪個主題的工具再搜尋 catalog、拉進來用。Anthropic 的實測語氣：
+
+> tool search tends to cut tool-definition tokens by 85%+ while maintaining high selection accuracy.
+
+注意原文用的是 "tends to"——**通常能把 tool-definition token 砍 85%+**，並維持選擇準確度。這不是保證值、是常態觀察。落地的感受是什麼？原本 agent 連到 8 個 server，tool spec 塞滿 context 前段、正經 reasoning 空間被擠掉一半；換上 tool search 之後，多出來的 context 足以讓本來只撐得了 5 步的工作流程撐到 15 步以上——**差別不是優化幾個百分點，是跑不跑得完一個真實任務**。
+
+### Programmatic tool calling：tool 結果在 code sandbox 處理
+
+第二招是**把 tool 結果丟進 code execution sandbox 處理**，不是把 raw response 原封不動塞回 model。agent 可以在 code 裡 loop、filter、aggregate，**只有最後算完的結果進 context**。Anthropic 的數字：
+
+> this reduces token usage by roughly 37% on complex multi-step workflows.
+
+**複雜多步 workflow 的 token 用量減少約 37%**。這招跟 tool search 可以疊加——多個 server 之間也能自然配合——**更精簡的 context、更少的 round-trip、更快的回應**。想知道完整拆解，原文指到他們另一篇 advanced tool use 的文章。
+
+<ClawdNote>
+把 85% 跟 37% 想像成兩道不同的過濾器。Tool search 在入口把**「不相關的 tool 不讓進來」**；programmatic tool calling 在出口把**「tool 吐出來的大量 raw data 先在 sandbox 揉成結論」**。前者擋雜訊、後者擠水分。兩招疊起來才是複利效果，不是二選一的 AB test。
+
+另外值得一提的是：Claude / ChatGPT / Cursor 這批 client 的 context 都已經在幾十萬 token 等級了，看起來很寬裕——但這是 agent engineer 最常踩的盲區。**Context 看起來夠用 ≠ 真的夠用**，因為前段被 tool spec + system prompt + 過去幾輪對話吃掉的比想像中多。該省的地方要省，不是為了省 token 費用，是為了讓 reasoning 還有空間呼吸 ٩(◕‿◕｡)۶
+</ClawdNote>
+
+---
+
+## Skill × MCP：原料 vs 菜單，合起來才是一道菜
+
+Anthropic 文章後半把話題轉到 **skill 跟 MCP 的配對**。Skill 這個概念前陣子 [SP-179 的 Garry Tan skillify](/posts/sp-179-20260422-garrytan-skillify-agent-failures) 那篇拆過——把 agent 的失敗經驗結晶成 `SKILL.md` + deterministic 腳本的那個 pattern。skill 跟 MCP 在 agent 系統裡互補，不衝突：
+
+- **MCP 給 agent「raw capability」**——接觸外部系統的 tool 跟 data
+- **Skill 給 agent「procedural knowledge」**——怎麼用這些 tool 把一件實際工作做完
+
+用食材 / 菜單的比喻：**MCP 是冰箱裡的食材（牛肉、蔥、薑、醬油），skill 是菜單上那道「蔥爆牛肉」的做法**。食材再全，沒有做法，agent 就是站在冰箱前發呆；做法再精，沒有食材，只能看著食譜流口水。最能幹的 agent 兩者都要——而且 skill 本身也讓 MCP server 能 scale 到「不只幾個 connection」的規模。
+
+Anthropic 給了兩個把 skill 跟 MCP 配在一起的 pattern。
+
+### Pattern 1：用 Plugin 把 skill + MCP server 打包成一份
+
+**Plugins for Claude** 是他們提出的抽象層——**skill、MCP server、hook、LSP server、專用 subagent 全部打包在一個 distribution 單位裡**。這是把多個 context provider 無縫統一的最乾淨方法。MCP server 給 tool，skill 教 Claude 怎麼串成 end-to-end 的 workflow，組合起來 agent 就像一個領域專家。
+
+原文直接舉例：
+
+> See our data plugin for Cowork as an example, which consists of 10 skills and 8 MCP servers for apps like Snowflake, Databricks, BigQuery, Hex and more.
+
+**Cowork 的 data plugin：10 個 skill + 8 個 MCP server**，覆蓋 Snowflake、Databricks、BigQuery、Hex 等一整套資料棧。不是空想 architecture，已經是 Anthropic 自家產品上的真實組合。
+
+### Pattern 2：Server 直接附 skill 發布
+
+另一種愈來愈常見的形狀：provider 在 publish MCP server 時順手附上 skill，讓 agent 一次拿到**原料（tool）+ 使用指南（opinionated playbook）**。文章點名 **Canva、Notion、Sentry** 等已經在 Claude 上這樣做——web directory 上 skill 跟對應的 connector 並列。
+
+為了讓這個配對跨 client 便攜，MCP 社群正在做一個**從 server 端直接遞送 skill 的 extension**。成形之後，client 會自動繼承 server 那份「使用 API 的專業經驗」，而且**跟 API 一起版本化**——API 改版 skill 也跟著換，不會漂。Anthropic 預期這個 pattern 會隨 extension 穩定而大範圍被採用。
+
+<ClawdNote>
+「provider 附一份 skill」這件事讀起來像 nice-to-have，但它可能是 MCP 生態最低調、卻最重要的演化。想像一下：今天連到一個新的 MCP server，agent 除了拿到 tool list，還拿到「這些 tool 該怎麼組合、常見錯誤是什麼、這家 API 有哪些 gotcha」——**等於雇主一邊把工具箱交給新來的員工，一邊把公司內部的 SOP 手冊一起發下去**。
+
+這個形狀如果成熟起來，agent engineer 手上的工作就從「自己摸索每個 third-party API 的脾氣」變成「讀一份 provider 寫好的 playbook」。SDK 改版有 release notes，skill 改版也能跟著 release notes——從 provider 的角度，這也是一個新的 DX 投資點。短期看可能會有一波「誰的 skill 寫得好誰就吃到 agent 流量」的 platform 競爭，跟當年 App Store 審核 / ASO 的動態有點像 (⌐■_■)
+</ClawdNote>
+
+---
+
+## 結語：三條路一起 ship，但只有 MCP 會複利
+
+文章的收束句把整個論點收緊到一個很乾淨的畫面：
+
+> In practice, mature integrations will ship all three: the API as the foundation, a CLI for local-first environments, and MCP for cloud-based agents.
+
+成熟的整合**三條路都會 ship**——API 當地基（底層怎麼做都要打 API）、CLI 給 local-first 環境、MCP 給雲端 agent。這不是單選題、不是互斥選擇。
+
+但 Anthropic 把關鍵差異點出來：**當 production agent 搬到雲上那一刻，MCP 就從「也可以有」變成「critical layer」**。而且——這才是重點——**它是唯一會複利的那一條**。
+
+原文的邏輯很直白：今天寫好一個 remote server，它**自動能被所有相容 client 吃、在任何 deployment 環境跑**，auth、interactivity、rich semantics 全由協定處理。**協定持續長、extension 持續進來，同一個 server 不用 ship 新東西就變得更強大**。這個「不動手也會變強」的複利效應，是 API / CLI 走不到的。
+
+> Every integration built on MCP strengthens the ecosystem: fewer edge cases to solve alone, fewer bespoke integrations to maintain.
+
+每一個建在 MCP 上的整合都在強化生態——**需要獨自解決的 edge case 變少、需要獨自維護的客製整合變少**。這是典型的 standards 論點：把本來分散吸收的 complexity 收斂到一個共同基礎設施，讓後來的人不用重蹈覆轍。
+
+對正在決定 agent 整合 roadmap 的團隊，這篇文章給的 guidance 也很乾脆：**如果目標是讓 production agent 從雲上搆到公司的系統，就去建一個 MCP server，而且用上面那四條心法把它建好**。
+
+<ClawdNote>
+把整篇文章的 takeaway 蒸乾：**API / CLI / MCP 不是技術選型，是部署地點的函數**。Agent 跑在 laptop 的 sandbox 裡，CLI 最順手；一個 agent 打一個 service，API 直接 call；一旦要跑在雲上、搆到別人雲上的系統、還要跨 client——**那是 MCP 的主場**。
+
+這篇作為 Anthropic 的 position paper 蠻誠實——沒有假裝 MCP 是萬能、也沒有假裝 API / CLI 過時。真正的論點不是「選 MCP」，是「想清楚自己的 agent 會跑在哪、搆到什麼、要不要跨 client」。答對這三題，該走哪條就不用猜。
+
+對 gu-log 讀者最實用的 takeaway：**如果正在做一個 side project 的 agent、只搆 2-3 個 service、只給自己用，直接 call API 就夠**。等哪天要把這個 agent 上線、給多個 client 用、或是給別人也能接，那才是重新評估走 MCP 的時候。**別還在 MVP 階段就硬上 MCP**——過早優化從來不是因為工具不好，而是因為選的時機不對 ʕ•ᴥ•ʔ
+</ClawdNote>


### PR DESCRIPTION
## Summary

- **SP-180**：翻譯 Anthropic 官方 blog [Building agents that reach production systems with MCP](https://claude.com/blog/building-agents-that-reach-production-systems-with-mcp)（2026-04-22 透過 @ClaudeDevs 推文公告）
- 主要論點：agent 搬上 cloud 那一刻，API / CLI / MCP 三條路一起 ship，但**只有 MCP 會複利**
- 包含四條 MCP server 設計心法（remote-first / intent-grouped / code orchestration / rich semantics + Elicitation + CIMD）、context-efficient client 兩招（tool search 85% / programmatic 37%）、skill × MCP 配對
- 同時 commit 進 CLAUDE.md 的事實查核紀律：**SP/CP 翻譯不得用 WebFetch，必須 curl 抓原文**（實測 WebFetch 會把 Cloudflare 2,500 endpoints、create_issue_from_thread 例子、elicitation form/URL mode 區別全部摘掉）
- CCC-playbook 硬化 `/tmp` chunks trigger：**First-Error-Means-Switch**，未來 user 不用講第二次

## Tribunal v2 分數（全 PASS）

| Judge | Model | Dims | Composite |
|---|---|---|---|
| Vibe | Opus 4.7 | persona 9 / clawdNote 9 / vibe 9 / clarity 9 / narrative 8 | **8** |
| Fact | Opus 4.7 | accuracy 9 / fidelity 8 / consistency 9 | **8** |
| Librarian | Sonnet 4.6 | glossary 9 / crossRef 9 / sourceAlign 10 / attribution 9 | **9** |
| Fresh Eyes | Haiku 4.5 | readability 8 / firstImpression 8 | **8** |

Pass bar 全過：composite ≥ 8、Vibe 至少一維 ≥ 9、無維 < 8。分數寫進 zh-tw frontmatter `scores.*`，Round 1 FAIL（Vibe narrative 7 / Librarian crossRef 5 glossary 7）→ 改寫後 Round 2 全過。

## Test plan

- [x] `validate-posts.mjs`：0 warnings on SP-180 zh-tw + en
- [x] `check-pronoun-clarity.mjs`：zh-tw 正文無你/我
- [x] `pnpm run build`：2861 頁全過
- [x] Pre-commit hook：10/10 content integrity tests 通過
- [x] Pre-push hook：bundle budget + PENDING guard 通過
- [ ] Vercel preview：PR merge 前 auto-deploy 驗收
- [ ] Production 上線後 ShroomDog 在 gu-log.vercel.app 親眼看一次

## 筆記

1. WebFetch vs curl 差異做成了實驗記錄，之後其他 agent 不用重踩
2. `/tmp` chunks strategy 第一次被當 First-Error-Means-Switch 硬規則使用，成功避開 stream idle timeout
3. SP-180 跟 SP-167（Claude Managed Agents）、SP-179（Garry Tan skillify）、SP-129（Cloudflare Workers sandbox）三篇有 cross-ref

https://claude.ai/code/session_01PGgQfkuHaDvsjkdJoBEuhu

---
_Generated by [Claude Code](https://claude.ai/code/session_01PGgQfkuHaDvsjkdJoBEuhu)_