### PR TITLE
feat(tribunal): auto scale-down / up on memory + OOM history

### DIFF
--- a/docs/tribunal-runbook.md
+++ b/docs/tribunal-runbook.md
@@ -124,6 +124,50 @@ scripts/tribunal-worker-bootstrap.sh remove-all
 
 Disk cost: ~500MB per worker (pnpm `node_modules` per worktree). On clawd-vm (75GB, historically ~45GB used) this is fine for 2–3 workers.
 
+## Auto scale-down / up (memory throttle)
+
+When `--workers > 1`, the supervisor samples its own cgroup memory each loop
+iteration and adjusts a soft cap on the active worker count. Keeps the
+service from OOM-killing itself when five parallel `pnpm build`s burst.
+
+**Decision ladder** (per iteration):
+
+| Signal | Action |
+|---|---|
+| `oom-kill` event in journal within 10min | Hard-cap `worker-limit` to 2 |
+| MemoryCurrent ≥ 85% of MemoryMax | Step `worker-limit` down by 1 (floor 1) |
+| MemoryCurrent < 50% for 5 consecutive samples | Step `worker-limit` up by 1 (ceiling `$WORKERS`) |
+| 50–84% | No change (hysteresis band to avoid flapping) |
+
+**Plus a spawn pre-check**: before forking a new worker, the supervisor
+estimates `MemoryCurrent + 400MB` — if that would cross 85%, the spawn is
+held for one iteration. Protects against fork-time bursts that a 30s
+sampling cadence can't catch in time.
+
+**Observability**:
+
+```bash
+# Current effective limit + last scaling event
+cat .score-loop/state/autoscale.json
+# { effective_workers, configured_workers, memory_pct, last_reason, updatedAt }
+
+# Recent autoscale events in the supervisor log
+ls -t .score-loop/logs/tribunal-quota-loop-*.log | head -1 | xargs grep 'AUTOSCALE:'
+```
+
+**Operator override**: planning a planned burn that you want to run hot
+without autoscale interference? Pin the limit manually:
+
+```bash
+echo 5 > .score-loop/control/worker-limit   # peg at 5, autoscaler still
+                                            # writes over this if OOM or
+                                            # memory crosses scale-down
+```
+
+The autoscaler treats the file as a read-with-floor source: it respects any
+integer `<= $WORKERS`. Delete the file to fall back to the `$WORKERS` CLI
+arg. Tune thresholds in `tribunal-quota-loop.sh` (search `AUTOSCALE_*`).
+
 ## Quota tiers
 
 From `tribunal-quota-loop.sh`:

--- a/scripts/tribunal-quota-loop.sh
+++ b/scripts/tribunal-quota-loop.sh
@@ -69,6 +69,192 @@ source "$SCRIPT_DIR/tribunal-run-control.sh"
 trap 'rc_on_stop_signal TERM' TERM
 trap 'rc_on_stop_signal INT' INT
 
+# ─── Auto scale-down / up ────────────────────────────────────────────────────
+# Memory-aware worker throttling. Runs only when WORKERS > 1.
+#
+# Decision ladder each loop iteration:
+#   1. Recent oom-kill in journal        → hard-cap limit at AUTOSCALE_OOM_CAP
+#   2. memory pct ≥ SCALE_DOWN_PCT       → step limit down by 1 (floor: 1)
+#   3. memory pct < SCALE_UP_PCT for N   → step limit up by 1 (ceiling: $WORKERS)
+#      consecutive samples
+#   4. between those thresholds          → no-op (hysteresis band)
+#
+# Plus a spawn pre-check: when the supervisor is about to fork a new worker,
+# it estimates current + PER_WORKER_MB and refuses to fork if that would
+# cross SCALE_DOWN_PCT. Protects against fork-time memory bursts that a
+# 30s sampling cadence can't catch in time.
+#
+# Operator overrides: writing an integer to .score-loop/control/worker-limit
+# pins the limit regardless of memory (e.g., for planned burn runs). The
+# autoscaler respects any value <= $WORKERS and ignores out-of-range garbage.
+#
+# Local dev: set AUTOSCALE_MOCK_MEMORY_CURRENT / AUTOSCALE_MOCK_MEMORY_MAX /
+# AUTOSCALE_MOCK_OOM to simulate production conditions on Mac (no systemd).
+AUTOSCALE_SCALE_DOWN_PCT=85
+AUTOSCALE_SCALE_UP_PCT=50
+AUTOSCALE_UP_SAMPLES=5
+AUTOSCALE_OOM_COOLDOWN_SEC=600
+AUTOSCALE_OOM_CAP=2
+AUTOSCALE_PER_WORKER_MB=400
+AUTOSCALE_CONTROL_FILE="$ROOT_DIR/.score-loop/control/worker-limit"
+AUTOSCALE_STATE_FILE="$ROOT_DIR/.score-loop/state/autoscale.json"
+AUTOSCALE_LOW_MEM_STREAK=0
+
+autoscale_memory_current() {
+  if [ -n "${AUTOSCALE_MOCK_MEMORY_CURRENT:-}" ]; then
+    echo "$AUTOSCALE_MOCK_MEMORY_CURRENT"
+    return
+  fi
+  systemctl --user show tribunal-loop -p MemoryCurrent --value 2>/dev/null \
+    | grep -E '^[0-9]+$' | head -1
+}
+
+autoscale_memory_max() {
+  if [ -n "${AUTOSCALE_MOCK_MEMORY_MAX:-}" ]; then
+    echo "$AUTOSCALE_MOCK_MEMORY_MAX"
+    return
+  fi
+  systemctl --user show tribunal-loop -p MemoryMax --value 2>/dev/null \
+    | grep -E '^[0-9]+$' | head -1
+}
+
+# Returns 0 if an oom-kill event exists within AUTOSCALE_OOM_COOLDOWN_SEC
+# of now. Best-effort on non-systemd platforms (silent false).
+autoscale_recent_oom() {
+  if [ -n "${AUTOSCALE_MOCK_OOM:-}" ]; then
+    [ "$AUTOSCALE_MOCK_OOM" = "1" ]
+    return
+  fi
+  command -v journalctl >/dev/null 2>&1 || return 1
+  journalctl --user -u tribunal-loop \
+    --since "${AUTOSCALE_OOM_COOLDOWN_SEC} sec ago" \
+    --no-pager 2>/dev/null | grep -q 'oom-kill'
+}
+
+autoscale_read_limit() {
+  if [ -f "$AUTOSCALE_CONTROL_FILE" ]; then
+    local n
+    n=$(tr -d '[:space:]' < "$AUTOSCALE_CONTROL_FILE")
+    if [[ "$n" =~ ^[1-9][0-9]*$ ]] && (( n <= WORKERS )); then
+      echo "$n"
+      return
+    fi
+  fi
+  echo "$WORKERS"
+}
+
+autoscale_write_limit() {
+  local n="$1" reason="$2"
+  mkdir -p "$(dirname "$AUTOSCALE_CONTROL_FILE")"
+  echo "$n" > "$AUTOSCALE_CONTROL_FILE"
+  tlog "AUTOSCALE: worker-limit=$n ($reason)"
+  autoscale_write_state "$n" "$reason"
+}
+
+autoscale_write_state() {
+  local limit="$1" reason="$2"
+  mkdir -p "$(dirname "$AUTOSCALE_STATE_FILE")"
+  local ts mc mx pct
+  ts=$(date -Iseconds 2>/dev/null || date -u +%Y-%m-%dT%H:%M:%SZ)
+  mc=$(autoscale_memory_current)
+  mx=$(autoscale_memory_max)
+  if [[ "$mc" =~ ^[0-9]+$ ]] && [[ "$mx" =~ ^[0-9]+$ ]] && (( mx > 0 )); then
+    pct=$(( mc * 100 / mx ))
+  else
+    pct=-1
+    mc=0; mx=0
+  fi
+  local tmp
+  tmp=$(mktemp "$(dirname "$AUTOSCALE_STATE_FILE")/.autoscale.XXXXXX") || return
+  if command -v jq >/dev/null 2>&1; then
+    jq -n \
+      --argjson limit "$limit" \
+      --argjson workers_max "$WORKERS" \
+      --argjson low_streak "$AUTOSCALE_LOW_MEM_STREAK" \
+      --argjson memory_current "$mc" \
+      --argjson memory_max "$mx" \
+      --argjson memory_pct "$pct" \
+      --arg reason "$reason" \
+      --arg ts "$ts" \
+      '{effective_workers: $limit, configured_workers: $workers_max, low_mem_streak: $low_streak, memory_current_bytes: $memory_current, memory_max_bytes: $memory_max, memory_pct: $memory_pct, last_reason: $reason, updatedAt: $ts}' \
+      > "$tmp"
+  else
+    printf '{"effective_workers":%d,"configured_workers":%d,"memory_pct":%d,"last_reason":"%s","updatedAt":"%s"}\n' \
+      "$limit" "$WORKERS" "$pct" "$reason" "$ts" > "$tmp"
+  fi
+  mv "$tmp" "$AUTOSCALE_STATE_FILE"
+}
+
+autoscale_check() {
+  (( WORKERS <= 1 )) && return 0
+
+  local mc mx pct current_limit
+  mc=$(autoscale_memory_current)
+  mx=$(autoscale_memory_max)
+
+  if ! [[ "$mc" =~ ^[0-9]+$ ]] || ! [[ "$mx" =~ ^[0-9]+$ ]] || (( mx == 0 )); then
+    return 0   # no systemd / no cgroup memory — can't autoscale, bail silently
+  fi
+
+  pct=$(( mc * 100 / mx ))
+  current_limit=$(autoscale_read_limit)
+
+  # 1. OOM hard-cap
+  if autoscale_recent_oom; then
+    if (( current_limit > AUTOSCALE_OOM_CAP )); then
+      autoscale_write_limit "$AUTOSCALE_OOM_CAP" \
+        "oom-kill within ${AUTOSCALE_OOM_COOLDOWN_SEC}s (memory=${pct}%)"
+    fi
+    AUTOSCALE_LOW_MEM_STREAK=0
+    return 0
+  fi
+
+  # 2. High memory → step down
+  if (( pct >= AUTOSCALE_SCALE_DOWN_PCT )); then
+    if (( current_limit > 1 )); then
+      autoscale_write_limit $(( current_limit - 1 )) \
+        "memory ${pct}% ≥ ${AUTOSCALE_SCALE_DOWN_PCT}%"
+    fi
+    AUTOSCALE_LOW_MEM_STREAK=0
+    return 0
+  fi
+
+  # 3. Low memory (stable) → step up
+  if (( pct < AUTOSCALE_SCALE_UP_PCT )); then
+    AUTOSCALE_LOW_MEM_STREAK=$(( AUTOSCALE_LOW_MEM_STREAK + 1 ))
+    if (( AUTOSCALE_LOW_MEM_STREAK >= AUTOSCALE_UP_SAMPLES )); then
+      if (( current_limit < WORKERS )); then
+        autoscale_write_limit $(( current_limit + 1 )) \
+          "memory ${pct}% stable < ${AUTOSCALE_SCALE_UP_PCT}% for ${AUTOSCALE_UP_SAMPLES} samples"
+      fi
+      AUTOSCALE_LOW_MEM_STREAK=0
+    fi
+    return 0
+  fi
+
+  # 4. Middle zone — hysteresis: do nothing, reset streak
+  AUTOSCALE_LOW_MEM_STREAK=0
+}
+
+# Returns 0 if forking another worker won't push memory past the scale-down
+# threshold. Estimated via current + AUTOSCALE_PER_WORKER_MB. Returns 0 if
+# memory can't be read (no blocker on non-systemd platforms).
+autoscale_can_spawn() {
+  (( WORKERS <= 1 )) && return 0
+  local mc mx projected projected_pct
+  mc=$(autoscale_memory_current)
+  mx=$(autoscale_memory_max)
+  if ! [[ "$mc" =~ ^[0-9]+$ ]] || ! [[ "$mx" =~ ^[0-9]+$ ]] || (( mx == 0 )); then
+    return 0
+  fi
+  projected=$(( mc + AUTOSCALE_PER_WORKER_MB * 1024 * 1024 ))
+  projected_pct=$(( projected * 100 / mx ))
+  if (( projected_pct > AUTOSCALE_SCALE_DOWN_PCT )); then
+    return 1
+  fi
+  return 0
+}
+
 # ─── Quota ────────────────────────────────────────────────────────────────────
 # Returns integer effective remaining pct (min of 5hr and weekly).
 # Returns -1 on error (usage-monitor unavailable or no claude entry).
@@ -333,6 +519,11 @@ tlog "  Usage monitor: ${USAGE_MONITOR}"
 ensure_worktrees
 rc_gc_stale_claims
 rc_write_state "running" "startup"
+# Seed autoscale state so operators see a baseline before the first scaling
+# event. Limit starts at $WORKERS (no throttle yet).
+if (( WORKERS > 1 )); then
+  autoscale_write_state "$WORKERS" "startup"
+fi
 
 while true; do
   # ── Stop boundary: top of iteration ──────────────────────────────────────
@@ -343,6 +534,10 @@ while true; do
       rc_exit_stopped
     fi
   fi
+
+  # ── Autoscale: read memory + OOM history, adjust worker-limit ───────────
+  autoscale_check
+  EFFECTIVE_WORKERS=$(autoscale_read_limit)
 
   # ── Git pull in main repo (workers do their own in their worktrees) ──────
   git pull --rebase origin main >> "$LOG_FILE" 2>&1 \
@@ -361,7 +556,11 @@ while true; do
   fi
 
   if [ "$TOTAL" -gt 0 ]; then
-    tlog "$TOTAL unscored articles remaining. in-flight=$IN_FLIGHT workers=$WORKERS"
+    if (( EFFECTIVE_WORKERS < WORKERS )); then
+      tlog "$TOTAL unscored articles remaining. in-flight=$IN_FLIGHT workers=$EFFECTIVE_WORKERS/$WORKERS (throttled)"
+    else
+      tlog "$TOTAL unscored articles remaining. in-flight=$IN_FLIGHT workers=$WORKERS"
+    fi
   fi
 
   # ── Check quota ────────────────────────────────────────────────────────────
@@ -420,9 +619,9 @@ while true; do
     continue
   fi
 
-  # Try to fill every free slot with a claimable article.
+  # Try to fill every free slot up to EFFECTIVE_WORKERS (autoscale-throttled).
   dispatched_this_iter=0
-  while (( ${#WORKER_PID[@]} < WORKERS )) && [ "$TOTAL" -gt 0 ]; do
+  while (( ${#WORKER_PID[@]} < EFFECTIVE_WORKERS )) && [ "$TOTAL" -gt 0 ]; do
     # Find a free worker id.
     free_id=""
     for id in "${WORKER_IDS[@]:-main}"; do
@@ -432,6 +631,14 @@ while true; do
       fi
     done
     [ -z "$free_id" ] && break
+
+    # Spawn pre-check: would adding another worker blow the memory budget?
+    # Only holds the dispatch off for this iteration — next iteration's
+    # autoscale_check will re-evaluate.
+    if ! autoscale_can_spawn; then
+      tlog "AUTOSCALE: holding spawn of worker-$free_id — projected memory would exceed ${AUTOSCALE_SCALE_DOWN_PCT}%"
+      break
+    fi
 
     # Claim + dispatch.
     if article=$(try_claim_next_article "worker-$free_id"); then


### PR DESCRIPTION
## Summary

Multi-worker supervisor now memory-aware. When `--workers > 1`:

- **OOM hard-cap**: journal shows `oom-kill` in last 10 min → cap to 2
- **High memory**: `MemoryCurrent ≥ 85% of MemoryMax` → step down by 1
- **Low memory**: `< 50%` for 5 consecutive samples → step up by 1 (up to `$WORKERS`)
- **Hysteresis band** 50–84% → no-op, avoids flapping
- **Spawn pre-check**: fork new worker only if `current + 400MB < 85%`; otherwise hold for 1 iteration (protects against 5×`pnpm build` fork-time bursts)

## Why

Yesterday's burn hit `MemoryMax=2G` → OOM loop. Other CC bumped to 4G in PR #159. This PR makes the system self-regulating so even at higher worker counts it throttles down before OOM instead of crashing, and recovers automatically when memory stabilises.

## Observability / override

```bash
cat .score-loop/state/autoscale.json         # live snapshot
grep AUTOSCALE .score-loop/logs/tribunal-quota-loop-*.log
echo 5 > .score-loop/control/worker-limit    # pin manually for planned burn
```

Runbook section added at `docs/tribunal-runbook.md#auto-scale-down--up-memory-throttle`.

## Test plan

- [x] `bash -n` syntax check — clean
- [x] Unit tests (9/9): scale down at 90%, middle-zone no-op, 5-sample step-up, OOM cap, spawn pre-check at 70% vs 80%, `WORKERS=1` no-op, operator override file respected
- [x] Mac dry-run (no systemd) — autoscale helpers return early cleanly
- [ ] VPS: first real memory sample + scaling event visible in supervisor log

## Files

- `scripts/tribunal-quota-loop.sh` — helpers + main loop hook + spawn pre-check
- `docs/tribunal-runbook.md` — new "Auto scale-down / up" section with decision table

🤖 Generated with [Claude Code](https://claude.com/claude-code)