### PR TITLE
chore(tribunal-loop): switch to --workers 1 for overnight

### DIFF
--- a/scripts/tribunal-loop.service
+++ b/scripts/tribunal-loop.service
@@ -5,7 +5,7 @@ After=network-online.target
 [Service]
 Type=simple
 WorkingDirectory=%h/clawd/projects/gu-log
-ExecStart=/bin/bash %h/clawd/projects/gu-log/scripts/cc-tribunal-loop-wrapper.sh --workers 5
+ExecStart=/bin/bash %h/clawd/projects/gu-log/scripts/cc-tribunal-loop-wrapper.sh --workers 1
 Restart=on-failure
 RestartSec=60
 Environment=TZ=Asia/Taipei
@@ -21,17 +21,17 @@ KillSignal=SIGTERM
 # write. Allow up to 60min before SIGKILL.
 TimeoutStopSec=3600
 
-# Resource limits — tuned for --workers 5 (5 parallel tribunal-all-claude.sh
-# subprocesses, each spawning a claude CLI judge + optional pnpm build).
-# CPUQuota 200% lets bursts of concurrent builds use multiple cores without
-# starving each other.
+# Resource limits — sized for --workers 1 (overnight / light mode).
+# A single worker peaks ~400MB (tribunal-writer + pnpm build + claude CLI),
+# supervisor + shared state ~200MB. 4G cap kept (rather than shrinking to
+# 1G or 2G) so scaling back up to 2–5 workers via `--workers N` only needs
+# the ExecStart line flipped, no unit-level retuning. CPUQuota 200% also
+# kept for the same reason; a single worker won't burn more than ~50%
+# steady-state anyway.
 #
-# MemoryMax 4G (bumped 2026-04-24, PR #158): previous 2G cap OOM-killed
-# tribunal-loop.service at 01:03:59 when 5 workers concurrently ran
-# tribunal-writer + pnpm build. Each worker peaks ~400MB, supervisor + shared
-# state another ~200MB, combined ~2.2G exceeds 2G. VM has 7.6 GB total;
-# 4G for tribunal leaves ~3.5 GB for OpenClaw agents + hermes gateway +
-# system overhead.
+# History: MemoryMax was bumped from 2G → 4G in PR #159 (2026-04-24) after
+# a 5-worker OOM kill on the 2G cap; the root cause (rc=2 tight re-dispatch
+# loop) is also fixed in that PR. The 4G headroom stays.
 CPUQuota=200%
 MemoryMax=4G
 


### PR DESCRIPTION
## Summary

把 `tribunal-loop.service` ExecStart 的 `--workers 5` 改成 `--workers 1`，overnight 輕量模式。

## Why

Post PR #159 的 OOM 事件 + rc=2 redispatch fix 之後，ShroomDog 想用 1 worker 跑整晚。單 worker 優點：

- 記憶體峰值可預測（~600 MB vs 5-worker 的 2+ GB）
- 一條 log tail 就能看全 — 半夜沒人盯也好 debug
- 對 VM 其他 service（OpenClaw agents、hermes-gateway）更友善

## What Changes

| 項目 | 舊 | 新 |
|---|---|---|
| `ExecStart` | `--workers 5` | `--workers 1` |
| `MemoryMax` | `4G` | `4G`（保留，備將來 scale-up 免再調） |
| `CPUQuota` | `200%` | `200%`（同上） |
| Resource limits comment | 描述 5-worker | 描述 1-worker + 為何保留 cap |

保留 4G cap 是刻意的 — 未來如果要 scale back up，只要改 ExecStart 一行，不用再動 resource 區段。

## Deploy

```bash
ssh clawd-vm
cd ~/clawd/projects/gu-log && git pull
cp scripts/tribunal-loop.service ~/.config/systemd/user/tribunal-loop.service
systemctl --user daemon-reload
# 等 stop-graceful drain 到剩 1 個 worker 後：
systemctl --user restart tribunal-loop
systemctl --user is-active tribunal-loop  # expect: active
```

## Test plan

- [x] Bash syntax on .service is static — no test harness needed
- [ ] Post-deploy: `systemctl --user show tribunal-loop -p ExecStart` → contains `--workers 1`
- [ ] Post-deploy: `pgrep -c -f tribunal-all-claude.sh` 穩定在 0 或 1 隨時間

🤖 Generated with [Claude Code](https://claude.com/claude-code)