### PR TITLE
feat(tribunal): sort by translatedDate + require the field schema-side

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,16 @@ tmp/
 # Local notes (not tracked)
 *.local.md
 
+# Handoff / scratch notes between CC sessions
+*.tmp.md
+
+# Tribunal runtime coordination files (locks, lifecycle state, claims, control flags)
+.score-loop/progress.lock
+.score-loop/push.lock
+.score-loop/state/
+.score-loop/claims/
+.score-loop/control/
+
 # Tribunal daemon workspace (separate clone to avoid git dirty conflicts)
 .tribunal-workspace/
 

--- a/scripts/tribunal-batch-runner.sh
+++ b/scripts/tribunal-batch-runner.sh
@@ -78,15 +78,20 @@ get_unscored_articles() {
     echo '{}' > "$PROGRESS_FILE"
   fi
 
-  # List zh-tw articles (not en-, not deprecated), sorted highest ticket id
-  # first. sort -V handles mixed 2/3-digit ids correctly (sp-180 > sp-99);
-  # keep in sync with tribunal-quota-loop.sh:get_unscored_articles.
+  # List zh-tw articles (not en-, not deprecated), sorted newest-first by
+  # frontmatter translatedDate. Keep in sync with
+  # tribunal-quota-loop.sh:get_unscored_articles — this replaces the old
+  # filename `sort -V` which grouped by series prefix.
   local all_zh_articles
-  all_zh_articles=$(ls -1 "$POSTS_DIR"/*.mdx 2>/dev/null \
-    | xargs -I{} basename {} \
-    | grep -v '^en-' \
-    | grep -v '^demo' \
-    | sort -V -r)
+  all_zh_articles=$(
+    for f in "$POSTS_DIR"/*.mdx; do
+      base=$(basename "$f")
+      case "$base" in en-*|demo*) continue ;; esac
+      td=$(awk '/^---$/{c++; if(c==2) exit; next} c==1 && /^translatedDate:/ {gsub(/[" ]/,"",$2); print $2; exit}' "$f")
+      [ -z "$td" ] && continue
+      printf '%s|%s\n' "$td" "$base"
+    done | sort -r | cut -d'|' -f2-
+  )
 
   for article in $all_zh_articles; do
     # Skip deprecated

--- a/scripts/tribunal-quota-loop.sh
+++ b/scripts/tribunal-quota-loop.sh
@@ -271,16 +271,24 @@ get_unscored_articles() {
     echo '{}' > "$PROGRESS_FILE"
   fi
 
-  # List zh-tw articles (not en-, not demo), sorted highest ticket id first.
-  # -V (version sort) treats the numeric ticket-id as a number so sp-180
-  # correctly ranks above sp-99 (plain `sort -r` did lex and put sp-60 >
-  # sp-180, making 2-digit tickets always run before 3-digit ones).
+  # List zh-tw articles (not en-, not demo), sorted newest-first by
+  # frontmatter translatedDate (the date we first shipped this post).
+  # Earlier we sorted by filename (sort -V), which grouped by prefix
+  # (all sp-* before all sd-* before all cp-*) and stranded slug-only
+  # files (no YYYYMMDD in filename) at the end. translatedDate lives in
+  # frontmatter for every post (Zod-required, see config.ts), so this is
+  # a uniform key across all series and naming conventions.
   local all_zh_articles
-  all_zh_articles=$(ls -1 "$POSTS_DIR"/*.mdx 2>/dev/null \
-    | xargs -I{} basename {} \
-    | grep -v '^en-' \
-    | grep -v '^demo' \
-    | sort -V -r)
+  all_zh_articles=$(
+    for f in "$POSTS_DIR"/*.mdx; do
+      base=$(basename "$f")
+      case "$base" in en-*|demo*) continue ;; esac
+      # Extract translatedDate from the first frontmatter block.
+      td=$(awk '/^---$/{c++; if(c==2) exit; next} c==1 && /^translatedDate:/ {gsub(/[" ]/,"",$2); print $2; exit}' "$f")
+      [ -z "$td" ] && continue
+      printf '%s|%s\n' "$td" "$base"
+    done | sort -r | cut -d'|' -f2-
+  )
 
   local article full_path status
   for article in $all_zh_articles; do

--- a/scripts/validate-posts.mjs
+++ b/scripts/validate-posts.mjs
@@ -136,7 +136,15 @@ function validatePost(filepath, allPosts) {
   }
 
   // ── Rule 2: Required fields ──
-  const required = ['title', 'originalDate', 'translatedDate', 'source', 'sourceUrl', 'summary', 'lang'];
+  const required = [
+    'title',
+    'originalDate',
+    'translatedDate',
+    'source',
+    'sourceUrl',
+    'summary',
+    'lang',
+  ];
   for (const field of required) {
     if (!fm[field]) {
       errors.push(`Missing required field: ${field}`);

--- a/scripts/validate-posts.mjs
+++ b/scripts/validate-posts.mjs
@@ -136,7 +136,7 @@ function validatePost(filepath, allPosts) {
   }
 
   // ── Rule 2: Required fields ──
-  const required = ['title', 'originalDate', 'source', 'sourceUrl', 'summary', 'lang'];
+  const required = ['title', 'originalDate', 'translatedDate', 'source', 'sourceUrl', 'summary', 'lang'];
   for (const field of required) {
     if (!fm[field]) {
       errors.push(`Missing required field: ${field}`);

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -7,7 +7,7 @@ const postsCollection = defineCollection({
       title: z.string(),
       ticketId: z.string().optional(), // e.g., "SP-15", "CP-1", "SD-1", "Lv-1"
       originalDate: z.string(), // Original publish date (YYYY-MM-DD format)
-      translatedDate: z.string().optional(), // Translation date (YYYY-MM-DD format)
+      translatedDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'translatedDate must be YYYY-MM-DD'), // Date we first shipped this post — tribunal sort key (required)
       translatedBy: z
         .object({
           model: z.string(),

--- a/src/content/posts/en-levelup-20260218-04-openclaw-gateway-core.mdx
+++ b/src/content/posts/en-levelup-20260218-04-openclaw-gateway-core.mdx
@@ -2,6 +2,7 @@
 ticketId: "Lv-04"
 title: "OpenClaw Gateway Core: What Your AI Butler Actually Looks Like"
 originalDate: "2026-02-18"
+translatedDate: "2026-02-18"
 source: "Level-Up Series"
 sourceUrl: "https://gu-log.vercel.app/posts/levelup-20260218-04-openclaw-gateway-core"
 summary: "Understanding OpenClaw architecture from scratch. Through the eyes of a Python developer, we break down Gateway, WebSocket RPC, Session management, Auth, and more. Quiz at every floor!"

--- a/src/content/posts/en-levelup-20260218-05-openclaw-channels-tools.mdx
+++ b/src/content/posts/en-levelup-20260218-05-openclaw-channels-tools.mdx
@@ -2,6 +2,7 @@
 ticketId: "Lv-05"
 title: "OpenClaw Channels & Tools: The AI's Mouth and Hands"
 originalDate: "2026-02-18"
+translatedDate: "2026-02-18"
 source: "Level-Up Series"
 sourceUrl: "https://gu-log.vercel.app/posts/levelup-20260218-05-openclaw-channels-tools"
 summary: "Breaking down how OpenClaw connects to Telegram, Discord, and more — plus how AI executes commands, drives a browser, and stays safely leashed. A Python-friendly tour of a TypeScript architecture."

--- a/src/content/posts/en-levelup-20260218-06-openclaw-memory-skills-automation.mdx
+++ b/src/content/posts/en-levelup-20260218-06-openclaw-memory-skills-automation.mdx
@@ -2,6 +2,7 @@
 ticketId: "Lv-06"
 title: "OpenClaw Memory, Skills & Automation: Brain and Habits"
 originalDate: "2026-02-18"
+translatedDate: "2026-02-18"
 source: "Level-Up Series"
 sourceUrl: "https://gu-log.vercel.app/posts/levelup-20260218-06-openclaw-memory-skills-automation"
 summary: "How OpenClaw remembers things, learns new skills, and runs tasks on autopilot. From Embeddings to Cron Jobs — explained for Python developers."

--- a/src/content/posts/en-levelup-20260218-07-openclaw-testing.mdx
+++ b/src/content/posts/en-levelup-20260218-07-openclaw-testing.mdx
@@ -2,6 +2,7 @@
 ticketId: "Lv-07"
 title: "OpenClaw Testing: Quality Assurance in the AI Era"
 originalDate: "2026-02-18"
+translatedDate: "2026-02-18"
 source: "Level-Up Series"
 sourceUrl: "https://gu-log.vercel.app/posts/levelup-20260218-07-openclaw-testing"
 summary: "The philosophy behind 1,086 tests. Why tests matter more than code review in the AI era. How to use tests as specs. The changing role of a Tech Lead."

--- a/src/content/posts/en-levelup-20260221-08-openclaw-health-suite.mdx
+++ b/src/content/posts/en-levelup-20260221-08-openclaw-health-suite.mdx
@@ -2,6 +2,7 @@
 ticketId: "Lv-08"
 title: "OpenClaw Health Suite (Part 1): From a 36-Hour Outage to Automated Health Checks"
 originalDate: "2026-02-21"
+translatedDate: "2026-02-21"
 source: "Level-Up Series"
 sourceUrl: "https://gu-log.vercel.app/posts/levelup-20260221-08-openclaw-health-suite"
 summary: "Why you need a Health Suite and how to detect problems early. From a 36-hour restart storm to healthcheck + watchdog as your first line of defense."

--- a/src/content/posts/en-levelup-20260221-09-openclaw-rollback-sop-drills.mdx
+++ b/src/content/posts/en-levelup-20260221-09-openclaw-rollback-sop-drills.mdx
@@ -2,6 +2,7 @@
 ticketId: "Lv-09"
 title: "OpenClaw Health Suite (Part 2): Rollback, SOPs & Failure Drills"
 originalDate: "2026-02-21"
+translatedDate: "2026-02-21"
 source: "Level-Up Series"
 sourceUrl: "https://gu-log.vercel.app/posts/levelup-20260221-09-openclaw-rollback-sop-drills"
 summary: "Lv-09 continues from Lv-08, focusing on the Recover Layer. We break down rollback safety design, upgrade SOP decision trees, a `|| true` showstopper caught in code review, and actionable drill KPIs."

--- a/src/content/posts/en-levelup-20260223-10-url-journey-browser-internals.mdx
+++ b/src/content/posts/en-levelup-20260223-10-url-journey-browser-internals.mdx
@@ -2,6 +2,7 @@
 ticketId: "Lv-10"
 title: "The Journey of a URL — What Actually Happens Between Pressing Enter and Seeing a Page"
 originalDate: "2026-02-23"
+translatedDate: "2026-02-23"
 source: "Level-Up Series"
 sourceUrl: "https://gu-log.vercel.app/posts/levelup-20260223-10-url-journey-browser-internals"
 summary: "You type a URL and press Enter every day, but what actually happens in between? This post uses gu-log as a real-world case study to walk you through 7 floors — from DNS to Service Worker — covering the full journey of a URL."

--- a/src/content/posts/en-levelup-20260312-11-unix-signals-process-management.mdx
+++ b/src/content/posts/en-levelup-20260312-11-unix-signals-process-management.mdx
@@ -2,6 +2,7 @@
 ticketId: "Lv-11"
 title: "Unix Signals 101 — SIGUSR1 vs SIGTERM vs SIGKILL: What Secret Codes Does Your Process Understand?"
 originalDate: "2026-03-12"
+translatedDate: "2026-03-12"
 source: "Level-Up Series"
 sourceUrl: "https://gu-log.vercel.app/posts/levelup-20260312-11-unix-signals-process-management"
 summary: "Today (2026-03-12) while managing OpenClaw Gateway, I used SIGUSR1 for config hot-reload. Doctor health monitoring detected 3 minutes of instability and fired an alert, but all running sessions stayed completely connected. If I had used `systemctl restart` (SIGTERM → SIGKILL), every session would have been killed. That difference is what we're learning today."

--- a/src/content/posts/en-sqaa-levelup-journey.mdx
+++ b/src/content/posts/en-sqaa-levelup-journey.mdx
@@ -2,6 +2,7 @@
 ticketId: "SD-3"
 title: "12 Levels in 2 Days: Learning Full-Stack Quality Metrics RPG-Style with AI"
 originalDate: "2026-02-13"
+translatedDate: "2026-02-13"
 source: "ShroomDog Internal Tech Share"
 sourceUrl: "https://gu-log.vercel.app/posts/sqaa-levelup-journey"
 summary: "A Tech Lead uses his own blog as a training ground, spending two days learning 12 quality metrics with an AI tutor using RPG-style Level-Up teaching — from npm audit to LLM-as-Judge — while sub-agents implement everything in parallel. The real takeaway isn't the metrics, but a replicable methodology for AI-assisted learning."

--- a/src/content/posts/levelup-20260213-01-oauth-complete-guide.mdx
+++ b/src/content/posts/levelup-20260213-01-oauth-complete-guide.mdx
@@ -2,6 +2,7 @@
 ticketId: "Lv-01"
 title: "OAuth 2.0 完全攻略：從 API Key 到 GitHub Login"
 originalDate: "2026-02-13"
+translatedDate: "2026-02-13"
 source: "Level-Up 系列"
 sourceUrl: "https://gu-log.vercel.app/posts/levelup-20260213-01-oauth-complete-guide"
 summary: "用 RPG 爬塔風格學 OAuth 2.0。從 API Key 出發，一路打到 GitHub OAuth + JWT。每層樓都有互動 Quiz，答對才能上樓！"

--- a/src/content/posts/levelup-20260213-02-opensource-ai-collaboration.mdx
+++ b/src/content/posts/levelup-20260213-02-opensource-ai-collaboration.mdx
@@ -2,6 +2,7 @@
 ticketId: "Lv-02"
 title: "開源 AI 協作系統設計：從 BYOK 到 PR-based 編輯"
 originalDate: "2026-02-13"
+translatedDate: "2026-02-13"
 source: "Level-Up 系列"
 sourceUrl: "https://gu-log.vercel.app/posts/levelup-20260213-02-opensource-ai-collaboration"
 summary: "用 RPG 爬塔風格學習如何設計開源 AI 協作系統。從 Owner Only 到 BYOK、PR-based 編輯、Trust System，一步步打造安全又開放的 AI 協作平台。"

--- a/src/content/posts/levelup-20260213-03-one-domain-multi-services.mdx
+++ b/src/content/posts/levelup-20260213-03-one-domain-multi-services.mdx
@@ -2,6 +2,7 @@
 ticketId: "Lv-03"
 title: "一個 Domain，多個 API Service：從地基蓋到屋頂"
 originalDate: "2026-02-13"
+translatedDate: "2026-02-13"
 source: "Level-Up 系列"
 sourceUrl: "https://gu-log.vercel.app/posts/levelup-20260213-03-one-domain-multi-services"
 summary: "你剛進一間公司，要把 3 個 FastAPI service 塞到同一個 domain。從 DNS 地基開始，一路往上蓋 Ingress、Istio、FastAPI、Swagger，每層一張手繪風圖，搭配 PTT 說故事風格帶你搞懂整棟架構。"

--- a/src/content/posts/levelup-20260218-04-openclaw-gateway-core.mdx
+++ b/src/content/posts/levelup-20260218-04-openclaw-gateway-core.mdx
@@ -2,6 +2,7 @@
 ticketId: "Lv-04"
 title: "OpenClaw Gateway 核心：你的 AI 管家長什麼樣"
 originalDate: "2026-02-18"
+translatedDate: "2026-02-18"
 source: "Level-Up 系列"
 sourceUrl: "https://gu-log.vercel.app/posts/levelup-20260218-04-openclaw-gateway-core"
 summary: "從零開始理解 OpenClaw 架構。用 Python 人的視角，拆解 Gateway、WebSocket RPC、Session 管理、Auth 等核心概念。每層樓都有 Quiz！"

--- a/src/content/posts/levelup-20260218-05-openclaw-channels-tools.mdx
+++ b/src/content/posts/levelup-20260218-05-openclaw-channels-tools.mdx
@@ -2,6 +2,7 @@
 ticketId: "Lv-05"
 title: "OpenClaw Channels & Tools：AI 的嘴巴和手"
 originalDate: "2026-02-18"
+translatedDate: "2026-02-18"
 source: "Level-Up 系列"
 sourceUrl: "https://gu-log.vercel.app/posts/levelup-20260218-05-openclaw-channels-tools"
 summary: "拆解 OpenClaw 怎麼接 Telegram、Discord 等多平台，以及 AI 怎麼執行指令、操作瀏覽器、管理安全。Python 人看得懂的 TypeScript 架構導覽。"

--- a/src/content/posts/levelup-20260218-06-openclaw-memory-skills-automation.mdx
+++ b/src/content/posts/levelup-20260218-06-openclaw-memory-skills-automation.mdx
@@ -2,6 +2,7 @@
 ticketId: "Lv-06"
 title: "OpenClaw Memory, Skills & Automation：大腦和習慣"
 originalDate: "2026-02-18"
+translatedDate: "2026-02-18"
 source: "Level-Up 系列"
 sourceUrl: "https://gu-log.vercel.app/posts/levelup-20260218-06-openclaw-memory-skills-automation"
 summary: "拆解 OpenClaw 怎麼記住東西、怎麼學新技能、怎麼自動執行任務。從 Embedding 到 Cron Job，Python 人也能懂的 AI 記憶與自動化系統。"

--- a/src/content/posts/levelup-20260218-07-openclaw-testing.mdx
+++ b/src/content/posts/levelup-20260218-07-openclaw-testing.mdx
@@ -2,6 +2,7 @@
 ticketId: "Lv-07"
 title: "OpenClaw Testing：AI 時代的品質保證"
 originalDate: "2026-02-18"
+translatedDate: "2026-02-18"
 source: "Level-Up 系列"
 sourceUrl: "https://gu-log.vercel.app/posts/levelup-20260218-07-openclaw-testing"
 summary: "1,086 個 test 的背後哲學。為什麼 AI 時代 test 比 code review 更重要？怎麼用 test 當規格書？Tech Lead 的核心技能轉變。"

--- a/src/content/posts/levelup-20260221-08-openclaw-health-suite.mdx
+++ b/src/content/posts/levelup-20260221-08-openclaw-health-suite.mdx
@@ -2,6 +2,7 @@
 ticketId: "Lv-08"
 title: "OpenClaw Health Suite（上）：從 36 小時故障到自動健檢"
 originalDate: "2026-02-21"
+translatedDate: "2026-02-21"
 source: "Level-Up 系列"
 sourceUrl: "https://gu-log.vercel.app/posts/levelup-20260221-08-openclaw-health-suite"
 summary: "這篇先拆『為什麼要 Health Suite』與『怎麼提早偵測』。從 36 小時 restart storm 事故，走到 healthcheck + watchdog 的診斷防線。"

--- a/src/content/posts/levelup-20260221-09-openclaw-rollback-sop-drills.mdx
+++ b/src/content/posts/levelup-20260221-09-openclaw-rollback-sop-drills.mdx
@@ -2,6 +2,7 @@
 ticketId: "Lv-09"
 title: "OpenClaw Health Suite（下）：Rollback、SOP 與故障演練"
 originalDate: "2026-02-21"
+translatedDate: "2026-02-21"
 source: "Level-Up 系列"
 sourceUrl: "https://gu-log.vercel.app/posts/levelup-20260221-09-openclaw-rollback-sop-drills"
 summary: "Lv-09 接續 Lv-08，下半場專講 Recover Layer。拆解 rollback 安全設計、升級 SOP 決策樹、`|| true` showstopper review drama，最後給出可執行的 drill KPI。"

--- a/src/content/posts/levelup-20260223-10-url-journey-browser-internals.mdx
+++ b/src/content/posts/levelup-20260223-10-url-journey-browser-internals.mdx
@@ -2,6 +2,7 @@
 ticketId: "Lv-10"
 title: "一個 URL 的旅程 — 從你按 Enter 到畫面出現，瀏覽器到底在幹嘛"
 originalDate: "2026-02-23"
+translatedDate: "2026-02-23"
 source: "Level-Up 系列"
 sourceUrl: "https://gu-log.vercel.app/posts/levelup-20260223-10-url-journey-browser-internals"
 summary: "你每天打網址、按 Enter，但中間到底發生了什麼事？這篇用 gu-log 當案例，從 DNS 到 Service Worker，7 個 Floor 帶你走完一個 URL 的完整旅程。"

--- a/src/content/posts/levelup-20260312-11-unix-signals-process-management.mdx
+++ b/src/content/posts/levelup-20260312-11-unix-signals-process-management.mdx
@@ -2,6 +2,7 @@
 ticketId: "Lv-11"
 title: "Unix Signals 101 — SIGUSR1 vs SIGTERM vs SIGKILL，你的 Process 聽得懂哪些暗號？"
 originalDate: "2026-03-12"
+translatedDate: "2026-03-12"
 source: "Level-Up 系列"
 sourceUrl: "https://gu-log.vercel.app/posts/levelup-20260312-11-unix-signals-process-management"
 summary: "今天（2026-03-12）在管理 OpenClaw Gateway 時，用 SIGUSR1 做 config hot-reload。Doctor 健康監控偵測到 3 分鐘的不穩定發了 alert，但所有 running sessions 完全沒斷。如果用的是 `systemctl restart`（SIGTERM → SIGKILL），所有 session 都會被殺掉。這個差異就是今天要教的。"

--- a/src/content/posts/sqaa-levelup-journey.mdx
+++ b/src/content/posts/sqaa-levelup-journey.mdx
@@ -2,6 +2,7 @@
 ticketId: "SD-3"
 title: "兩天打完 12 關：用 RPG 風格跟 AI 學全棧品質指標"
 originalDate: "2026-02-13"
+translatedDate: "2026-02-13"
 source: "ShroomDog 內部技術分享"
 sourceUrl: "https://gu-log.vercel.app/posts/sqaa-levelup-journey"
 summary: "Tech Lead 用自己的部落格當練兵場，花兩天跟 AI 助手用 Level-Up 互動教學打完 12 關品質指標，從 npm audit 到 LLM-as-Judge，同時讓 sub-agents 平行實作。學到的不只是指標，還有一套可複製的 AI 輔助學習方法論。"


### PR DESCRIPTION
## Summary

- Make `translatedDate` required in both the Astro Zod schema and `validate-posts.mjs`. Now `astro check` and the pre-commit hook both block any new post that omits it.
- Switch tribunal dispatch (both `tribunal-quota-loop.sh` and `tribunal-batch-runner.sh`) to sort by frontmatter `translatedDate` newest-first. Previously sorted by filename (`sort -V`), which grouped all `sp-*` before all `sd-*` before all `cp-*` and stranded slug-only files (no `YYYYMMDD` in filename) at the end.
- Backfill the 21 posts that were missing `translatedDate` (11 levelup + 1 sqaa zh-tw, 9 en- siblings). They're all originals, so `translatedDate = originalDate` for each.
- Gitignore `*.tmp.md` handoff notes and runtime coordination files (`.score-loop/{progress,push}.lock`, `.score-loop/state/`, `.score-loop/claims/`, `.score-loop/control/`).

## Why

User: "按檔名內嵌日期欄位：sp-180-20260423-slug 裡的 20260423。不是所有檔案都有（sp-56-zuozizhen 就沒）… so we will add proper 日期欄位 for all posts, make sure the script will work. Meanwhile, let's add pre-commit hook to make sure each posts will have a first-written time."

Turned out the field already existed (`translatedDate` in frontmatter, 484/496 zh-tw posts had it). Filling the gap and promoting the field to required was simpler than adding a new `firstWritten` field.

## Test plan

- [x] `node scripts/validate-posts.mjs` — 942 files, 0 errors, 220 pre-existing warnings
- [x] `pnpm exec astro check` — 0 errors, 0 warnings, 15 pre-existing hints
- [x] Negative: strip `translatedDate` from one file → validator reports `❌ Missing required field: translatedDate` (restored after)
- [x] `bash scripts/tribunal-batch-runner.sh --dry-run` — top 10 is now newest-first by date, mixed across series (sp-180, sp-179, sp-178, sp-176, sd-21, sd-20, clawd-picks, sp-175, cp-300, sp-174)
- [ ] VPS: drain tribunal-loop.service, pull, restart with 5 workers, confirm dispatch order

🤖 Generated with [Claude Code](https://claude.com/claude-code)