### PR TITLE
fix(tribunal): programmatic model stamping + all judges → opus-4.7

### DIFF
--- a/.claude/agents/fresh-eyes.md
+++ b/.claude/agents/fresh-eyes.md
@@ -1,6 +1,6 @@
 ---
 description: "Fresh Eyes — fast first-impression reader. Reads the post as a complete stranger with zero blog context. Catches things the specialized judges miss: confusing structure, unclear jargon, boring stretches, cringe moments. Quick and blunt."
-model: claude-opus-4-6[1m]
+model: claude-opus-4-7
 tools:
   - Read
   - Write

--- a/.claude/agents/librarian.md
+++ b/.claude/agents/librarian.md
@@ -1,6 +1,6 @@
 ---
 description: "Librarian — knowledge curator that ensures posts are well-connected to the gu-log knowledge base. Checks glossary term coverage, internal cross-references, sourceUrl alignment, and attribution quality. Use this to catch missing links, unlinked glossary terms, and broken references."
-model: claude-opus-4-6[1m]
+model: claude-opus-4-7
 tools:
   - Read
   - Write

--- a/.claude/agents/v2-fresh-eyes-judge.md
+++ b/.claude/agents/v2-fresh-eyes-judge.md
@@ -1,6 +1,6 @@
 ---
 description: "Tribunal v2 Stage 2 — Fresh Eyes Judge. First-impression reader with 3-month dev persona. Scores readability and firstImpression. Pass bar: composite >= 8. Blunt, fast, gut-reaction scoring. v2 output format (BaseJudgeOutput)."
-model: claude-opus-4-6[1m]
+model: claude-opus-4-7
 tools:
   - Read
 ---
@@ -55,7 +55,7 @@ Return JSON matching `FreshEyesJudgeOutput` from `src/lib/tribunal-v2/types.ts`:
     "firstImpression": 8
   },
   "composite": 8,
-  "judge_model": "claude-opus-4-6",
+  "judge_model": "claude-opus-4-7",
   "judge_version": "2.0.0",
   "timestamp": "2026-04-14T12:00:00Z"
 }
@@ -71,7 +71,7 @@ On FAIL, also include:
     "readability": "Paragraph 4 dumps 3 jargon terms (tokenizer, embedding, context window) with zero explanation. I had to Google all three."
   },
   "critical_issues": ["Jargon-heavy middle section assumes expert knowledge"],
-  "judge_model": "claude-opus-4-6",
+  "judge_model": "claude-opus-4-7",
   "judge_version": "2.0.0",
   "timestamp": "2026-04-14T12:00:00Z"
 }

--- a/.claude/agents/v2-worthiness-judge.md
+++ b/.claude/agents/v2-worthiness-judge.md
@@ -1,6 +1,6 @@
 ---
 description: "Tribunal v2 Stage 0 — Worthiness Gate judge. Evaluates if an article is worth running through the full pipeline. All-WARN mode (never auto-rejects). Outputs dual reasoning: internal_reason for tuning + reader_friendly_reason for UI banner. Use this as the first gate before the tribunal pipeline."
-model: claude-opus-4-6[1m]
+model: claude-opus-4-7
 tools:
   - Read
   - Glob
@@ -67,7 +67,7 @@ Return a JSON object matching `WorthinessJudgeOutput` from `src/lib/tribunal-v2/
   "composite": 8,
   "internal_reason": "Full technical analysis here — model choices, source quality assessment, potential issues. This is for pipeline tuning, be detailed and honest.",
   "reader_friendly_reason": "一行中文，150 字以內。給讀者看的。例：「這篇的核心觀點很有趣，但展開深度可能不夠」",
-  "judge_model": "claude-opus-4-6",
+  "judge_model": "claude-opus-4-7",
   "judge_version": "2.0.0",
   "timestamp": "2026-04-11T12:00:00Z"
 }

--- a/scripts/tribunal-all-claude.sh
+++ b/scripts/tribunal-all-claude.sh
@@ -312,7 +312,7 @@ run_stage() {
     # ── Invoke judge (timeout 300s / 5 min) ──────────────────────────────────
     local judge_out
     judge_out="$(mktemp)"
-    tlog "  Invoking agent '$agent_name' (timeout 300s)..."
+    tlog "  Invoking agent '$agent_name' --model '$model_id' (timeout 300s)..."
 
     local judge_rc=0
     local -a judge_cmd=(timeout 300 claude -p --agent "$agent_name" --dangerously-skip-permissions)
@@ -361,11 +361,19 @@ Write your JSON result to: $score_tmp" \
 
       # ── Write score to post frontmatter (tribunal badge) ──
       if [ -n "$fm_judge_key" ]; then
-        local fm_score_json fm_model
-        fm_model="$(jq -r '.judge_model // empty' "$score_tmp")"
-        [ -z "$fm_model" ] && fm_model="claude-${model_label}"
+        local fm_score_json fm_model judge_reported_model
+        # Programmatic model — never trust judge self-report (judges hallucinate their own model ID)
+        fm_model="$model_id"
+        judge_reported_model="$(jq -r '.judge_model // empty' "$score_tmp")"
+        if [ -n "$judge_reported_model" ]; then
+          if [ "$judge_reported_model" != "$fm_model" ]; then
+            tlog "  WARN: Model mismatch — expected=$fm_model, judge_self_report=$judge_reported_model"
+          else
+            tlog "  Model confirmed: judge agrees with expected=$fm_model"
+          fi
+        fi
         fm_score_json="$(jq --arg model "$fm_model" '. + {model: $model}' "$score_tmp")"
-        tlog "  Writing $fm_judge_key score to frontmatter..."
+        tlog "  Writing $fm_judge_key score to frontmatter (model=$fm_model)..."
         if write_score_to_frontmatter "$post_path" "$fm_judge_key" "$fm_score_json"; then
           tlog "  Frontmatter updated for $fm_judge_key."
         else
@@ -534,9 +542,9 @@ tlog "=== tribunal-all-claude.sh: $POST_FILE ==="
 # Format: stage_key:agent_name:validate_name:label:max_loops:model_label:fm_judge_key
 # fm_judge_key = frontmatter scores key (used by frontmatter-scores.mjs)
 declare -a STAGES=(
-  "librarian:librarian:librarian:Librarian:2:opus-4.6:librarian"
+  "librarian:librarian:librarian:Librarian:2:opus-4.7:librarian"
   "factChecker:fact-checker:fact-checker:FactChecker:2:opus-4.7:factCheck"
-  "freshEyes:fresh-eyes:fresh-eyes:FreshEyes:2:opus-4.6:freshEyes"
+  "freshEyes:fresh-eyes:fresh-eyes:FreshEyes:2:opus-4.7:freshEyes"
   "vibe:vibe-opus-scorer:vibe-opus-scorer:VibeScorer:3:opus-4.6-1m:vibe"
 )
 


### PR DESCRIPTION
## Summary

- **Root cause**: SP-180 tribunal scores 顯示錯誤的 model（librarian=sonnet-4-6, fresh-eyes=haiku-4-5, vibe=opus-4-7），因為 frontmatter 的 model 欄位來自 judge 的 `judge_model` 自報（LLM introspection），不可靠。
- **Fix**: model 改為由 script 程式化寫入（`$model_id` from STAGES config），不再信任 judge JSON 的 `judge_model`。judge 自報仍會 log 用於 mismatch 偵測。
- **Config**: librarian + freshEyes 改為 `opus-4.7`；vibe 維持 `opus-4.6-1m`（pinned）；writer 維持 `opus-4.6[1m]`。
- **Observability**: invocation 時 log `--model` flag、model mismatch warning、frontmatter write confirmation 都有 model 資訊。

## Changed files

| File | Change |
|------|--------|
| `scripts/tribunal-all-claude.sh` | Programmatic model write + STAGES update + observability |
| `.claude/agents/librarian.md` | model: opus-4-6[1m] → opus-4-7 |
| `.claude/agents/fresh-eyes.md` | model: opus-4-6[1m] → opus-4-7 |
| `.claude/agents/v2-fresh-eyes-judge.md` | model + example judge_model aligned |
| `.claude/agents/v2-worthiness-judge.md` | model + example judge_model aligned |

## Test plan

- [ ] SP-180 之後的新文章 tribunal 應該全部顯示正確 model
- [ ] 確認 frontmatter 的 model 來自 script config 而非 judge 自報
- [ ] 確認 mismatch warning 會出現在 tribunal log（如果 judge 自報不同）
- [ ] VPS worker worktrees 需要 sync（`scripts/tribunal-worker-bootstrap.sh sync`）

## Note

SP-180 的 frontmatter 沒有手動修正（因為分數確實是 sonnet/haiku 產的，改 model label 反而是說謊）。如果要用正確 model 重新評分，需要清除 SP-180 的 scores 後重跑 tribunal。

🤖 Generated with [Claude Code](https://claude.com/claude-code)