### PR TITLE
fix(tribunal): rc=2 redispatch loop + MemoryMax bump after 2026-04-24 OOM

### DIFF
--- a/scripts/tribunal-all-claude.sh
+++ b/scripts/tribunal-all-claude.sh
@@ -67,7 +67,19 @@ if ! flock -n 200; then
 fi
 
 # ─── Progress Tracking ────────────────────────────────────────────────────────
-PROGRESS_FILE="$ROOT_DIR/scores/tribunal-progress.json"
+# Phase 2 (tribunal-safe-parallelism): supervisor runs in the main repo and
+# exports PROGRESS_FILE pointing at the shared progress file there; workers
+# run in isolated worktrees. Without the fallback, this line unconditionally
+# clobbers the export with the WORKTREE's local path, so per-worker
+# init_article_progress / mark_article_* writes land in the wrong file. The
+# main repo's progress.json only refreshes via `git pull`, and whenever that
+# pull warns-and-continues (dirty tree, rebase conflict) the supervisor's
+# get_unscored_articles() keeps re-dispatching articles a worker already
+# marked EXHAUSTED — producing the tight re-dispatch loop that filled the
+# 2 GB cgroup and OOM-killed tribunal-loop.service on 2026-04-24 01:03:59.
+# Honor the exported env so shared flock + shared file + shared commit path
+# all line up.
+PROGRESS_FILE="${PROGRESS_FILE:-$ROOT_DIR/scores/tribunal-progress.json}"
 
 ensure_progress_file() {
   mkdir -p "$(dirname "$PROGRESS_FILE")"

--- a/scripts/tribunal-loop.service
+++ b/scripts/tribunal-loop.service
@@ -24,10 +24,16 @@ TimeoutStopSec=3600
 # Resource limits — tuned for --workers 5 (5 parallel tribunal-all-claude.sh
 # subprocesses, each spawning a claude CLI judge + optional pnpm build).
 # CPUQuota 200% lets bursts of concurrent builds use multiple cores without
-# starving each other; MemoryMax 2G covers peak (5 × ~150MB worker +
-# supervisor + shared helpers) with headroom for pnpm node_modules caching.
+# starving each other.
+#
+# MemoryMax 4G (bumped 2026-04-24, PR #158): previous 2G cap OOM-killed
+# tribunal-loop.service at 01:03:59 when 5 workers concurrently ran
+# tribunal-writer + pnpm build. Each worker peaks ~400MB, supervisor + shared
+# state another ~200MB, combined ~2.2G exceeds 2G. VM has 7.6 GB total;
+# 4G for tribunal leaves ~3.5 GB for OpenClaw agents + hermes gateway +
+# system overhead.
 CPUQuota=200%
-MemoryMax=2G
+MemoryMax=4G
 
 # Logging
 StandardOutput=journal


### PR DESCRIPTION
## Summary

2026-04-24 01:03:59 `tribunal-loop.service` 被 `MemoryMax=2G` cgroup OOM-killed。追到兩件事，一起修：

1. **rc=2 redispatch tight loop**（commit 1）— 真正的罪魁。worker 把 progress.json 更新寫到自己 worktree 那份、不是 shared 那份，main repo 的 supervisor 看不到 EXHAUSTED 狀態，同一篇文章每 20-30 秒被重派，5 個 worker 同時燒爆記憶體
2. **MemoryMax 2G 其實也真的太緊**（commit 2）— 哪怕 rc=2 修了，5-worker × opus-4-6[1m] × 同時 pnpm build 的 peak 會接近 2G；加頭皮到 4G 安全

## Commit 1: `fix(tribunal): honor exported PROGRESS_FILE` (`d57e2dbb`)

### 根本原因

`scripts/tribunal-all-claude.sh:70` 原本寫：

```bash
PROGRESS_FILE="$ROOT_DIR/scores/tribunal-progress.json"
```

Phase 2 safe-parallelism 之後，worker 跑在隔離 worktree（`~/clawd/projects/gu-log-worker-<id>`）。Supervisor 透過 env var 傳遞 shared coordinates：

```bash
# tribunal-quota-loop.sh spawn_worker
export PROGRESS_FILE="$ROOT_DIR/scores/tribunal-progress.json"  # main repo
export TRIBUNAL_MAIN_REPO="$ROOT_DIR"
export RC_ROOT_DIR="$ROOT_DIR"
```

但 worker 那行 **unconditional assignment** 直接 clobbered supervisor 的 export，改回指向 worker 自己的 worktree。結果：

- `init_article_progress` / `mark_article_*` 的 jq 寫入落在 worker worktree 的 progress.json
- `commit_progress` 做 `cd $TRIBUNAL_MAIN_REPO` 後 `git add $PROGRESS_FILE`，但 PROGRESS_FILE 仍指向 worker worktree 外的路徑 → `git add` silent no-op
- commit 沒內容、沒 push
- Main repo 的 progress.json 只能靠 supervisor 每次 iteration `git pull --rebase` 才更新
- clawd-vm main worktree 有 ~22 個 in-flight tribunal rewrite（graceful-run-control handoff 的 known loose end），`git pull` 常常 warn-and-continue
- → EXHAUSTED 寫入永遠飄不回 supervisor 眼裡
- `get_unscored_articles()` 只 filter PASS / EXHAUSTED，看不到就不停重派
- 每次重派又跑一次 init_article_progress → attempts bump → 超過 MAX_TOP_ATTEMPTS=5 → rc=2 再 fail
- 5 個 worker 同時在 3-4 篇卡死文章上迴圈 → 吃爆 cgroup 2G cap → OOM

### Fix

```bash
PROGRESS_FILE="${PROGRESS_FILE:-$ROOT_DIR/scores/tribunal-progress.json}"
```

- 有 export（supervisor 呼叫）→ 用 shared 那份
- 沒 export（standalone `bash scripts/tribunal-all-claude.sh <slug>`）→ fallback 回 worktree-local

flock 本來就用 `RC_PROGRESS_LOCK`（經 `RC_ROOT_DIR` 解析 shared 路徑），所以改 `PROGRESS_FILE` 自動對齊。不必動 `commit_progress`、`init_article_progress`、flock 任何一個。

### 驗證計畫

- Bash syntax: `bash -n` ✓
- 沒 unit test harness（純 shell）
- Deploy 後監測：`.score-loop/logs/tribunal-quota-loop-*.log` 不再有同一 slug 的 20 秒內重派 + `failed (rc=2)` pattern

## Commit 2: `chore(tribunal-loop): bump MemoryMax 2G → 4G` (`4c303d3f`)

### 為什麼要加

即使 rc=2 bug 修掉，2G 對 5-worker × opus-4-6[1m] × 同時 pnpm build 還是太緊。OOM 時實測：

- idle + 5 dispatched workers: ~700 MB
- 中階段並行 tribunal-writer + pnpm build: 逼近 2.0G
- Peak at OOM: 剛好 2.0G（cgroup 強制天花板）

### 新 budget 對照 VM 7.6 GB：

| 項目 | 預計 RAM |
|---|---|
| tribunal cap (new) | **4.0 GB** |
| OpenClaw agents (Home / gu-write / gu-issues × ~250 MB) | ~1.0 GB |
| hermes gateway | ~600 MB |
| 系統 / kernel | ~500 MB |
| Slack（spike / buff cache） | ~1.5 GB |
| **合計** | **~7.6 GB** |

4G 是 free 的一半，留給其他服務的空間夠。

### 驗證背景

VM 有 7 個 orphan `claude` processes（PPID=1、Sleeping 9-16 天、無 listening socket、無 established connection、cmdline 只有 `claude`），佔 ~1.7 GB — 已經清掉。清完 `MemAvailable` 從 2.0 GB 跳到 4.0 GB，4G cap 才有意義。

### Deploy

```bash
# on clawd-vm
cp scripts/tribunal-loop.service ~/.config/systemd/user/tribunal-loop.service
systemctl --user daemon-reload
systemctl --user restart tribunal-loop
```

`restart` 會先 drain 現有 article（`TimeoutStopSec=3600`）再起新 unit — 安全。

## Post-merge deploy order

1. Merge PR（或先 squash 後 merge）
2. SSH to clawd-vm → `cd ~/clawd/projects/gu-log && git pull`
3. `cp scripts/tribunal-loop.service ~/.config/systemd/user/...`
4. `systemctl --user daemon-reload`
5. `systemctl --user restart tribunal-loop`
6. Supervisor 自動 `tribunal-worker-bootstrap.sh sync` → worker worktrees 吃到這兩個修
7. 監測 15 分鐘，確認：
   - `systemctl --user is-active` = active
   - `free -h` Used 不再爬過 4G
   - log 沒有同一 slug 20 秒內重派

## Test plan

- [x] `bash -n` 過
- [x] 兩個改動都是 surgical，沒動共用路徑
- [ ] VM deploy 後監測（留 PR 描述作 deploy checklist）

🤖 Generated with [Claude Code](https://claude.com/claude-code)