### PR TITLE
fix(tribunal): sort unscored articles by numeric ticket id

### DIFF
--- a/scripts/tribunal-batch-runner.sh
+++ b/scripts/tribunal-batch-runner.sh
@@ -78,13 +78,15 @@ get_unscored_articles() {
     echo '{}' > "$PROGRESS_FILE"
   fi
 
-  # List zh-tw articles (not en-, not deprecated), sorted newest first by filename date
+  # List zh-tw articles (not en-, not deprecated), sorted highest ticket id
+  # first. sort -V handles mixed 2/3-digit ids correctly (sp-180 > sp-99);
+  # keep in sync with tribunal-quota-loop.sh:get_unscored_articles.
   local all_zh_articles
   all_zh_articles=$(ls -1 "$POSTS_DIR"/*.mdx 2>/dev/null \
     | xargs -I{} basename {} \
     | grep -v '^en-' \
     | grep -v '^demo' \
-    | sort -r)
+    | sort -V -r)
 
   for article in $all_zh_articles; do
     # Skip deprecated

--- a/scripts/tribunal-quota-loop.sh
+++ b/scripts/tribunal-quota-loop.sh
@@ -271,13 +271,16 @@ get_unscored_articles() {
     echo '{}' > "$PROGRESS_FILE"
   fi
 
-  # List zh-tw articles (not en-, not demo), sorted newest first by filename date
+  # List zh-tw articles (not en-, not demo), sorted highest ticket id first.
+  # -V (version sort) treats the numeric ticket-id as a number so sp-180
+  # correctly ranks above sp-99 (plain `sort -r` did lex and put sp-60 >
+  # sp-180, making 2-digit tickets always run before 3-digit ones).
   local all_zh_articles
   all_zh_articles=$(ls -1 "$POSTS_DIR"/*.mdx 2>/dev/null \
     | xargs -I{} basename {} \
     | grep -v '^en-' \
     | grep -v '^demo' \
-    | sort -r)
+    | sort -V -r)
 
   local article full_path status
   for article in $all_zh_articles; do


### PR DESCRIPTION
`get_unscored_articles` used `sort -r` (lexicographic) so sp-60 ranked above sp-180. Workers kept picking 2-digit tickets first. Switch to `sort -V -r` (version sort) so numeric ticket-id is compared as a number.

Affects both tribunal-quota-loop.sh and tribunal-batch-runner.sh. Takes effect after supervisor restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)