### PR TITLE
Pin SP writer/scorer to Opus 4.6; accept any http(s) URL via curl fallback

### DIFF
--- a/.claude/agents/fact-checker.md
+++ b/.claude/agents/fact-checker.md
@@ -1,6 +1,8 @@
 ---
 description: "Fact Checker — independent factual accuracy verifier for gu-log posts. Checks technical accuracy, source faithfulness, and logical consistency. Does NOT evaluate writing style. Use this to catch fabricated numbers, translation distortions, and factual errors."
-model: claude-opus-4-7
+# Tracks latest Opus: fact-checking benefits from newest reasoning, and voice
+# doesn't matter (no prose output). Writer/scorer are separately pinned to 4.6.
+model: opus
 tools:
   - Read
   - Write

--- a/.claude/agents/tribunal-writer.md
+++ b/.claude/agents/tribunal-writer.md
@@ -1,5 +1,9 @@
 ---
 description: "Tribunal Writer — rewrite agent for the tribunal quality pipeline. Receives judge feedback and the scoring standard, then rewrites the article to address specific failures. Used across all 4 tribunal stages (Librarian, Fact Checker, Fresh Eyes, Vibe Scorer)."
+# PINNED: claude-opus-4-6[1m]. This is the SP / rewrite voice — maintainer
+# has explicitly rejected Opus 4.7's writing style (too press-release, loses
+# LHY persona). Do NOT bump to "opus" alias or 4.7 without owner sign-off.
+# Matched by tools/sp-pipeline/internal/llm/claude.go ClaudeOpusPinned.
 model: claude-opus-4-6[1m]
 tools:
   - Read

--- a/.claude/agents/v2-factlib-judge.md
+++ b/.claude/agents/v2-factlib-judge.md
@@ -1,6 +1,8 @@
 ---
 description: "Tribunal v2 Stage 3 — FactLib Combined Judge. Evaluates factual accuracy, library coverage, AND dedup correctness (dupCheck) in one pass, with INDEPENDENT pass bars (none compensates another). Runs after FactCorrector and Librarian workers. Use this to verify Stage 3 worker output + judge whether the post duplicates existing corpus."
-model: claude-opus-4-7
+# Tracks latest Opus: fact-check + dedup benefit from newest reasoning, and
+# voice doesn't matter. Writer/scorer are separately pinned to 4.6.
+model: opus
 tools:
   - Read
   - Glob

--- a/.claude/agents/vibe-opus-scorer.md
+++ b/.claude/agents/vibe-opus-scorer.md
@@ -1,5 +1,9 @@
 ---
 description: "Vibe Scorer — independent, harsh quality scorer for gu-log posts. Scores on 5 dimensions (Persona/ClawdNote/Vibe/Clarity/Narrative). Pass bar: composite ≥ 8 AND at least one dimension ≥ 9 AND no dimension < 8. Zero context from parent conversation. Use this to evaluate post quality without bias."
+# PINNED: claude-opus-4-6[1m]. Maintainer has explicitly rejected Opus 4.7's
+# vibe-scoring calibration — 4.7 inflates scores and misses decorative-persona
+# traps that 4.6 catches. Do NOT bump to "opus" alias or 4.7 without owner
+# sign-off. Matched by tools/sp-pipeline/internal/llm/claude.go ClaudeOpusPinned.
 model: claude-opus-4-6[1m]
 tools:
   - Read

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,7 +187,7 @@ gu-log 的文章草稿有三種來源，全部最終都變成 `src/content/posts
 - **CC 自己跑 `pnpm run dev`** 來 iterate，用 `playwright-cli` 截圖驗證 UI（skill 在 `.claude/skills/playwright-cli/`）。
 - **UI/UX 品質**：改完任何視覺的東西（CSS、component、color、spacing、typography、layout）就跑 `uiux-auditor` skill（`.claude/skills/uiux-auditor/`）。它會強制兩個主題都截圖、算 WCAG 對比、flag 寫死的 hex。不要等 user 來挑錯。
 - **建立 / 修改 skill**：用 `skill-creator` skill（`.claude/skills/skill-creator/`）— 官方 anthropic/skills 的來源。
-- **沙箱環境限制**：這個 agent 沙箱封鎖外部 HTTPS（fonts.googleapis.com 等），playwright-cli 的 `goto` 會在 `domcontentloaded` 卡死。每次 navigate 前先用 `run-code` 裝一個 route handler：localhost/data: 放行，其他一律 abort。uiux-auditor skill 裡有完整範本。
+- **沙箱網路能力**（2026-04-23 實測修正）：command-line HTTPS（curl、`sp-pipeline` 的 FetchGeneric）**是通的**，不要假設沒外網。真正受限的是 `playwright-cli` 的 browser navigation——`goto` 在 `domcontentloaded` 卡死，fonts.googleapis.com 之類 CSS 外鏈拿不到。每次 navigate 前先用 `run-code` 裝一個 route handler：localhost/data: 放行，其他一律 abort。uiux-auditor skill 裡有完整範本。
 - Push 到 main → Vercel auto-deploy → user 在 production 驗收。
 
 ## Quality: Vibe Scoring + Tribunal

--- a/playbooks/CCC-playbook.md
+++ b/playbooks/CCC-playbook.md
@@ -126,6 +126,68 @@ Vercel build / tribunal / validate-posts / CI 沒過：
 
 **必附證據**：PR body 或一個隨 PR 的 commit 要包含四個 judge 的分數 + verdict，並把 `scores.vibe` / `scores.factCheck` / `scores.librarian` / `scores.freshEyes` 寫進文章 frontmatter（用 `scripts/frontmatter-scores.mjs write <file> <judge> <score_json>`，schema 見 `src/content/config.ts`）。pre-commit 的 score gate（`.githooks/pre-commit` 第 60 行起）會擋掉**新增**且 ticketId 非 PENDING 的 zh-tw 文章 commit，所以 swap PENDING → 真號那個 commit 之前，分數要先進 frontmatter。
 
+## URL 貼過來 → 預設走 sp-pipeline
+
+User 在 CCC 丟一個 URL 進來、**沒有附任何其他指示**（沒說「解釋這個」「總結這個」「fix bug in this PR」等）→ **預設當成是要你開 SP 任務**，走 `tools/sp-pipeline/sp-pipeline run <url>`。
+
+### 為什麼 URL-only paste = SP 任務
+
+這個 repo 的主產出就是 SP/CP 翻譯文章。User 拋 URL 沒多話 = 最常見的 workflow 就是「幫我把這條評估一下、該寫就寫」。**不要再回頭問「你想幹嘛？」**——直接跑 pipeline，它內建的 eval gate 會自己判斷該不該寫。
+
+### pipeline 內建的 eval gate（不是你決定該不該寫）
+
+`sp-pipeline run` 的 step 1.5 `eval` 是雙評估（Gemini + Codex）worthiness gate：
+
+- **GO/GO** → 繼續跑寫作 → 12-point review → refine → tribunal → deploy
+- **SKIP/SKIP** → exit 12 → 不寫，從 queue 丟掉（不夠 SP-worthy）
+- **split（一 GO 一 SKIP）** → exit 2 → 需要 human review，用 `--force` 可以 override gate 硬寫
+
+**這代表 CCC 不用事先判斷「這條推文值不值得翻」**——交給 pipeline 的 eval 決定。你的工作是 run，不是 gatekeep。
+
+### URL 範圍
+
+`sp-pipeline` 的 `source.Fetch` dispatcher（`tools/sp-pipeline/internal/source/fetch.go`）接受**任意 http(s) URL**：
+
+- **X / Twitter URLs**（`x.com` / `twitter.com`，含 `www.`）→ 走 `FetchX`，用 `scripts/fetch-x-article.sh` 拉 fxtwitter JSON，品質最好
+- **其他 http(s) URL**（`claude.com` / `anthropic.com` / blogs / docs / etc.）→ 走 `FetchGeneric`，用 `curl -sSL` + 最小 HTML cleanup（砍 `<script>` / `<style>` / 標籤、decode entities、壓縮空白），送進 `ValidateArticleCapture` 驗
+
+非 http(s) scheme（`file://`、`javascript:`）、localhost、RFC1918 / loopback / link-local IP 會在 URL validator 被擋掉（SSRF 防線）。遇到 paywall / JS-challenge / SSR-heavy 的 host，`ValidateArticleCapture` 會拒絕並給你 `code: 11`——這時再走手動 fallback。
+
+### 建議指令
+
+```bash
+# 預設：跑完整 pipeline（fetch → eval → dedup → write → review → refine → tribunal → deploy）
+tools/sp-pipeline/sp-pipeline run <url>
+
+# 只想看 eval gate 怎麼判（不寫）：先 fetch 再單跑 eval
+tools/sp-pipeline/sp-pipeline fetch <url> --work-dir /tmp/sp-probe
+tools/sp-pipeline/sp-pipeline eval --source /tmp/sp-probe/source-tweet.md
+
+# Eval gate split/SKIP 但 user 堅持要寫 → 加 --force
+tools/sp-pipeline/sp-pipeline run <url> --force
+```
+
+### Sandbox 跑不起來 → 手動 `claude -p` fallback
+
+CCC 沙箱常見問題：sp-pipeline 內部的 `claude -p` 子呼叫在某些權限模式下會卡住（見本檔下方「Stream idle timeout」那一節）。這時 fallback 流程：
+
+1. 手動 fetch（`curl` 或其他方式拉到乾淨的 source 文字）
+2. 逐步跑 prompt，用 `claude -p --model claude-opus-4-6[1m] --permission-mode bypassPermissions -p "<prompt>"` 模擬 write / review / refine 各階段
+3. tribunal 改用本 playbook「Tribunal 必跑規則」那段的 4 個 subagent 平行跑
+
+**`--model` 一定要帶 `claude-opus-4-6[1m]`**——不能用 `opus` alias（會跑到 4.7）。理由見下一段。
+
+### 模型鎖定（SP writer + Vibe scorer 不准用 4.7）
+
+Maintainer 明確拒絕 Opus 4.7 的寫作聲音 + vibe 評分校準。因此：
+
+- **SP writer**（`tools/sp-pipeline/internal/llm/claude.go` 的 `ClaudeOpusPinned`）→ 鎖 `claude-opus-4-6[1m]`
+- **Vibe Scorer**（`.claude/agents/vibe-opus-scorer.md`）→ 鎖 `claude-opus-4-6[1m]`
+- **Tribunal Writer**（`.claude/agents/tribunal-writer.md`）→ 鎖 `claude-opus-4-6[1m]`
+- **Fact Checker / v2-factlib-judge** → 用 `opus` alias（追最新，fact-check 要 reasoning 強的，沒有 voice 問題）
+
+修這些檔案之前先讀 frontmatter 上方的 PIN 註解。要改 pin 需要 user 明確同意。
+
 ## 文章寫作 SOP（省 token 版）
 
 **核心原則：先寫好 zh-tw，通過 tribunal 後才翻 en。不要兩個版本同時寫、同時改。**

--- a/playbooks/CCC-playbook.md
+++ b/playbooks/CCC-playbook.md
@@ -167,12 +167,23 @@ tools/sp-pipeline/sp-pipeline eval --source /tmp/sp-probe/source-tweet.md
 tools/sp-pipeline/sp-pipeline run <url> --force
 ```
 
-### Sandbox 跑不起來 → 手動 `claude -p` fallback
+### Sandbox 網路能力（2026-04-23 實測）
 
-CCC 沙箱常見問題：sp-pipeline 內部的 `claude -p` 子呼叫在某些權限模式下會卡住（見本檔下方「Stream idle timeout」那一節）。這時 fallback 流程：
+**CCC 沙箱的 command-line HTTPS 是通的。** `curl https://claude.com/...` 正常回 200，`sp-pipeline` 內建的 `FetchGeneric`（走 curl）實測可以直接在 CCC 裡抓外部文章。**不要再用「沙箱沒外網所以只能 mac 跑」當藉口**——那是過時的心智模型。
 
-1. 手動 fetch（`curl` 或其他方式拉到乾淨的 source 文字）
-2. 逐步跑 prompt，用 `claude -p --model claude-opus-4-6[1m] --permission-mode bypassPermissions -p "<prompt>"` 模擬 write / review / refine 各階段
+什麼還是受限：
+- **`playwright-cli` 的 browser navigation**：`goto` 在 `domcontentloaded` 卡死、Google Fonts 之類 CSS 外鏈拿不到（要 route-abort workaround，見 `uiux-auditor` skill）
+- **`x.com` / `twitter.com` 直接 curl**：會拿到 React shell（沒 prerender content）——所以 X 專用的 fetch 路徑走 `fetch-x-article.sh`（fxtwitter）而不是 raw curl。這跟「外網通不通」無關，是 X 自己 anti-bot
+- **`WebFetch` tool**：對某些 host 會被 upstream proxy 檔掉，curl 反而可以
+
+結論：CCC 沙箱可以直接 `sp-pipeline run <url>`，fetch + eval + dedup + write + review + refine + tribunal + deploy 整條都能在 CCC 跑完。
+
+### 什麼時候才真的要 fallback 到手動 `claude -p`
+
+不是因為沒網路，是因為 **`claude -p` 子呼叫在 long creative generation 時會 stream idle timeout**（見本檔下方「Stream idle timeout 應對」那一節）。遇到那個 failure mode 時才走：
+
+1. `sp-pipeline fetch <url>` 先把 source 抓下來（這步幾乎不會炸）
+2. 單獨跑 prompt：`claude -p --model claude-opus-4-6[1m] --permission-mode bypassPermissions "<prompt>"` 模擬 write / review / refine 各階段（短 call，不容易 timeout）
 3. tribunal 改用本 playbook「Tribunal 必跑規則」那段的 4 個 subagent 平行跑
 
 **`--model` 一定要帶 `claude-opus-4-6[1m]`**——不能用 `opus` alias（會跑到 4.7）。理由見下一段。

--- a/tools/sp-pipeline/cmd/sp-pipeline/fetch.go
+++ b/tools/sp-pipeline/cmd/sp-pipeline/fetch.go
@@ -34,12 +34,15 @@ type fetchOutputReport struct {
 
 func newFetchCmd(state *rootState) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "fetch <tweet_url>",
-		Short: "Capture a tweet into a work directory",
-		Long: `fetch downloads a tweet or X Article into the pipeline work directory.
+		Use:   "fetch <url>",
+		Short: "Capture a source URL into a work directory",
+		Long: `fetch downloads a source URL into the pipeline work directory.
 
-For an X URL it shells out to scripts/fetch-x-article.sh (fxtwitter with
-vxtwitter fallback), then runs the native Go validator over the result.
+For X / Twitter URLs it shells out to scripts/fetch-x-article.sh (fxtwitter
+with vxtwitter fallback), then runs the tweet-specific validator. For any
+other http(s) URL it falls back to curl + a minimal HTML cleanup pass and
+runs the looser article validator.
+
 On validation failure it exits with code 11 so callers can distinguish
 "fetch returned but the content looks contaminated" from "fetch itself
 crashed" (exit code 10).
@@ -71,7 +74,7 @@ func runFetch(ctx context.Context, state *rootState, url string) error {
 	stepCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()
 
-	res, err := source.FetchX(stepCtx, url, source.FetchOptions{
+	res, err := source.Fetch(stepCtx, url, source.FetchOptions{
 		WorkDir:             workDir,
 		FetchXArticleScript: state.cfg.FetchXArticle,
 	})

--- a/tools/sp-pipeline/internal/llm/claude.go
+++ b/tools/sp-pipeline/internal/llm/claude.go
@@ -11,13 +11,26 @@ import (
 // bypassPermissions`, feeding prompt to stdin and reading the response from
 // stdout. This matches how scripts/sp-pipeline.sh invokes Claude today.
 type ClaudeProvider struct {
-	// ModelFlag is the value passed to --model ("opus", "sonnet", "haiku").
-	// Defaults to "opus".
+	// ModelFlag is the value passed to --model. For Opus we pin the exact
+	// build ("claude-opus-4-6[1m]") rather than the "opus" alias — see the
+	// PIN note below. Sonnet/Haiku may use aliases since only the Opus
+	// writing voice is taste-locked.
 	ModelFlag string
 }
 
-// NewClaudeOpus returns a ClaudeProvider wired to Claude Opus.
-func NewClaudeOpus() *ClaudeProvider { return &ClaudeProvider{ModelFlag: "opus"} }
+// Pinned model IDs. SP writer uses Opus 4.6 because the maintainer has
+// explicitly rejected Opus 4.7's writing voice and vibe-scoring calibration;
+// "opus" alias auto-upgrades to the latest and would silently break that.
+// DO NOT change ClaudeOpusPinned to the "opus" alias without owner sign-off.
+// Keep this in sync with .claude/agents/vibe-opus-scorer.md and
+// .claude/agents/tribunal-writer.md frontmatter.
+const (
+	ClaudeOpusPinned = "claude-opus-4-6[1m]"
+)
+
+// NewClaudeOpus returns a ClaudeProvider wired to the pinned Claude Opus
+// build (see ClaudeOpusPinned).
+func NewClaudeOpus() *ClaudeProvider { return &ClaudeProvider{ModelFlag: ClaudeOpusPinned} }
 
 // NewClaudeSonnet returns a ClaudeProvider wired to Claude Sonnet.
 func NewClaudeSonnet() *ClaudeProvider { return &ClaudeProvider{ModelFlag: "sonnet"} }
@@ -30,11 +43,14 @@ func (c *ClaudeProvider) Name() string { return "claude-" + c.modelFlag() }
 
 // Model implements Provider.
 func (c *ClaudeProvider) Model() ModelID {
-	switch c.modelFlag() {
+	flag := c.modelFlag()
+	switch flag {
 	case "sonnet":
 		return ModelClaudeSonnet
 	case "haiku":
 		return ModelClaudeHaiku
+	case ClaudeOpusPinned, "opus":
+		return ModelClaudeOpus
 	default:
 		return ModelClaudeOpus
 	}
@@ -67,7 +83,7 @@ func (c *ClaudeProvider) Run(ctx context.Context, prompt string, opts RunOptions
 
 func (c *ClaudeProvider) modelFlag() string {
 	if c.ModelFlag == "" {
-		return "opus"
+		return ClaudeOpusPinned
 	}
 	return c.ModelFlag
 }

--- a/tools/sp-pipeline/internal/llm/models.go
+++ b/tools/sp-pipeline/internal/llm/models.go
@@ -34,6 +34,10 @@ const (
 // DisplayName returns the human-readable model name the validator expects
 // in translatedBy.model. Unknown IDs pass through unchanged so the caller
 // fails loudly at validation time instead of silently truncating.
+//
+// Opus is pinned to 4.6 in claude.go (ClaudeOpusPinned) — the maintainer
+// has explicitly rejected 4.7's writing voice and vibe-scoring calibration.
+// Do not bump the Opus display name without also unpinning the model.
 func DisplayName(m ModelID) string {
 	switch m {
 	case ModelClaudeOpus:

--- a/tools/sp-pipeline/internal/pipeline/fetch.go
+++ b/tools/sp-pipeline/internal/pipeline/fetch.go
@@ -45,7 +45,7 @@ func (s *State) Fetch(ctx context.Context) error {
 		return nil
 	}
 
-	res, err := source.FetchX(ctx, s.TweetURL, source.FetchOptions{
+	res, err := source.Fetch(ctx, s.TweetURL, source.FetchOptions{
 		WorkDir:             s.WorkDir,
 		FetchXArticleScript: s.Cfg.FetchXArticle,
 	})

--- a/tools/sp-pipeline/internal/source/fetch.go
+++ b/tools/sp-pipeline/internal/source/fetch.go
@@ -3,10 +3,14 @@ package source
 import (
 	"context"
 	"fmt"
+	"html"
+	"net"
+	nethttp "net/url"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/chitienhsiehwork-ai/gu-log/tools/sp-pipeline/internal/runner"
 )
@@ -36,6 +40,18 @@ type FetchOptions struct {
 
 // xURLRe matches https://x.com/... and twitter.com/... URLs.
 var xURLRe = regexp.MustCompile(`^https?://(?:www\.)?(?:x|twitter)\.com/`)
+
+// Fetch routes a URL to the best available fetcher. X / Twitter URLs go
+// through FetchX (fxtwitter quality); everything else goes through
+// FetchGeneric (curl + minimal HTML cleanup). This is the entry point
+// callers should use by default — FetchX and FetchGeneric remain exported
+// for tests and for callers that want to force a specific path.
+func Fetch(ctx context.Context, url string, opts FetchOptions) (*FetchResult, error) {
+	if xURLRe.MatchString(url) {
+		return FetchX(ctx, url, opts)
+	}
+	return FetchGeneric(ctx, url, opts)
+}
 
 // FetchX fetches a tweet / X article URL into WorkDir/source-tweet.md by
 // shelling out to scripts/fetch-x-article.sh, validating the result, and
@@ -77,6 +93,139 @@ func FetchX(ctx context.Context, url string, opts FetchOptions) (*FetchResult, e
 	parsed.Path = outPath
 	parsed.Bytes = len(res.Stdout)
 	return parsed, nil
+}
+
+// FetchGeneric fetches an arbitrary http(s) URL via curl and writes the
+// result to WorkDir/source-tweet.md with a header compatible with the rest
+// of the pipeline. HTML pages pass through a minimal cleanup (drop script /
+// style / comments, decode entities, collapse whitespace) so the LLM gets
+// readable prose instead of a raw SSR dump.
+//
+// This is the default fallback when a URL doesn't match the X-specific
+// fetcher. Validation uses ValidateArticleCapture, the looser validator
+// designed for generic article captures (paywall / JS-shell detection).
+//
+// User-Agent is pinned to a browser-like string so the fetcher looks real
+// to anti-bot WAFs. This is a capture tool for content the user has already
+// chosen to translate — not a scraper — so a browser UA is appropriate.
+func FetchGeneric(ctx context.Context, urlStr string, opts FetchOptions) (*FetchResult, error) {
+	if err := validateSafeHTTPURL(urlStr); err != nil {
+		return nil, fmt.Errorf("fetchgeneric: %w", err)
+	}
+	if opts.WorkDir == "" {
+		return nil, fmt.Errorf("fetchgeneric: WorkDir is required")
+	}
+
+	ua := "Mozilla/5.0 (compatible; sp-pipeline/1; +https://gu-log.vercel.app)"
+	res, err := runner.Run(ctx, "curl", "-sSL", "--max-time", "60", "-A", ua, urlStr)
+	if err != nil {
+		return nil, fmt.Errorf("fetchgeneric: curl: %w", err)
+	}
+
+	host := hostname(urlStr)
+	date := time.Now().Format("2006-01-02")
+	body := cleanupHTML(res.Stdout)
+
+	header := fmt.Sprintf("@%s — %s\nSource URL: %s\nFetched via: curl\n\n", host, date, urlStr)
+	payload := []byte(header + string(body))
+
+	if verr := ValidateArticleCapture(payload); verr != nil {
+		return nil, verr
+	}
+
+	outPath := filepath.Join(opts.WorkDir, "source-tweet.md")
+	if err := os.WriteFile(outPath, payload, 0o644); err != nil {
+		return nil, fmt.Errorf("fetchgeneric: writing capture to %s: %w", outPath, err)
+	}
+
+	return &FetchResult{
+		Path:       outPath,
+		Handle:     "@" + host,
+		Date:       date,
+		FetchedVia: "curl",
+		Bytes:      len(payload),
+	}, nil
+}
+
+// validateSafeHTTPURL rejects non-http(s) schemes, malformed URLs, and
+// obvious internal / loopback targets. Not a full SSRF block — DNS
+// rebinding and redirects can still land on private IPs — but it stops
+// the casual ways ("file://", "http://localhost/admin") to misuse the
+// fetcher if this pipeline ever runs somewhere with internal services.
+func validateSafeHTTPURL(raw string) error {
+	u, err := nethttp.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("invalid URL: %w", err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("only http(s) URLs are supported, got %q", u.Scheme)
+	}
+	host := u.Hostname()
+	if host == "" {
+		return fmt.Errorf("URL has no host")
+	}
+	lower := strings.ToLower(host)
+	if lower == "localhost" || lower == "localhost.localdomain" {
+		return fmt.Errorf("localhost is not allowed")
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		if ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsUnspecified() {
+			return fmt.Errorf("internal / loopback IP %s is not allowed", ip)
+		}
+	}
+	return nil
+}
+
+// hostname returns the URL's host (without port) or "unknown" if parsing
+// fails. Used as the synthetic @handle in the capture header.
+func hostname(raw string) string {
+	u, err := nethttp.Parse(raw)
+	if err != nil || u.Hostname() == "" {
+		return "unknown"
+	}
+	return u.Hostname()
+}
+
+var (
+	scriptRe   = regexp.MustCompile(`(?is)<script[^>]*>.*?</script>`)
+	styleRe    = regexp.MustCompile(`(?is)<style[^>]*>.*?</style>`)
+	commentRe  = regexp.MustCompile(`(?s)<!--.*?-->`)
+	brRe       = regexp.MustCompile(`(?i)<br\s*/?>`)
+	blockTagRe = regexp.MustCompile(`(?i)</(?:p|div|h[1-6]|li|tr|section|article|header|footer|nav|aside|main|blockquote)>`)
+	anyTagRe   = regexp.MustCompile(`<[^>]+>`)
+	wsRe       = regexp.MustCompile(`[ \t]+`)
+	blankRe    = regexp.MustCompile(`\n{3,}`)
+)
+
+// cleanupHTML does minimal HTML → plaintext extraction sufficient to feed
+// the capture into downstream LLM prompts. It is NOT a general-purpose
+// readability implementation — it just strips the noisiest things
+// (scripts, styles, tags) so the validator's "too much code-shaped content"
+// rule doesn't misfire on legitimate article bodies.
+//
+// Plain text / markdown inputs (no angle brackets) pass through unchanged.
+func cleanupHTML(in []byte) []byte {
+	if !hasHTMLMarkers(in) {
+		return in
+	}
+	s := string(in)
+	s = scriptRe.ReplaceAllString(s, "")
+	s = styleRe.ReplaceAllString(s, "")
+	s = commentRe.ReplaceAllString(s, "")
+	s = brRe.ReplaceAllString(s, "\n")
+	s = blockTagRe.ReplaceAllString(s, "\n")
+	s = anyTagRe.ReplaceAllString(s, " ")
+	s = html.UnescapeString(s)
+	s = wsRe.ReplaceAllString(s, " ")
+	s = blankRe.ReplaceAllString(s, "\n\n")
+	return []byte(strings.TrimSpace(s))
+}
+
+func hasHTMLMarkers(in []byte) bool {
+	// Cheap heuristic: HTML always has a closing tag somewhere, or a
+	// DOCTYPE declaration. Plain text / markdown shouldn't.
+	s := string(in)
+	return strings.Contains(s, "</") || strings.Contains(strings.ToLower(s), "<!doctype")
 }
 
 // parseCaptureHeader pulls @handle, date, and "Fetched via" out of the

--- a/tools/sp-pipeline/internal/source/generic_test.go
+++ b/tools/sp-pipeline/internal/source/generic_test.go
@@ -1,0 +1,93 @@
+package source
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateSafeHTTPURL(t *testing.T) {
+	cases := []struct {
+		name    string
+		url     string
+		wantErr bool
+	}{
+		{"https ok", "https://www.anthropic.com/news/claude-4-6", false},
+		{"http ok", "http://example.com/article", false},
+		{"ftp rejected", "ftp://example.com/file", true},
+		{"file rejected", "file:///etc/passwd", true},
+		{"javascript rejected", "javascript:alert(1)", true},
+		{"localhost rejected", "http://localhost:8080/", true},
+		{"loopback IP rejected", "http://127.0.0.1/secret", true},
+		{"private RFC1918 rejected", "http://192.168.1.1/", true},
+		{"link-local rejected", "http://169.254.169.254/latest/meta-data/", true},
+		{"no host rejected", "https:///path", true},
+		{"garbage rejected", "not a url", true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := validateSafeHTTPURL(c.url)
+			if c.wantErr && err == nil {
+				t.Fatalf("want error for %q, got nil", c.url)
+			}
+			if !c.wantErr && err != nil {
+				t.Fatalf("unexpected error for %q: %v", c.url, err)
+			}
+		})
+	}
+}
+
+func TestCleanupHTML_PlainTextPassThrough(t *testing.T) {
+	in := []byte("Just some plain text.\n\nNo HTML here.")
+	out := cleanupHTML(in)
+	if string(out) != string(in) {
+		t.Fatalf("plain text was modified:\n  want %q\n  got  %q", in, out)
+	}
+}
+
+func TestCleanupHTML_StripsScriptsAndStyles(t *testing.T) {
+	in := []byte(`<html><head>
+<style>body { color: red; }</style>
+<script>alert("xss")</script>
+</head><body>
+<h1>Claude Code 4.6 Released</h1>
+<p>Anthropic shipped <em>Claude Opus 4.6</em> today with a 1M context window.</p>
+<script type="application/json">{"bad":"json"}</script>
+<p>Read more at <a href="/blog">the blog</a>.</p>
+</body></html>`)
+	out := cleanupHTML(in)
+	s := string(out)
+	if strings.Contains(s, "<script") || strings.Contains(s, "<style") {
+		t.Fatalf("script/style not stripped: %q", s)
+	}
+	if strings.Contains(s, "alert(") || strings.Contains(s, "color: red") {
+		t.Fatalf("script/style contents leaked: %q", s)
+	}
+	if !strings.Contains(s, "Claude Code 4.6 Released") {
+		t.Fatalf("heading text was dropped: %q", s)
+	}
+	if !strings.Contains(s, "1M context window") {
+		t.Fatalf("body text was dropped: %q", s)
+	}
+}
+
+func TestCleanupHTML_DecodesEntities(t *testing.T) {
+	in := []byte(`<p>Tom &amp; Jerry &mdash; &quot;hi&quot;</p>`)
+	out := string(cleanupHTML(in))
+	if !strings.Contains(out, "Tom & Jerry") || !strings.Contains(out, `"hi"`) {
+		t.Fatalf("entities not decoded: %q", out)
+	}
+}
+
+func TestHostname(t *testing.T) {
+	cases := map[string]string{
+		"https://www.anthropic.com/news/x":     "www.anthropic.com",
+		"https://claude.com/product/agent-sdk": "claude.com",
+		"http://example.com:8080/foo":          "example.com",
+		"not a url":                            "unknown",
+	}
+	for in, want := range cases {
+		if got := hostname(in); got != want {
+			t.Errorf("hostname(%q) = %q, want %q", in, got, want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Pins the SP writing voice + vibe-scoring calibration to **Opus 4.6**
(explicitly rejecting the 4.7 alias), and expands the `sp-pipeline` fetch
layer so any http(s) URL — not just x.com / twitter.com — can kick off an
SP task. Also documents both in the CCC playbook so future CCC sessions
default to the right thing when the user drops a URL, and corrects an
outdated claim that the CCC sandbox blocks external HTTPS.

## Motivation

- Maintainer has explicitly rejected Opus 4.7's writing style and its
  vibe-scoring behaviour. The SP pipeline was calling `claude -p --model opus`,
  which is an alias that silently tracks the latest Opus build — i.e. 4.7
  right now. That alias was overwriting the intended 4.6 voice without
  anyone noticing.
- The fetch step hard-bailed on anything that wasn't an X URL, so the common
  case of "here's a claude.com / anthropic.com post, SP it" had to be done
  manually. Now pasting any URL into CCC just works — the pipeline's own
  step 1.5 `eval` gate decides whether the piece is SP-worthy.
- The playbook (and CLAUDE.md) leaned on "CCC sandbox blocks external HTTPS"
  which is narrower than it sounds — only playwright browser navigation and
  a few Anthropic proxies are restricted. `curl` to arbitrary https works
  fine, as the live verification below shows.

## What changed

### Model pins
- `tools/sp-pipeline/internal/llm/claude.go` — new `ClaudeOpusPinned =
  "claude-opus-4-6[1m]"` constant; `NewClaudeOpus()` wires it in instead of
  the `"opus"` alias. Sonnet / Haiku aliases unchanged (only Opus voice is
  taste-locked).
- `.claude/agents/vibe-opus-scorer.md`, `tribunal-writer.md` — already on
  4.6; add PIN-reason comment above frontmatter so future bumps require
  owner sign-off.
- `.claude/agents/fact-checker.md`, `v2-factlib-judge.md` — move from
  explicit `claude-opus-4-7` to the `opus` alias. Fact-check benefits from
  newest reasoning and emits no prose, so voice doesn't matter.

### URL expansion
- `source.Fetch` is now a dispatcher: X / Twitter URLs → `FetchX`
  (unchanged fxtwitter path); everything else → new `FetchGeneric` that
  curls the page with a browser-like UA, strips `<script>` / `<style>` /
  tags, decodes entities, collapses whitespace, and runs
  `ValidateArticleCapture` (the looser article-mode validator that was
  already in the source package but never wired in).
- URL validator rejects non-http(s) schemes, `localhost`, and
  RFC1918 / loopback / link-local IPs so this can't be trivially misused
  for SSRF if the pipeline ever runs somewhere with internal services.
- Both `pipeline.Fetch` and `sp-pipeline fetch` route through the dispatcher.
  No new flag, no new binary — bash shim keeps working.

### Docs
- `playbooks/CCC-playbook.md` — new "URL 貼過來 → 預設走 sp-pipeline" section
  explaining the default behaviour, the eval-gate verdicts (GO/GO →
  continue, SKIP/SKIP → exit 12, split → exit 2, `--force` to override),
  the expanded URL range, and the curl fallback. Records the 4.6 pins
  explicitly so future CCC sessions don't bump them without asking.
- `playbooks/CCC-playbook.md` + `CLAUDE.md` — correct the "sandbox blocks
  external HTTPS" claim. CLI HTTPS (curl, sp-pipeline's FetchGeneric)
  works fine in the CCC sandbox — verified live against claude.com
  (28KB real article prose captured). Only playwright browser loads and
  a few specific proxied hosts are actually restricted.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` green (including new `generic_test.go` covering URL
      validator, HTML cleanup, entity decoding, hostname parsing)
- [x] **Live end-to-end fetch verified in CCC sandbox**:
      `sp-pipeline fetch https://claude.com/blog/building-agents-that-reach-production-systems-with-mcp`
      returned exit 0, captured 28709 bytes, header parses as
      `@claude.com — 2026-04-23 / Fetched via: curl`, real article prose
      comes through readable from roughly line 657 onwards (MCP 3-path
      framing, 300M monthly SDK downloads, design-pattern bullets on
      fewer+wider tools vs code-execution servers, MCP Apps, Elicitation,
      OAuth/CIMD, Vaults — all intact). Nav menu residue adds some
      line-level noise but SNR is fine for downstream LLM consumption.
- [ ] Live verification for X URL path: `sp-pipeline run <x.com URL>` still
      produces byte-identical output to the old path (X URL regex +
      `FetchX` unchanged, but worth one smoke run before relying on this
      in production).

## Not in this PR

- No prompt changes — the `write` / `review` / `refine` stages still use
  tweet-centric language. For most article sources this works fine, but if
  non-tweet sources come through with awkward framing we can iterate on
  prompts in a follow-up.
- Fact-checker's prose rubric wasn't touched. Only the model tag moved.
- HTML cleanup is intentionally minimal (regex-based, pure stdlib). If
  noisy SSR-heavy sites start failing `ValidateArticleCapture`, the
  follow-up is either (a) add `w3m -dump` as a preferred path when
  available, or (b) pull in `golang.org/x/net/html` for a real parse.
