### PR TITLE
feat(tribunal): 5 workers + opus-4-6[1m] + per-dispatch sync + runbook

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,6 +201,10 @@ gu-log 的文章草稿有三種來源，全部最終都變成 `src/content/posts
 - **Rewrite**: 沒過 → rewriter 改寫 → 再跑 → 最多 3 次
 - Agents 在 `.claude/agents/`，評分標準 SSOT 在 `scripts/vibe-scoring-standard.md`
 
+### Tribunal runtime ops
+
+Daemon 行為、graceful stop、2-worker 平行化、worker worktree 管理，全部寫在 **`docs/tribunal-runbook.md`**。**碰 tribunal 自動化之前先讀這個檔**，特別是 worker worktree 不會跟著 main 自動更新這個雷，要用 `scripts/tribunal-worker-bootstrap.sh sync` 手動刷。
+
 ## Style Guide (Quick Ref)
 
 完整規則見 `WRITING_GUIDELINES.md`。

--- a/docs/tribunal-runbook.md
+++ b/docs/tribunal-runbook.md
@@ -1,0 +1,144 @@
+# Tribunal operations runbook
+
+> gu-log tribunal runtime is a quota-aware, graceful-stop daemon running on clawd-vm. It runs 4 judges (Librarian / FactChecker / FreshEyes / VibeScorer) against unscored posts and auto-rewrites failures. This doc covers the day-to-day operational moves.
+
+**Canonical specs (archived)**
+- `openspec/changes/archive/2026-04-23-tribunal-graceful-run-control/` — Phase 1, stop contract
+- `openspec/changes/archive/2026-04-23-tribunal-safe-parallelism/` — Phase 2, 2-worker pool
+
+**Key files**
+- `scripts/tribunal-quota-loop.sh` — the daemon / supervisor. SSOT for long-running runtime.
+- `scripts/tribunal-all-claude.sh` — per-article worker (4 stages).
+- `scripts/tribunal-run-control.sh` — shared stop / claim / flock helpers.
+- `scripts/tribunal-worker-bootstrap.sh` — manage worker worktrees.
+- `scripts/tribunal-batch-runner.sh` — bounded one-shot (cron / manual). **Not a daemon** — use `tribunal-quota-loop.sh` for daemon.
+- `scripts/tribunal-loop.service` — systemd unit (user-scope).
+- `scripts/cc-tribunal-loop-wrapper.sh` — loads CLAUDE_CODE_OAUTH_TOKEN, exec's the loop.
+
+## Deploy
+
+VPS path: `~/clawd/projects/gu-log` (main worktree) + `~/clawd/projects/gu-log-worker-{a,b}` (worker worktrees).
+
+```bash
+# On Mac: push the change
+git push origin main
+
+# On VPS
+ssh clawd-vm
+cd ~/clawd/projects/gu-log
+git stash push -m "wip" --include-untracked        # uncommitted tribunal rewrites live here
+git checkout main && git pull
+git stash pop
+
+# If scripts/tribunal-loop.service changed, redeploy + reload:
+cp scripts/tribunal-loop.service ~/.config/systemd/user/tribunal-loop.service
+systemctl --user daemon-reload
+
+# If tribunal code changed AND workers are running:
+#   option A (preferred, no token waste) — drain + restart
+touch .score-loop/control/stop-graceful
+# wait for service inactive (minutes → up to 60min if article is mid-stage)
+until [ "$(systemctl --user is-active tribunal-loop)" != "active" ]; do sleep 10; done
+systemctl --user start tribunal-loop   # supervisor auto-syncs worker worktrees at startup
+
+#   option B (if drain stalls) — kill workers, let supervisor exit
+pkill -TERM -f tribunal-all-claude.sh
+# supervisor exits on next iteration (top-of-loop stop check)
+systemctl --user start tribunal-loop
+```
+
+## Worker worktree gotcha
+
+**Worker worktrees don't auto-update when main advances.** `git worktree add <path> origin/main` checks out whatever origin/main was at that moment. Subsequent `git pull` in the main worktree does **not** propagate to worker worktrees. Running workers keep executing their stale snapshot until explicitly synced.
+
+Symptoms:
+- Merged a bug fix to main, restarted service, workers still show old behavior.
+- `cat ~/clawd/projects/gu-log/scripts/<file>` shows new code; `cat ~/clawd/projects/gu-log-worker-a/scripts/<same-file>` shows old code.
+
+Fix:
+```bash
+# Sync all worker worktrees to origin/main, with pnpm install if deps changed
+scripts/tribunal-worker-bootstrap.sh sync
+
+# Or specific worker
+scripts/tribunal-worker-bootstrap.sh sync a
+```
+
+The supervisor (`tribunal-quota-loop.sh`) runs `sync` automatically at every startup (in `ensure_worktrees`), so a clean restart cycle always picks up the latest code. Manual `sync` is only needed if you want to refresh worktrees without restarting (e.g. before the next article dispatch, without draining current articles).
+
+## Graceful stop
+
+Two channels, same semantics (see `tribunal-run-control.sh`):
+- **Signal** — `systemctl --user stop tribunal-loop` sends SIGTERM. With `KillMode=mixed`, only the supervisor gets the signal; the in-flight per-article subprocess is left alive to finish its current article.
+- **File flag** — `touch .score-loop/control/stop-graceful`. Supervisor and workers poll in 15s slices, both notice within a slice and enter drain.
+
+Safe boundary = **article**, not stage. A stop during a judge call waits for the stage + rewrite + build to finish, then the next article won't be dispatched. Worst case ~60min per article (systemd `TimeoutStopSec=3600`).
+
+Restart after stop: `systemctl --user start tribunal-loop`. `rc_exit_stopped` removes the flag file on clean exit, so there's no sticky stop-state to clear.
+
+## Observability
+
+```bash
+# Live state
+cat .score-loop/state/runtime.json
+# Expected states: running / draining / idle_wait / stopped_by_request / stopped_by_quota
+
+# Active claims (one per in-flight article)
+ls .score-loop/claims/
+
+# Tail supervisor log
+ls -t .score-loop/logs/tribunal-quota-loop-*.log | head -1 | xargs tail -f
+
+# Tail per-article log (inside a worker worktree)
+ls -t ~/clawd/projects/gu-log-worker-a/.score-loop/logs/tribunal-*.log | head -1 | xargs tail -f
+
+# Process tree
+ps -ef --forest | grep -E "tribunal|bash scripts/tribunal"
+```
+
+Exit code conventions (from `tribunal-all-claude.sh`):
+- `0` — all 4 stages passed
+- `1` — stage failed (normal failure, will be retried on next dispatch)
+- `2` — EXHAUSTED (hit `MAX_TOP_ATTEMPTS=5`; will NOT be retried automatically)
+- `75` — skipped (per-article lock held by another instance)
+- `77` — stopped_by_request (graceful stop propagated from a long wait)
+
+## Worktree lifecycle cheat sheet
+
+```bash
+# Provision
+scripts/tribunal-worker-bootstrap.sh create a
+scripts/tribunal-worker-bootstrap.sh create b
+
+# Inspect
+scripts/tribunal-worker-bootstrap.sh status
+
+# Sync to latest main (safe — detached HEAD, no local work preserved)
+scripts/tribunal-worker-bootstrap.sh sync          # all workers
+scripts/tribunal-worker-bootstrap.sh sync a        # just worker-a
+
+# Remove (e.g. disk pressure, or reverting to --workers 1)
+scripts/tribunal-worker-bootstrap.sh remove a
+scripts/tribunal-worker-bootstrap.sh remove-all
+```
+
+Disk cost: ~500MB per worker (pnpm `node_modules` per worktree). On clawd-vm (75GB, historically ~45GB used) this is fine for 2–3 workers.
+
+## Quota tiers
+
+From `tribunal-quota-loop.sh`:
+- `GO` (>3% remaining): dispatch freely
+- `STOP` (≤3%): enter `stopped_by_quota`, poll every 30min (interruptible), resume at ≥10% (hysteresis prevents flapping)
+
+Quota source: `~/clawd/scripts/usage-monitor.sh --json`. If that file is missing or returns non-ok, the loop enters `idle_wait` with `quota_unreadable` and polls every 10min.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Workers dispatched but log stays quiet for >1min | Worker sleeping inside `wait_for_*` (quota/quiet-hours left over from old code) | `sync` workers + restart |
+| Service inactive, `rc_exit_stopped` in log, flag still present | Someone touched the flag manually; supervisor cleared it on exit | `systemctl --user start tribunal-loop` |
+| Same article claimed by a dead pid, new workers blocked | Worker crashed without releasing claim | `scripts/tribunal-worker-bootstrap.sh status` to confirm workers are alive; supervisor runs `rc_gc_stale_claims` at startup; to force now: `rm -rf .score-loop/claims/<slug>.claim` |
+| `git pull failed: unstaged changes` warning in supervisor log | Dirty tribunal rewrites in main worktree from an earlier partial run | Non-fatal; supervisor continues with its current checkout. Clean up via `git stash` or `git checkout -- .` when safe. |
+| New code on main isn't reaching running workers | Worker worktrees are stale (see "Worker worktree gotcha" above) | `scripts/tribunal-worker-bootstrap.sh sync` — or restart (supervisor auto-syncs) |
+| Article marked EXHAUSTED after 5 attempts | Real content / scoring issue, or model-induced flakiness | Open the stage log, look at scorer reasons; rewrite manually or flag for human review |

--- a/scripts/tribunal-all-claude.sh
+++ b/scripts/tribunal-all-claude.sh
@@ -259,11 +259,17 @@ run_stage() {
 
   local post_path="$ROOT_DIR/src/content/posts/$post_file"
 
-  # Map model_label to CLI model ID (belt + suspenders: agent file also pins)
+  # Map model_label to CLI model ID (belt + suspenders: agent file also pins).
+  # [1m] suffix = 1M-token context window variant. Use for stages where the
+  # post + judge prompt may exceed 200k tokens (vibe scorer sees full post +
+  # scoring SSOT; librarian sees glossary + cross-refs). Quote to prevent
+  # bash glob expansion (no `claude-opus-4-6m` file on disk, but be safe).
   local model_id
   case "$model_label" in
-    opus-4.6) model_id="claude-opus-4-6" ;;
-    opus-4.7) model_id="claude-opus-4-7" ;;
+    opus-4.6)    model_id="claude-opus-4-6" ;;
+    opus-4.6-1m) model_id="claude-opus-4-6[1m]" ;;
+    opus-4.7)    model_id="claude-opus-4-7" ;;
+    opus-4.7-1m) model_id="claude-opus-4-7[1m]" ;;
     *) model_id="" ;;  # no override, rely on agent file
   esac
 
@@ -405,7 +411,10 @@ PROMPT
     writer_out="$(mktemp)"
     writer_rc=0
 
-    local -a writer_cmd=(timeout 900 claude -p --agent tribunal-writer --dangerously-skip-permissions --model claude-opus-4-6)
+    # Writer needs to read the full post + judge feedback + scoring SSOT; use
+    # the 1M-context variant so it never gets truncated mid-rewrite. Quote the
+    # model ID to keep bash from trying to glob-expand the [1m] suffix.
+    local -a writer_cmd=(timeout 900 claude -p --agent tribunal-writer --dangerously-skip-permissions --model 'claude-opus-4-6[1m]')
     "${writer_cmd[@]}" \
       "$writer_prompt" \
       > "$writer_out" 2>&1 || writer_rc=$?
@@ -516,7 +525,7 @@ declare -a STAGES=(
   "librarian:librarian:librarian:Librarian:2:opus-4.6:librarian"
   "factChecker:fact-checker:fact-checker:FactChecker:2:opus-4.7:factCheck"
   "freshEyes:fresh-eyes:fresh-eyes:FreshEyes:2:opus-4.6:freshEyes"
-  "vibe:vibe-opus-scorer:vibe-opus-scorer:VibeScorer:3:opus-4.6:vibe"
+  "vibe:vibe-opus-scorer:vibe-opus-scorer:VibeScorer:3:opus-4.6-1m:vibe"
 )
 
 for stage_def in "${STAGES[@]}"; do

--- a/scripts/tribunal-loop.service
+++ b/scripts/tribunal-loop.service
@@ -5,7 +5,7 @@ After=network-online.target
 [Service]
 Type=simple
 WorkingDirectory=%h/clawd/projects/gu-log
-ExecStart=/bin/bash %h/clawd/projects/gu-log/scripts/cc-tribunal-loop-wrapper.sh --workers 2
+ExecStart=/bin/bash %h/clawd/projects/gu-log/scripts/cc-tribunal-loop-wrapper.sh --workers 5
 Restart=on-failure
 RestartSec=60
 Environment=TZ=Asia/Taipei
@@ -21,9 +21,13 @@ KillSignal=SIGTERM
 # write. Allow up to 60min before SIGKILL.
 TimeoutStopSec=3600
 
-# Resource limits
-CPUQuota=50%
-MemoryMax=512M
+# Resource limits — tuned for --workers 5 (5 parallel tribunal-all-claude.sh
+# subprocesses, each spawning a claude CLI judge + optional pnpm build).
+# CPUQuota 200% lets bursts of concurrent builds use multiple cores without
+# starving each other; MemoryMax 2G covers peak (5 × ~150MB worker +
+# supervisor + shared helpers) with headroom for pnpm node_modules caching.
+CPUQuota=200%
+MemoryMax=2G
 
 # Logging
 StandardOutput=journal

--- a/scripts/tribunal-quota-loop.sh
+++ b/scripts/tribunal-quota-loop.sh
@@ -141,7 +141,10 @@ worker_worktree() {
   fi
 }
 
-# Ensure worker worktrees exist (idempotent). Called once at startup.
+# Ensure worker worktrees exist AND are synced with origin/main. Called once
+# at supervisor startup. Without the sync step, worker worktrees keep
+# whichever origin/main snapshot they had at `git worktree add` time, so
+# tribunal fixes merged to main never reach running workers.
 ensure_worktrees() {
   (( WORKERS == 1 )) && return 0
   local id wt
@@ -155,6 +158,10 @@ ensure_worktrees() {
       }
     fi
   done
+  # Fast-forward every worker worktree to whatever main currently is.
+  tlog "Syncing worker worktrees to origin/main…"
+  bash "$SCRIPT_DIR/tribunal-worker-bootstrap.sh" sync >> "$LOG_FILE" 2>&1 || \
+    tlog "WARN: worktree sync reported errors (see log)"
 }
 
 # Try to claim the next unscored article that isn't already claimed.

--- a/scripts/tribunal-quota-loop.sh
+++ b/scripts/tribunal-quota-loop.sh
@@ -185,6 +185,15 @@ spawn_worker() {
   wt=$(worker_worktree "$id")
   local slug="${article%.mdx}"
 
+  # Sync worker worktree to origin/main before each dispatch. Per-dispatch
+  # cost is one git fetch (~100ms with cached refs) plus a no-op hard reset
+  # if nothing changed; supervisor doesn't need a restart for new tribunal
+  # fixes to reach the next article's worker.
+  if (( WORKERS > 1 )); then
+    bash "$SCRIPT_DIR/tribunal-worker-bootstrap.sh" sync "$id" >> "$LOG_FILE" 2>&1 || \
+      tlog "  WARN: pre-dispatch sync failed for worker-$id (continuing with current snapshot)"
+  fi
+
   (
     cd "$wt" || exit 1
     # Hand shared coordinates to the subprocess so flock/claims/locks all

--- a/scripts/tribunal-worker-bootstrap.sh
+++ b/scripts/tribunal-worker-bootstrap.sh
@@ -10,6 +10,7 @@
 # Usage:
 #   scripts/tribunal-worker-bootstrap.sh create <id>    # create worktree, pnpm install
 #   scripts/tribunal-worker-bootstrap.sh status         # list all worker worktrees
+#   scripts/tribunal-worker-bootstrap.sh sync [id]      # fast-forward worker(s) to origin/main
 #   scripts/tribunal-worker-bootstrap.sh remove <id>    # git worktree remove
 #   scripts/tribunal-worker-bootstrap.sh remove-all     # remove every gu-log-worker-*
 #
@@ -17,6 +18,11 @@
 #   - Disk cost is ~500MB per worker (pnpm node_modules per worktree).
 #   - Safe to run create on an id that already exists: prints a warning and
 #     exits 0 so this is idempotent for supervisor startup.
+#   - `sync` MUST be run after every main-branch change to tribunal code or
+#     workers will continue running the stale snapshot of their worktree.
+#     Supervisor invokes `sync` at startup; also run it manually when you
+#     see new code on main that should reach running workers without a
+#     full service restart.
 
 set -euo pipefail
 
@@ -83,6 +89,64 @@ cmd_status() {
   fi
 }
 
+cmd_sync() {
+  local only_id="${1:-}"
+  cd "$MAIN_REPO"
+  git fetch origin main >/dev/null 2>&1 || { echo "WARN: git fetch origin main failed" >&2; }
+  local target_sha
+  target_sha=$(git rev-parse origin/main)
+
+  local dir id before_sha lockfile_changed pkg_changed
+  local any=0
+  for dir in "$WORKER_PARENT"/gu-log-worker-*; do
+    [ -d "$dir" ] || continue
+    id="${dir##*/gu-log-worker-}"
+    if [ -n "$only_id" ] && [ "$id" != "$only_id" ]; then
+      continue
+    fi
+    any=1
+
+    before_sha=$(git -C "$dir" rev-parse HEAD 2>/dev/null || echo "unknown")
+    if [ "$before_sha" = "$target_sha" ]; then
+      echo "worker-$id: already at ${target_sha:0:8} (origin/main) — nothing to do"
+      continue
+    fi
+
+    # Detect lockfile / package.json drift BEFORE reset so we can decide
+    # whether to re-run pnpm install after the reset.
+    lockfile_changed=0
+    pkg_changed=0
+    if ! git -C "$dir" diff --quiet "$before_sha" "$target_sha" -- pnpm-lock.yaml 2>/dev/null; then
+      lockfile_changed=1
+    fi
+    if ! git -C "$dir" diff --quiet "$before_sha" "$target_sha" -- package.json 2>/dev/null; then
+      pkg_changed=1
+    fi
+
+    echo "worker-$id: ${before_sha:0:8} -> ${target_sha:0:8}"
+    # Reset is safe: worker worktrees are detached-HEAD, ephemeral snapshots
+    # rebuilt from origin/main. Nothing worth preserving lives in them.
+    if ! git -C "$dir" reset --hard "$target_sha" >/dev/null 2>&1; then
+      echo "  ERROR: reset failed for worker-$id" >&2
+      continue
+    fi
+
+    if [ "$lockfile_changed" = 1 ] || [ "$pkg_changed" = 1 ]; then
+      echo "  pnpm-lock / package.json changed — running pnpm install"
+      ( cd "$dir" && pnpm install --frozen-lockfile >/dev/null 2>&1 ) \
+        || echo "  WARN: pnpm install failed for worker-$id" >&2
+    fi
+  done
+
+  if [ "$any" -eq 0 ]; then
+    if [ -n "$only_id" ]; then
+      echo "No worker worktree matches id=$only_id"
+    else
+      echo "No worker worktrees found — nothing to sync"
+    fi
+  fi
+}
+
 cmd_remove() {
   local id="${1:-}"
   [ -z "$id" ] && { echo "ERROR: missing worker id" >&2; usage 1; }
@@ -112,6 +176,7 @@ cmd_remove_all() {
 case "${1:-}" in
   create)     shift; cmd_create "$@" ;;
   status|ls)  cmd_status ;;
+  sync)       shift; cmd_sync "$@" ;;
   remove|rm)  shift; cmd_remove "$@" ;;
   remove-all) cmd_remove_all ;;
   ""|help|-h|--help) usage 0 ;;


### PR DESCRIPTION
## Summary

Bundles three related operational changes for the tribunal 2-worker→5-worker scale-up window.

### Commit 1 — `chore(tribunal): add worker sync subcommand + runbook`

- `scripts/tribunal-worker-bootstrap.sh sync [id]` — fast-forward worker worktrees to origin/main, detects lockfile drift and re-runs \`pnpm install --frozen-lockfile\` only when needed.
- Supervisor \`ensure_worktrees\` calls \`sync\` at startup, so a clean \`systemctl restart\` always picks up latest code.
- New \`docs/tribunal-runbook.md\` — deploy flow, graceful stop, worker worktree gotcha, observability, quota tiers, troubleshooting matrix.
- CLAUDE.md links the runbook.

### Commit 2 — `feat(tribunal): scale to 5 workers + vibe/writer on opus-4-6[1m]`

- Vibe scorer + writer switched to \`claude-opus-4-6[1m]\` (1M context) so they never truncate on bigger posts + scoring SSOT.
- \`--workers\` in the systemd unit bumped 2 → 5. \`CPUQuota=200%\` + \`MemoryMax=2G\` sized for 5 concurrent subprocesses + pnpm build bursts.
- Supervisor now runs \`sync <id>\` BEFORE each worker dispatch, so new main commits reach the next article's worker without a full service restart.

## Smoke tests

\`\`\`
$ claude -p --model 'claude-opus-4-6[1m]' --dangerously-skip-permissions 'Reply...'
opus 4.6 1m OK

$ claude -p --model 'claude-opus-4-7[1m]' --dangerously-skip-permissions 'Reply...'
4.7 1m OK

# bash array preserves [1m] literally (no glob expansion)
$ bash -c 'args=(--model "claude-opus-4-6[1m]"); printf "%s\n" "\${args[@]}"'
--model
claude-opus-4-6[1m]
\`\`\`

## Deploy plan (VPS after merge)

1. \`systemctl --user stop tribunal-loop\` (or touch stop flag + wait for drain)
2. \`git pull\` in main worktree
3. \`scripts/tribunal-worker-bootstrap.sh create {c,d,e}\` (bootstrap 3 more workers)
4. \`cp scripts/tribunal-loop.service ~/.config/systemd/user/ && systemctl --user daemon-reload\`
5. \`systemctl --user start tribunal-loop\` (supervisor auto-syncs all 5 worker worktrees at startup)

## Worktree gotcha

Documented in runbook + now automated away: supervisor auto-syncs at startup AND before each dispatch. No more "merged a fix but workers didn't pick it up" surprises.

🤖 Generated with [Claude Code](https://claude.com/claude-code)