### PR TITLE
fix(tribunal): align AiJudgeScore prop type with Zod schema

### DIFF
--- a/src/components/AiJudgeScore.astro
+++ b/src/components/AiJudgeScore.astro
@@ -15,35 +15,35 @@ interface Props {
   scores?: {
     tribunalVersion?: number;
     librarian?: {
-      glossary: number;
-      crossRef: number;
-      sourceAlign: number;
-      attribution: number;
+      glossary?: number;
+      crossRef?: number;
+      sourceAlign?: number;
+      attribution?: number;
       score: number;
       date: string;
       model?: string;
     };
     factCheck?: {
-      accuracy: number;
-      fidelity: number;
-      consistency: number;
+      accuracy?: number;
+      fidelity?: number;
+      consistency?: number;
       score: number;
       date: string;
       model?: string;
     };
     freshEyes?: {
-      readability: number;
-      firstImpression: number;
+      readability?: number;
+      firstImpression?: number;
       score: number;
       date: string;
       model?: string;
     };
     vibe?: {
-      persona: number;
-      clawdNote: number;
-      vibe: number;
-      clarity: number;
-      narrative: number;
+      persona?: number;
+      clawdNote?: number;
+      vibe?: number;
+      clarity?: number;
+      narrative?: number;
       score: number;
       date: string;
       model?: string;
@@ -125,33 +125,38 @@ const labels = {
               <span class="score-denom">/10</span>
             </div>
             <div class="dim-list">
-              <span class="dim-item">
-                <span class="dim-label">{labels.glossary}</span>
-                <strong class={scoreColor(scores.librarian.glossary)}>
-                  {scores.librarian.glossary}
-                </strong>
-              </span>
-              <span class="dim-sep">·</span>
-              <span class="dim-item">
-                <span class="dim-label">{labels.crossRef}</span>
-                <strong class={scoreColor(scores.librarian.crossRef)}>
-                  {scores.librarian.crossRef}
-                </strong>
-              </span>
-              <span class="dim-sep">·</span>
-              <span class="dim-item">
-                <span class="dim-label">{labels.sourceAlign}</span>
-                <strong class={scoreColor(scores.librarian.sourceAlign)}>
-                  {scores.librarian.sourceAlign}
-                </strong>
-              </span>
-              <span class="dim-sep">·</span>
-              <span class="dim-item">
-                <span class="dim-label">{labels.attribution}</span>
-                <strong class={scoreColor(scores.librarian.attribution)}>
-                  {scores.librarian.attribution}
-                </strong>
-              </span>
+              {scores.librarian.glossary !== undefined && (
+                <span class="dim-item">
+                  <span class="dim-label">{labels.glossary}</span>
+                  <strong class={scoreColor(scores.librarian.glossary)}>
+                    {scores.librarian.glossary}
+                  </strong>
+                </span>
+              )}
+              {scores.librarian.crossRef !== undefined && (
+                <span class="dim-item">
+                  <span class="dim-label">{labels.crossRef}</span>
+                  <strong class={scoreColor(scores.librarian.crossRef)}>
+                    {scores.librarian.crossRef}
+                  </strong>
+                </span>
+              )}
+              {scores.librarian.sourceAlign !== undefined && (
+                <span class="dim-item">
+                  <span class="dim-label">{labels.sourceAlign}</span>
+                  <strong class={scoreColor(scores.librarian.sourceAlign)}>
+                    {scores.librarian.sourceAlign}
+                  </strong>
+                </span>
+              )}
+              {scores.librarian.attribution !== undefined && (
+                <span class="dim-item">
+                  <span class="dim-label">{labels.attribution}</span>
+                  <strong class={scoreColor(scores.librarian.attribution)}>
+                    {scores.librarian.attribution}
+                  </strong>
+                </span>
+              )}
             </div>
           </div>
         )}
@@ -185,26 +190,30 @@ const labels = {
               <span class="score-denom">/10</span>
             </div>
             <div class="dim-list">
-              <span class="dim-item">
-                <span class="dim-label">{labels.accuracy}</span>
-                <strong class={scoreColor(scores.factCheck.accuracy)}>
-                  {scores.factCheck.accuracy}
-                </strong>
-              </span>
-              <span class="dim-sep">·</span>
-              <span class="dim-item">
-                <span class="dim-label">{labels.fidelity}</span>
-                <strong class={scoreColor(scores.factCheck.fidelity)}>
-                  {scores.factCheck.fidelity}
-                </strong>
-              </span>
-              <span class="dim-sep">·</span>
-              <span class="dim-item">
-                <span class="dim-label">{labels.consistency}</span>
-                <strong class={scoreColor(scores.factCheck.consistency)}>
-                  {scores.factCheck.consistency}
-                </strong>
-              </span>
+              {scores.factCheck.accuracy !== undefined && (
+                <span class="dim-item">
+                  <span class="dim-label">{labels.accuracy}</span>
+                  <strong class={scoreColor(scores.factCheck.accuracy)}>
+                    {scores.factCheck.accuracy}
+                  </strong>
+                </span>
+              )}
+              {scores.factCheck.fidelity !== undefined && (
+                <span class="dim-item">
+                  <span class="dim-label">{labels.fidelity}</span>
+                  <strong class={scoreColor(scores.factCheck.fidelity)}>
+                    {scores.factCheck.fidelity}
+                  </strong>
+                </span>
+              )}
+              {scores.factCheck.consistency !== undefined && (
+                <span class="dim-item">
+                  <span class="dim-label">{labels.consistency}</span>
+                  <strong class={scoreColor(scores.factCheck.consistency)}>
+                    {scores.factCheck.consistency}
+                  </strong>
+                </span>
+              )}
             </div>
           </div>
         )}
@@ -238,19 +247,22 @@ const labels = {
               <span class="score-denom">/10</span>
             </div>
             <div class="dim-list">
-              <span class="dim-item">
-                <span class="dim-label">{labels.readability}</span>
-                <strong class={scoreColor(scores.freshEyes.readability)}>
-                  {scores.freshEyes.readability}
-                </strong>
-              </span>
-              <span class="dim-sep">·</span>
-              <span class="dim-item">
-                <span class="dim-label">{labels.firstImpression}</span>
-                <strong class={scoreColor(scores.freshEyes.firstImpression)}>
-                  {scores.freshEyes.firstImpression}
-                </strong>
-              </span>
+              {scores.freshEyes.readability !== undefined && (
+                <span class="dim-item">
+                  <span class="dim-label">{labels.readability}</span>
+                  <strong class={scoreColor(scores.freshEyes.readability)}>
+                    {scores.freshEyes.readability}
+                  </strong>
+                </span>
+              )}
+              {scores.freshEyes.firstImpression !== undefined && (
+                <span class="dim-item">
+                  <span class="dim-label">{labels.firstImpression}</span>
+                  <strong class={scoreColor(scores.freshEyes.firstImpression)}>
+                    {scores.freshEyes.firstImpression}
+                  </strong>
+                </span>
+              )}
             </div>
           </div>
         )}
@@ -283,30 +295,36 @@ const labels = {
               <span class="score-denom">/10</span>
             </div>
             <div class="dim-list">
-              <span class="dim-item">
-                <span class="dim-label">{labels.persona}</span>
-                <strong class={scoreColor(scores.vibe.persona)}>{scores.vibe.persona}</strong>
-              </span>
-              <span class="dim-sep">·</span>
-              <span class="dim-item">
-                <span class="dim-label">{labels.clawdNote}</span>
-                <strong class={scoreColor(scores.vibe.clawdNote)}>{scores.vibe.clawdNote}</strong>
-              </span>
-              <span class="dim-sep">·</span>
-              <span class="dim-item">
-                <span class="dim-label">{labels.vibe_dim}</span>
-                <strong class={scoreColor(scores.vibe.vibe)}>{scores.vibe.vibe}</strong>
-              </span>
-              <span class="dim-sep">·</span>
-              <span class="dim-item">
-                <span class="dim-label">{labels.clarity}</span>
-                <strong class={scoreColor(scores.vibe.clarity)}>{scores.vibe.clarity}</strong>
-              </span>
-              <span class="dim-sep">·</span>
-              <span class="dim-item">
-                <span class="dim-label">{labels.narrative}</span>
-                <strong class={scoreColor(scores.vibe.narrative)}>{scores.vibe.narrative}</strong>
-              </span>
+              {scores.vibe.persona !== undefined && (
+                <span class="dim-item">
+                  <span class="dim-label">{labels.persona}</span>
+                  <strong class={scoreColor(scores.vibe.persona)}>{scores.vibe.persona}</strong>
+                </span>
+              )}
+              {scores.vibe.clawdNote !== undefined && (
+                <span class="dim-item">
+                  <span class="dim-label">{labels.clawdNote}</span>
+                  <strong class={scoreColor(scores.vibe.clawdNote)}>{scores.vibe.clawdNote}</strong>
+                </span>
+              )}
+              {scores.vibe.vibe !== undefined && (
+                <span class="dim-item">
+                  <span class="dim-label">{labels.vibe_dim}</span>
+                  <strong class={scoreColor(scores.vibe.vibe)}>{scores.vibe.vibe}</strong>
+                </span>
+              )}
+              {scores.vibe.clarity !== undefined && (
+                <span class="dim-item">
+                  <span class="dim-label">{labels.clarity}</span>
+                  <strong class={scoreColor(scores.vibe.clarity)}>{scores.vibe.clarity}</strong>
+                </span>
+              )}
+              {scores.vibe.narrative !== undefined && (
+                <span class="dim-item">
+                  <span class="dim-label">{labels.narrative}</span>
+                  <strong class={scoreColor(scores.vibe.narrative)}>{scores.vibe.narrative}</strong>
+                </span>
+              )}
             </div>
           </div>
         )}
@@ -495,8 +513,10 @@ const labels = {
     font-size: 0.75rem;
   }
 
-  .dim-sep {
+  .dim-item + .dim-item::before {
+    content: '·';
     color: var(--color-border);
     font-size: 0.7rem;
+    margin-right: 0.15rem;
   }
 </style>


### PR DESCRIPTION
## 背景

`pnpm exec astro check` 在 main HEAD 連兩個錯誤（ts(2322)）：

- `src/pages/posts/[...slug].astro:169:40`
- `src/pages/en/posts/[...slug].astro:172:40`

兩邊都在 `<AiJudgeScore scores={post.data.scores} ...>` 傳 prop 時炸，因為 `AiJudgeScore.astro` 的 `Props` interface 把 14 個 tribunal sub-dimension 宣告成 required `number`，但 `src/content/config.ts` 的 Zod schema 把它們全部 `.optional()`。Schema 和 component 從 dc3e12a 之後就 drift 了，branch protection 不 block type-check，所以所有 PR 都繼承這個 error。

## 修法（Option A，smallest blast radius）

只動 `src/components/AiJudgeScore.astro`，**不改 schema、不改任何 post 資料**：

1. Props interface：14 個 sub-dim 加 `?`（`glossary?: number` 等）。`score` / `date` 不動（schema 那邊本來就 required）。
2. 每個 `<span class="dim-item">` 用 `{scores.X.dim !== undefined && (...)}` 包起來，分數沒填就不渲染。
3. 移除硬寫的 `<span class="dim-sep">·</span>`，改用 `.dim-item + .dim-item::before { content: '·'; ... }` 自動加 separator — 這樣 partial dim 不會留 orphan `·`。

## Test plan

- [x] `pnpm exec astro check` → 0 errors（原本 2 errors）
- [x] `pnpm run build` → 完整 build 通過
- [x] `node scripts/validate-posts.mjs` → 無新 warning
- [x] Grep 確認目前所有 post 的 judge block 都是 full dims 或完全沒 scores block — 無 partial 案例會被這次改動影響
- [ ] Preview deploy 綠燈，sp-179 score panel 兩主題顯示正常（待 Vercel build）

## 不做什麼

- 不動 `src/content/config.ts`（Option B 才要）
- 不動 `src/content/posts/*.mdx`
- 不 rebase 或 touch SP-180 PR (#148)

---
_Generated by [Claude Code](https://claude.ai/code/session_0156tjBLgHejJkoaSahCFRsp)_