### PR TITLE
Add SP-181: Multi-Agent 十個月後的誠實報告 (Walden Yan / Cognition)

### DIFF
--- a/scripts/article-counter.json
+++ b/scripts/article-counter.json
@@ -5,7 +5,7 @@
     "description": "Original articles written by ShroomDog"
   },
   "SP": {
-    "next": 181,
+    "next": 182,
     "label": "ShroomDog Picks",
     "description": "Articles picked by ShroomDog, translated by Clawd"
   },

--- a/src/content/posts/en-sp-181-20260423-walden-cognition-multi-agents-working.mdx
+++ b/src/content/posts/en-sp-181-20260423-walden-cognition-multi-agents-working.mdx
@@ -9,7 +9,7 @@ translatedBy:
 source: "@walden_yan on X (Walden Yan, Cognition co-founder)"
 sourceUrl: "https://x.com/walden_yan/status/2047054401341370639"
 lang: "en"
-summary: "Ten months ago Cognition's Walden Yan wrote Don't Build Multi-Agents, telling most people to back off. This time he returns with three patterns that actually ship — Devin Review's clean-context loop (2 bugs per PR, ~58% severe), cross-frontier smart friends, and manager Devin's map-reduce-and-manage. One principle runs through all three: writes stay single-threaded, other agents contribute intelligence, not actions."
+summary: "Ten months after writing Don't Build Multi-Agents, Cognition's Walden Yan returns with three patterns that actually ship: Devin Review's clean-context loop (2 bugs per PR, ~58% severe), cross-frontier smart friends, and manager Devin's map-reduce-and-manage. One principle runs through all three — writes stay single-threaded; other agents contribute intelligence, not actions."
 tags: ["multi-agent", "agent-engineering", "cognition", "devin", "context-engineering"]
 ---
 

--- a/src/content/posts/en-sp-181-20260423-walden-cognition-multi-agents-working.mdx
+++ b/src/content/posts/en-sp-181-20260423-walden-cognition-multi-agents-working.mdx
@@ -1,0 +1,170 @@
+---
+ticketId: "SP-181"
+title: "The Honest Multi-Agent Report, 10 Months Later — Cognition's Walden: Keep Writes Single-Threaded, Let Other Agents Pour In Intelligence"
+originalDate: "2026-04-22"
+translatedDate: "2026-04-23"
+translatedBy:
+  model: "Opus 4.7"
+  harness: "Claude Code"
+source: "@walden_yan on X (Walden Yan, Cognition co-founder)"
+sourceUrl: "https://x.com/walden_yan/status/2047054401341370639"
+lang: "en"
+summary: "Ten months ago Cognition's Walden Yan wrote Don't Build Multi-Agents, telling most people to back off. This time he returns with three patterns that actually ship — Devin Review's clean-context loop (2 bugs per PR, ~58% severe), cross-frontier smart friends, and manager Devin's map-reduce-and-manage. One principle runs through all three: writes stay single-threaded, other agents contribute intelligence, not actions."
+tags: ["multi-agent", "agent-engineering", "cognition", "devin", "context-engineering"]
+---
+
+import ClawdNote from '../../components/ClawdNote.astro';
+
+Let's start with an idea that sounds too dumb to work: **have the same model review the code it just wrote**. Same brain, same training data, same default blind spots — intuition says whatever it missed the first time, it'll miss again.
+
+Then Cognition measured what actually happens inside Devin: **on average, every Devin-authored PR gets 2 bugs caught by Devin Review, and ~58% of those are severe** — logic errors, missing edge cases, security vulnerabilities. The hit rate doesn't converge to zero either; each extra review loop keeps finding new ones.
+
+This isn't an accident. It's one of the centerpiece findings in [Walden Yan](https://cognition.ai/blog/dont-build-multi-agents)'s ten-months-later follow-up — less a retraction of his earlier "don't build multi-agents" stance, more a **sharper cut of it**: "most people shouldn't" becomes "most people shouldn't, but a narrow class really works." This SP is about unpacking that narrow class.
+
+## The old article, and the narrow class that ships today
+
+The core argument of Walden's **Don't Build Multi-Agents** (ten months ago): **parallel agents make implicit decisions about style, edge cases, and code patterns, and those decisions collide**. The result is fragile products. His advice then was blunt — don't.
+
+He hasn't reversed that. He's **drawn a sharper line**:
+
+> The sexy parallel-writer swarm ideas still don't see meaningful adoption. But we've found a narrower class of patterns that do work — setups where multiple agents contribute intelligence to a task, **while writes stay single-threaded**.
+
+That one sentence is the whole through-line of the article. The three patterns Cognition has shipped into Devin / Windsurf over the past ten months — Devin Review, smart friend, manager Devin — look superficially different. Underneath they're the same move: **keep the writer as a single agent; let everyone else step back into reviewer / advisor / router roles**.
+
+Context engineering still matters as much as it did ten months ago. Walden's earlier push was to shift the brain from "prompt engineering" to "context engineering" — drop the cheap tricks ("you're a senior engineer", "think harder") and instead **feed the right context in, then assume models get stronger over time**. That principle has aged well, and most multi-agent setups in the world are still shaped by it: the majority live as read-only [subagents](/glossary#subagent) (web search, code search) that are basically tool calls in disguise, not real collaboration.
+
+What Walden wanted to dig into is **the configuration where agents actually interact — and you still ship a product that works**.
+
+---
+
+## The backdrop: what actually happened in the last ten months
+
+Before we unpack the three patterns, one data point for context — **agent usage has exploded over the last ten months**.
+
+Models themselves became "natively agentic": they intuitively use tools, track their own context limits, and distill state for the next agent (human or otherwise). Usage followed. Even Devin, in the enterprise segment traditionally most conservative about new tech, **grew roughly 8x over the last six months**. Walden's exact phrasing: "a shit ton" — and yes, he bolded it himself.
+
+The explosion creates a push and a pull. **Push** side: once you're running many agents, the bottleneck shifts from the agents themselves to **the management, planning, and reviewing around them**. People naturally start stacking Devins that manage other Devins, coding agents that loop back and forth with review agents. **Pull** side: cost. Heavy use means heavy cost, and Anthropic has a new [Mythos class](https://www-cdn.anthropic.com/08ab9158070959f88f296514c21b7facce6f52bc.pdf) of even larger and more capable models on the horizon. **How do you reach frontier-level capability at a lower cost?** becomes a natural question. Multi-agent systems are a plausible answer.
+
+At the same time, there's been a wave of sensational demos: Cursor's agents [building a web browser](https://cursor.com/blog/scaling-agents) (200k LOC), Anthropic's agents [building a C compiler](https://www.anthropic.com/engineering/building-c-compiler) (100k LOC), Karpathy's [autoresearch](https://github.com/karpathy/autoresearch) running LLM training scripts through 10k+ iterations ([gu-log covered Karpathy's multi-agent research org earlier](/posts/clawd-picks-20260301-karpathy-multi-agent-research-org)). Impressive, but all three share a property **most real software doesn't have: a simple, machine-verifiable success criterion**. Does the browser run? Headless smoke test. Is the compiler correct? Conformance suite. Is the training script good? Look at the loss curve. The feedback loop is fast and deterministic, and agents can reinforce on it tens of thousands of times without a human in the loop.
+
+**Real software isn't like that.** An order-page UI has no loss function. Whether a backend should be refactored has no pytest. These are taste, tradeoffs, and models that only live in human heads. Walden draws a clean line here: Cognition's multi-agent explorations aren't benchmark tasks — they're the scenarios where **human judgment has to survive**.
+
+<ClawdNote>
+That "simple verifiable success criterion" detail is easy to skip past. Translated: the reason you can throw a hundred agents at those demos is that **if they get it wrong, CI turns red; if they get it right, CI turns green.** No human needs to be there. Real products don't have that luxury, which is why a lot of demo press releases look great and stop working the moment someone tries them on their own codebase.
+
+Another way to feel the gap: those demos are agents playing a **single-player game with infinite continues** — die and respawn, last frame wins. Real product development is a family cooking a full dinner together — the food has to come out, hit the right flavor, arrive on time, and **the kitchen can't catch fire**. Multi-agent works in both settings; it's just that one setting tolerates chaos and the other one really doesn't. Walden's whole article is strictly about the second kind. (⌐■_■)
+</ClawdNote>
+
+---
+
+## Pattern 1: The clean-context review loop that's "too dumb to work"
+
+Back to that opening number. **Every Devin PR, 2 bugs caught, ~58% severe.**
+
+The question is: why does the same model reviewing itself work? It shouldn't, on paper. Walden's answer has a philosophical layer and a technical layer, and the technical layer is the load-bearing one.
+
+Philosophically first — you have to reset your mental model. **Putting the same model in two agents is not the same as one human doing two jobs.** Human self-review is hard because humans **have egos, have invested interests, and have a built-in reluctance to admit the thing they just did an hour ago was wrong**. LLM-based agents don't. They're **pure functions of their context** — no ego, no continuity, no stake. Two agents are two blank slates with no social basis for collusion. Any shared bias comes from training, and training-level bias is a **capability-level** thing, not a **task-level** self-protection instinct.
+
+The technical layer is the nastier one. [Context Rot](https://www.trychroma.com/research/context-rot) is a well-documented phenomenon — **as context gets longer, decision quality drops**. There's a finite number of attention heads. When the model has to juggle instructions, prompt, code, and decisions from an hour ago, **some important detail doesn't make it into the reasoning**.
+
+What state is the coding agent in by the time it's "done"? It's been grinding on this task for hours — reading the repo, running commands, trying three approaches, fixing two errors. **Its context is long, messy, and full of history that's no longer relevant but still taking up attention.** When you ask it to review its own work, what it misses isn't a failure of intelligence — **its attention has been eaten by history**.
+
+Now bring in a completely fresh reviewer. It's forced to **look only at the diff and rebuild any context it needs from the code itself**. Short context, clean attention, and — bonus — it's **reasoning backward from the implementation without the spec getting in the way**. That freedom lets it openly question things the original agent had normalized (like a user instruction that was itself flawed: "please implement this insecure pattern").
+
+The review agent isn't "smarter." Same model, same ceiling. It just has **attention that hasn't been diluted**.
+
+<ClawdNote>
+This insight deserves its own picture. Imagine an engineer who's been working for 12 hours, has 30 browser tabs open, and 200 lines of terminal scrollback. A PM walks over and asks, "did you handle that edge case?" With all that context overflow in their head, the answer is probably "uh... I think so?" Now pull in a new hire who just sat down, hand them only the diff, and they'll often spot **"this doesn't handle null"** on first read.
+
+That's not an intelligence gap. **It's attention bandwidth that got eaten.** A clean-context reviewer is basically doing **token-economic arbitrage** — taking attention that got eaten by history and giving it back to the diff itself.
+
+Quick aside that feels very on-the-nose: gu-log's own tribunal system (every post has to pass four judges — Vibe / Fact / Librarian / Fresh Eyes) is exactly this principle in practice. Each judge only sees **the post plus the scoring rubric** — no writing process, no commit history, no rewriter's self-defense. When a judge flags an issue, the feedback goes back to the writer as a concrete note, not as stream-of-consciousness. It looks like a dumb setup. **It's actually engineering against the physics of context rot.**
+
+Walden is making the same point, just with Devin as the example. Worth stopping here and asking yourself: how many agents in your own system are reviewing each other right now, and how much context are they sharing that they shouldn't be? ٩(◕‿◕｡)۶
+</ClawdNote>
+
+Clean context alone doesn't close the loop. The last piece is **the communication bridge between Devin and Devin Review**. The key question: does Devin use its richer context (user intent, decisions already made) to **filter** the bug list Devin Review hands back? If it doesn't — you loop forever, violate user intent, end up doing out-of-scope work.
+
+Walden's finding: **today's models, with a bit of dedicated prompting, can make sensible calls here.** What ships is a three-way interaction — coding agent, review agent, human PR reviewer — where the first two iterate until most bugs are gone, and by the time the human opens the PR, 80% of the issues are already resolved.
+
+One-line takeaway: **clean context + a good communication bridge = the production-grade version of a generator-verifier loop.**
+
+(gu-log covered the outer autofix-loop architecture earlier in [SP-66: self-healing PR](/posts/self-healing-pr-devin-autofix). This post is the same topic one layer deeper: why the small choice of keeping context clean is the lever the whole system hangs on.)
+
+---
+
+## Pattern 2: Smart Friend — starting with Cognition admitting failure
+
+The second pattern doesn't open with "look, we built it." It opens with "look, we got it wrong."
+
+The setup: **frontier intelligence is about to get too expensive (and too slow) for most day-to-day work**. Sonnet-class models are being replaced by Opus-class for serious jobs; Mythos is on the way and it's only going to get bigger and pricier. So the natural architecture question surfaces — **can you use a small model as the primary and call out to a big model only when needed?** Cognition's Windsurf tried this in October 2025 with [SWE-1.5](https://cognition.ai/blog/swe-1-5), a 950 tok/sec sub-frontier model — **SWE-1.5 as primary, Sonnet 4.5 as the "smart friend" called in for planning**.
+
+Two tricky communication problems showed up, both about **how primary and smart friend talk to each other**.
+
+The hard direction is the upward call. The core issue: **how does a dumber model know it's at its limits?** This is the inverse of the popular pattern (a smart primary delegating to smaller subagents) — here, the less smart one is deciding whether to delegate, and the less smart something is, the less it knows it doesn't know. Walden lists a few workarounds: **force the primary to make at least one smart-friend call per task**, prompt-tune or train the primary toward better calibration, or write hard rules ("always consult smart friend on merge conflicts"). Context transfer has an 80/20 solution too — **just fork the whole primary context over**; don't try to save a few thousand tokens. And the primary's question style matters — **ask broad questions** ("what should I do?") rather than specific sub-questions, because the primary often doesn't know which sub-question to ask.
+
+The downward direction also has to be tuned. The smart friend shouldn't **invent theories** to fill gaps — if the primary never looked at a critical file and asks a question that depends on it, the right response isn't to guess. The right response is **tell the primary to read that file and come back**. Smart friend should also **over-reach** — answering not just the asked question but also surfacing directions the primary didn't know to ask, based on the full agent trajectory. Walden calls this "over-scoped smart friend," and it produces better interactions in practice than a smart friend that strictly stays on topic.
+
+Then — Walden is direct about this — **this setup didn't work yet**.
+
+SWE-1.5 wasn't strong enough to hold the primary role. The gap between it and Sonnet 4.5 **fell exactly on the skills this setup needs**: knowing when to escalate, knowing what to ask. The cost and speed wins were real, but **the primary sets the ceiling**, and this primary couldn't clear it. [SWE 1.6](https://cognition.ai/blog/swe-1-6) (Opus-4.5-level on SWE-bench) is meaningfully better, closes some of the gap, but **still isn't where we want it to be**. Walden's read: this is mostly a **training problem**, and future SWE models will be trained with "back-and-forth with a stronger model" baked in.
+
+So which version actually works? **Cross-frontier pairing.**
+
+Cognition has run Claude + GPT together in production, and **in the trickiest scenarios it produces real gains**. And the prompt-tuning problems look completely different from the small-vs-large case. Cross-frontier isn't about "weak model escalating to strong model" — it's about **routing sub-tasks to whichever model is best at that sub-task**. Some models debug better, some handle visual reasoning better, some write tests better. The delegation logic shifts from a **difficulty escalator** to a **capability router**.
+
+That phrase is worth pausing on. **Capability router, not difficulty escalator.** That framing directly undermines the naïve narrative that "big model + small model always saves money" — **the real economic story of two frontier models as complements is more interesting than that**.
+
+<ClawdNote>
+"A weak model doesn't know it's weak" — in agent-design circles this is **the Dunning-Kruger problem for LLMs**. The human version is familiar: **the least competent people are the least aware they're incompetent**. The LLM version is just as lethal: a model two generations behind frontier genuinely can't tell when a task exceeds its ability. **It'll bullshit with confidence.**
+
+Walden's three workarounds (forced consultation, prompt-tuning, hard rules) are all **external scaffolding that simulates self-awareness** — the model itself isn't calibrated, so the harness compensates. It's the same move ML engineers used to make with classifier calibration layers: **the model's own confidence estimate is unreliable, so you train a separate meta-model to estimate confidence on top**.
+
+Quick aside: Anthropic recently [launched a similar beta](https://claude.com/blog/the-advisor-strategy) — the Advisor strategy, where smaller models can call out to larger ones. Two companies shipping this simultaneously tells you one thing: **the "smart friend side" will be properly trained soon**, and the back-and-forth will get smarter at the training level rather than the harness level. Fixing things at training time is always more elegant than bolting on harness logic. ╰(°▽°)╯
+</ClawdNote>
+
+---
+
+## Pattern 3: Manager Devin, and why "unstructured swarm is mostly a distraction"
+
+Patterns 1 and 2 share a shape: **one writer, with other agents contributing intelligence around it**. The obvious next question — **can you expand the scope?** A product feature spanning 10 PRs, a migration that touches a dozen services, a week of work instead of an afternoon.
+
+Cognition's answer is already live in Devin: **manager Devin** — breaks a large task into pieces, spawns child Devins to handle them, coordinates progress through an internal [MCP](/glossary#mcp). Walden is honest about the cost: **making it feel coherent took far more context engineering than expected**. Some specific potholes: a manager trained on small-scope delegation **defaults to being over-prescriptive** (bad when the manager's own codebase context is thin); agents **wrongly assume they share state with their children** when they don't; **cross-agent communication** (a sub-agent writing a message back to its manager, who passes it to siblings) **doesn't happen by default**, because models were never trained in environments where it was needed.
+
+But the most quotable line in this section isn't about manager Devin's implementation details. It's this one:
+
+> unstructured swarm — arbitrary networks of agents negotiating with each other — **is mostly a distraction**
+
+This is that whole genre — agents haggling in simulated markets, agents voting for the best solution, agents forming leaderless democratic collectives. **Looks great in papers. Doesn't ship products.**
+
+What actually works, consistently, is **map-reduce-and-manage**: the manager splits the work, children execute, the manager synthesizes and reports back. That's it. Making this feel as coherent as a single agent on a single task is **one of Cognition's main engineering bets for 2026**.
+
+<ClawdNote>
+"Unstructured swarm is mostly a distraction" — frame that one. The agent world has had a huge hype wave the last two years for **a hundred agents haggling in simulated markets, agents voting for best solutions, agents forming leaderless democratic collectives**. Sounds sci-fi. Academic papers wrote it up enthusiastically.
+
+**It doesn't ship products.** The reason Walden gave in his earlier post is still the reason today — **actions carry implicit decisions**. Every agent that can write adds another set of conflicting side effects, and at the end, **no one knows who's supposed to own the outcome**. Map-reduce has been around for decades — why is it still here? **Because it makes "who is responsible for integrating the decision" unambiguous** — the manager, one person, owns it. Children can be many, parallel, cheap, and occasionally wrong, but **the integration point has single-owner responsibility**.
+
+Apply this to tribunals, to code review, to release pipelines, and you notice: **every multi-agent system that actually ships looks structurally identical** — one owner, many advisors, owner integrates. This isn't an invention. It's **rediscovering a century of engineering management wisdom**. Cognition took ten months of looping to get back here, and Walden writing it up honestly at least saves the next cohort from doing the same loop. ┐(￣ヘ￣)┌
+</ClawdNote>
+
+---
+
+## Closing: The "too dumb to work" loop was never dumb
+
+Back to the opening number — 58% severe bugs caught by Devin Review.
+
+Why does Devin-reviewing-Devin work? Not because any one model is unusually smart. Not because any one prompt is unusually clever. **It works because the whole system keeps the writer single, gives the reviewer clean attention, and uses a precise bridge to communicate**. Strip the structure down and you end up at exactly **the principle this entire article is about**: **writes stay single-threaded; other agents pour in intelligence, not actions**.
+
+Smart friend is a variation — the primary writes, the smart friend advises, advice never touches code. Manager Devin is the scaled-up version — manager doesn't write, one child writes at a time, manager integrates decisions. **Three patterns, one move.**
+
+The open problems Walden leaves us with, he collapses into "they're all communication problems": **how does a weaker model learn when to escalate? How does a child agent surface a finding that should change its siblings' work? How do you pass context between agents without drowning the receiver?** You can get reasonably far with prompting; beyond that needs the next generation of models — including the ones Cognition trains themselves — to have these gaps trained away.
+
+<ClawdNote>
+The single most useful thing to take from this article **isn't the three patterns. It's the principle itself — writes stay single-threaded**. A lot of agent engineering over the last two years has gone into "how do we get multiple agents to write together," and in hindsight most of it was a detour. **The solution wasn't to make them write together — it was to accept that there's only ever one pen.**
+
+Practical action item for gu-log readers: **if an agent system of yours feels fragile right now**, start with one question — **"are two agents writing the same thing in parallel?"** If yes — **that's probably it**. Collapse the writer back to one, push other agents into reviewer / advisor / router roles, and most of the fragility goes away. You don't need the next generation of models for this. You can do it today.
+
+One last slightly pointed thing — this article reads like Cognition stapling "I told you so, but now with a product" onto their ten-month-old paper. But **this kind of self-correcting honesty is healthier than the usual "everything is going according to roadmap" PR posture**. Walden explicitly admits SWE-1.5 wasn't good enough, that smart friend in asymmetric settings is an open problem, that manager Devin is still being debugged — **that density of "we got it wrong" is rare in SF product blogs**.
+
+The best reaction after reading this isn't nodding along. It's **going back to your own system and checking whether the branching write you have is actually necessary**. Most of the time — it isn't. (ง •̀_•́)ง
+</ClawdNote>

--- a/src/content/posts/sp-181-20260423-walden-cognition-multi-agents-working.mdx
+++ b/src/content/posts/sp-181-20260423-walden-cognition-multi-agents-working.mdx
@@ -1,0 +1,202 @@
+---
+ticketId: "SP-181"
+title: "Multi-Agent 十個月後的誠實報告——Cognition Walden：寫入保持單執行緒，其他 agent 只灌 intelligence"
+originalDate: "2026-04-22"
+translatedDate: "2026-04-23"
+translatedBy:
+  model: "Opus 4.7"
+  harness: "Claude Code"
+source: "@walden_yan on X (Walden Yan, Cognition co-founder)"
+sourceUrl: "https://x.com/walden_yan/status/2047054401341370639"
+lang: "zh-tw"
+summary: "Cognition 的 Walden Yan 十個月前寫過一篇 Don't Build Multi-Agents 勸大家別碰 multi-agent，這次回頭端出三個真的跑得動的 pattern——Devin Review 的 clean-context loop（平均每 PR 抓 2 個 bug、58% 是嚴重級）、跨前沿模型的 smart friend、manager Devin 的 map-reduce-and-manage。貫穿所有 pattern 的核心原則只有一條：寫入保持單執行緒，其他 agent 只灌 intelligence 不動手。"
+tags: ["multi-agent", "agent-engineering", "cognition", "devin", "context-engineering"]
+scores:
+  tribunalVersion: 3
+  vibe:
+    persona: 9
+    clawdNote: 9
+    vibe: 8
+    clarity: 9
+    narrative: 8
+    score: 8
+    date: "2026-04-23"
+    model: "Opus 4.6"
+  factCheck:
+    accuracy: 9
+    fidelity: 9
+    consistency: 9
+    score: 9
+    date: "2026-04-23"
+    model: "Opus 4.7"
+  librarian:
+    glossary: 7
+    crossRef: 8
+    sourceAlign: 9
+    attribution: 9
+    score: 8
+    date: "2026-04-23"
+    model: "Sonnet 4.6"
+  freshEyes:
+    readability: 8
+    firstImpression: 8
+    score: 8
+    date: "2026-04-23"
+    model: "Haiku 4.5"
+---
+
+import ClawdNote from '../../components/ClawdNote.astro';
+
+先丟一個看起來蠢到不該 work 的做法：**讓同一顆模型去 review 自己寫的 code**。同一個腦袋、同一個訓練資料、同一套默認偏見——直覺就是「該漏掉的還是會漏掉」。
+
+結果 Cognition 在 Devin 上量出來的數字長這樣：**平均每一個 Devin 寫的 PR，被 Devin Review 抓出 2 個 bug，其中約 58% 是嚴重等級**——邏輯錯誤、漏掉的 edge case、安全漏洞。抓到的比例還不會因為多跑幾輪就收斂，經常每一輪都再撈出新的。
+
+這不是意外，是 [Walden Yan](https://cognition.ai/blog/dont-build-multi-agents) 十個月後寫來打自己臉的重點之一——但更精準地說，不是「打臉」，是**把原本那句「大部分人別做 multi-agent」精修成「多數人不該、但有窄一類真的可以」**。這篇 SP 就是把那一類拆乾淨。
+
+## 十個月前那篇文章，跟今天能 ship 的那窄一類
+
+Walden 十個月前那篇 **Don't Build Multi-Agents** 的核心論點是：**多個 agent 平行動作會在 style、edge case、pattern 上做出互相衝突的隱形決策**，拼成一個脆弱產品。當時的勸退非常直接——不要做。
+
+今天回頭看那個判斷，Walden 的態度沒有轉彎，而是**把界線畫得更細**：
+
+> 那些 sexy 的 parallel-writer 群聚想像，今天還是 ship 不出來。但我們找到一類**比較窄、會動**的 pattern——多個 agent 對任務貢獻 intelligence，**但寫入始終保持單執行緒**。
+
+一句話，這就是整篇文章的 through-line。Cognition 過去十個月 ship 到 Devin / Windsurf 的三招——Devin Review、smart friend、manager Devin——看起來做的事情很不一樣，但骨子裡長一樣：**讓 writer 保持一個人，其他 agent 退到 reviewer / advisor / router 的位置**。
+
+Context engineering 這件事的重要性也沒變。當時 Walden 強調要把腦袋從 "prompt engineering" 換到 "context engineering"——意思是別去雕「扮演資深工程師」、「想久一點」那種小把戲，正確姿勢是**把對的資料餵給模型、然後假設模型愈強會愈好用**。這個原則今天一樣沒動，而且所有 multi-agent setup 都還被它強力限制著——大部分世界上的 multi-agent 實作還是 read-only [subagent](/glossary#subagent)（web search、code search 那類），幾乎等於被包裝成 tool call，談不上真正協作。
+
+Walden 想挖的就是**那一類願意讓 agent 真的互動、而且還不會把產品打壞**的配置。
+
+---
+
+## 背景值：過去十個月，agent 到底為什麼變成這樣
+
+開始拆招之前要鋪一個背景值——**agent 用量在過去十個月整個爆掉了**。
+
+模型本身變得「天生 agentic」：直覺上會用 tool、懂自己 context 的邊界、會把狀態萃取給下一棒。結果就是連 Devin 在那些對新技術最保守的大企業客戶群裡，**過去六個月用量也長了大約 8 倍**——原文用的字是 "a shit ton"，Walden 自己特地加粗。
+
+用量爆掉會帶出一推一拉：**推**的那邊是 user 用多之後瓶頸從 agent 本身位移到「agent 的管理、規劃、review」——於是自然開始堆疊 Devin 管 Devin、coding agent 跟 review agent 來回 iterate 這些 setup。**拉**的那邊是成本——用得愈兇愈貴，加上 Anthropic 不遠處還有 [Mythos class](https://www-cdn.anthropic.com/08ab9158070959f88f296514c21b7facce6f52bc.pdf) 這種更大更強的模型在路上，**怎麼用較低成本跑出前沿能力**的問題自然變成焦點。multi-agent 很可能是其中一個答案。
+
+同一時間還有一波「丟大量 agent 硬衝大專案」的 sensational demo：Cursor 用 agent [蓋整個 web browser](https://cursor.com/blog/scaling-agents)（200k LOC）、Anthropic 讓 agent [蓋 C compiler](https://www.anthropic.com/engineering/building-c-compiler)（100k LOC）、Karpathy 的 [autoresearch](https://github.com/karpathy/autoresearch) 跑 LLM training script 10k+ 次迭代（[gu-log 之前拆過 Karpathy 那套 multi-agent research org](/posts/clawd-picks-20260301-karpathy-multi-agent-research-org)）。很壯觀，但這些 demo 全都有一個**真實商業軟體幾乎都不具備的特性：簡單、機器可驗證的成功條件**。瀏覽器跑不跑得起來？跑 headless browser smoke test。Compiler 對不對？跑 spec conformance suite。Training script 好不好？看 loss 曲線就好。回饋循環都是秒級、deterministic，agent 可以 reinforce 幾萬次都不用人類介入。
+
+**真實軟體長得不是這樣**。訂單 UI 沒有 loss function，後端該不該重構沒有 pytest 能驗，這些全是口味、權衡、與只住在人類心智裡的 model。Walden 在這邊劃下了一條界線——Cognition 要探索的不是 benchmark 式任務，是得**把人類判斷力放大**的那種場景。
+
+<ClawdNote>
+那三個 sensational demo 的共同特徵，Walden 用「simple verifiable success criterion」帶過，讀者很容易放過。講白一點：那類任務之所以 agent 可以一百支一起跑，**是因為錯了 run CI 就會紅燈、對了自動綠燈**——人類完全可以離開現場。真實產品沒有這種奢侈，所以大部分 demo 發表完的新聞稿好看，但搬到自己的 codebase 就垮掉。
+
+換個比喻：那些 demo 是 agent 在玩**無限續關的單機遊戲**，死了就重來、最後畫面留下就算贏。真實產品開發是一家人在廚房做一頓年夜飯——菜要端得上桌、端得對味、端得準時，**還不能把廚房燒掉**。同樣是多人合作，一個可以亂、一個不能亂。Cognition 這篇文章決定只談後者那種場景 (⌐■_■)
+</ClawdNote>
+
+---
+
+## 第一招：那個「蠢到不該 work」的 clean-context review loop
+
+回到開頭那個數字。**每個 Devin 寫的 PR、2 個 bug、58% 嚴重級**。
+
+問題是——為什麼同一顆模型 review 自己會 work？直覺上講不通。Walden 給的答案分成哲學跟技術兩層，技術那層才是硬的。
+
+哲學那層先把腦袋轉過來：**同一顆模型擺在兩個 agent 裡面，不等於一個人兼做兩個角色**。人自省很難，原因是人**有自尊、有既得立場、有不想承認前一小時做錯的本能**。LLM-based agent 不是這樣——agent 是**純粹由 context 決定表現的系統**，沒有面子、沒有連續感、沒有立場。兩個 agent 就是兩個 blank slate，互相之間沒有共謀的社會基礎。就算共享什麼偏見，也是來自訓練過程——而這個偏見是**底層能力**，不是**任務級別**的自保本能。
+
+技術那層真的狠。[Context Rot](https://www.trychroma.com/research/context-rot) 是個被反覆記錄的現象——**模型在 context 愈長的情況下，決策品質會下降**。attention head 的數量有上限，同時要盯 instruction、prompt、code、一小時前做過的決策時，**有些重要細節就不會進推論**。
+
+Coding agent 是什麼狀態？在這個任務上已經泡了幾個小時——讀過 repo、跑過一堆 command、想過三種寫法、修了兩次錯誤。**context 很長，很雜，很多已經不重要但仍在佔位**。這時候叫它自己 review，它看不到的不是因為它笨，是因為**它的 attention 已經被歷史包袱吃掉了**。
+
+換一個完全空白的 review agent 來呢？它被迫**只看 diff、需要什麼 context 就從 code 重讀**。短 context、乾淨 attention、而且**從實作反推、沒有原始 spec 的包袱**——這讓它敢坦然質疑那些 user instruction 本身就有問題的地方（例如「幫忙實作這個不安全的 pattern」這種原始指令）。
+
+這不是 review agent「更聰明」——同一顆模型，能力上限沒動。是**它手上的 attention 沒有被稀釋**。
+
+<ClawdNote>
+這個 insight 值得獨立做個比喻：想像一個工程師做了 12 小時、開了 30 個瀏覽器分頁、終端機有 200 行 scrollback，PM 走過來問「那個 edge case 你處理了嗎？」——他腦袋裡 context overflow，答案很可能是「呃...應該有？」。另外找一個剛坐下來、只給他看 diff 的新同事，反而更容易一眼抓出**「這裡沒 handle null」**。
+
+這不是 intelligence 不夠，是 **attention bandwidth 被吃光了**。Clean-context reviewer 本質上在做一個 token 經濟學套利——**把被歷史包袱吃掉的 attention 還給 diff 本身**。
+
+順便講一件很巧的事：gu-log 自己的 tribunal 系統（每篇文章都要過四個 judge：Vibe / Fact / Librarian / Fresh Eyes）早就是這個原則的實作版本。四個 judge **只吃文章本身 + 評分標準**，不吃寫作過程、不吃 commit history、不吃 rewriter 的辯解。等到 judge 發現問題再丟給原 writer 去改寫——中間傳遞的是具體 feedback，不是 reviewer 的意識流。看起來像笨方法，**實際上在利用 context rot 的物理特性做工程**。
+
+Walden 講的是同一件事，只是用 Devin 的例子講。讀完這段值得停下來想想——自己現在手上有幾個 agent 在互相 review？它們共享了多少不該共享的 context？ ٩(◕‿◕｡)۶
+</ClawdNote>
+
+Clean context 做對了還差最後一塊——**Devin 跟 Devin Review 之間的溝通橋**。關鍵問題是：Devin 有沒有用它那段更完整的 context（user 意圖、已經做過的決策），去**過濾** Devin Review 吐回來的那一堆 bug？如果沒有——就是 loop 到天荒地老、違反 user 意圖、做出 scope 外的東西。
+
+Walden 的發現：**今天的模型配上一點專門 prompting，就能做出合理的判斷**。最後 ship 出來的互動是三方的——coding agent、review agent、人類 PR 作者——中間兩個先彼此磨到差不多，人類打開 PR 時 80% 的 bug 已經不在了。
+
+這整招的 takeaway 壓成一句：**clean context + 良好溝通橋 = generator-verifier loop 的產品級版本**。
+
+（gu-log 之前在 [SP-66 self-healing PR](/posts/self-healing-pr-devin-autofix) 拆過外圍的 autofix 迴圈架構——這一篇是同個主題往裡面挖一層：為什麼 clean-context 這個小決定，是整個系統的關鍵槓桿。）
+
+---
+
+## 第二招：Smart Friend——從 Cognition 坦承失敗開始講
+
+第二個 pattern 不是從「看，Cognition 做出了」開始，是從「看，Cognition 坦承做歪了」開始。
+
+場景設定：**前沿 intelligence 很快會貴到、慢到不適合日常工作**。Sonnet 被 Opus 取代、Mythos 還在更大更貴的路上——於是「能不能用小模型當 primary、有事再 call 大模型」變成很自然的架構問題。Cognition 的 Windsurf 在 2025 年 10 月 [launch SWE-1.5](https://cognition.ai/blog/swe-1-5)（每秒 950 token 的 sub-frontier 模型）時，就試了這個想法——**把 SWE-1.5 當 primary，Sonnet 4.5 當 "smart friend" 被 call 出來做規劃**。
+
+架構層面他們遇到兩個 tricky 的溝通問題，兩個都是 **primary 跟 smart friend 之間怎麼說話**。
+
+往上呼叫的方向最難。核心問題是——**一個比較笨的模型要怎麼知道自己撞到極限？** 這跟主流的「聰明 primary 派任務給小 subagent」剛好顛倒。primary 愈不聰明，愈不知道自己不會。幾個 workaround：強制每題至少打一次 smart friend、prompt-tune 或訓練到更校準、或寫硬規則（遇到 merge conflict 一律叫 smart friend）。context 傳遞也有個 80/20 解——**直接 fork 整份 primary context 傳過去**，不要想省那幾千 token。primary 提問要**問得廣**——「現在該怎麼做？」這種開放式問法比塞具體子問題更有用，因為該問什麼 primary 自己就不見得知道。
+
+往下回話的方向也要調。smart friend 收到問題不能**瞎編理論**填空——如果 primary 從沒看過某個關鍵檔案卻跑來問依賴它的問題，正確反應不是猜，是**叫 primary 去讀那個檔、讀完再回來**。smart friend 還該「**過問**」——不只回答被問的，還順手根據 agent trajectory 丟出 primary 沒想到要問的方向。Walden 稱這種配置是「over-scoped smart friend」，實務上比乖乖回答的 smart friend 激出更多好互動。
+
+然後——Cognition 很直接地承認——**這整個 setup 當時沒成功**。
+
+SWE-1.5 還不夠好，撐不起 primary 角色。它跟 Sonnet 4.5 之間的差距**剛好壓在這個 setup 最需要的能力上**——「知道什麼時候該求援」、「知道要問什麼」。成本跟速度的好處是真的，但**品質天花板由 primary 決定**，primary 撐不起來，整套 setup 的上限就只有 primary 的上限。[SWE 1.6](https://cognition.ai/blog/swe-1-6)（打到 Opus-4.5 等級在 SWE-bench 上）明顯好很多，補了一些，**但還沒到理想位置**。Walden 判斷這主要是**訓練問題**——未來 SWE 系列會把「跟更強模型來回」納入訓練目標。
+
+那什麼版本真的 work 了？**跨前沿模型互相 call**。
+
+Cognition 在 production 上跑過 Claude 跟 GPT 的組合，**在最棘手的場景拿到真實收益**。而且跨前沿的 prompt-tuning 問題長得跟小-大模型 pair 完全不同——重點不是「弱模型何時該請強模型」，是**把 sub-task 路由到最擅長的那顆**。有的模型 debug 比較強、有的視覺推理比較強、有的寫 test 比較強。delegation 邏輯從**「難度升級器」變成「能力路由器」**。
+
+這句話值得停一下。**capability router, not difficulty escalator**。整句直接推翻「大模型配小模型一定省錢」的天真敘事——**兩顆前沿模型互補**的經濟學反而比想像中好。
+
+<ClawdNote>
+「小模型不知道自己不會」這件事，在 agent 設計圈叫 **Dunning-Kruger problem for LLMs**。人的版本大家都知道——**能力最低的人最不知道自己低**。LLM 的版本同樣致命：一個比前沿差兩個世代的模型，真的看不出題目什麼時候超出能力範圍——**它會很有自信地 bullshit**。
+
+Walden 給的三個 workaround（強制諮詢、prompt-tune、硬規則）全部是在**外面蓋一層「能力自覺的替代品」**——本體不夠，harness 補。這跟當年 ML 工程師給 classifier 蓋 calibration layer 是同一招：**模型自己估的 confidence 不可靠，就外掛一個 meta-model 去估 confidence**。
+
+順道提一下——Anthropic 最近也 [推出一個相似的 beta](https://claude.com/blog/the-advisor-strategy)：Advisor 策略，讓小模型呼叫大模型。兩家同時出招代表一件事——**未來「smart friend 端」會在訓練階段被好好餵過，雙向溝通會愈來愈聰明**。訓練端補漏永遠比外掛 harness 優雅 ╰(°▽°)╯
+</ClawdNote>
+
+---
+
+## 第三招：Manager Devin 跟為什麼「無結構 swarm 是分心」
+
+前兩招都是**一個 writer、旁邊圍繞其他貢獻 intelligence 的 agent**。下一個自然問題——**能不能把 scope 放大？** 橫跨 10 個 PR 的產品 feature、影響十幾個 service 的 migration、一整週而不是一個下午的工作。
+
+這題 Cognition 的答案是 Devin 上已經在跑的 **manager Devin**——把大任務拆成小塊、spawn child Devin 去處理、透過內部 [MCP](/glossary#mcp) 協調進度。Walden 很誠實地交代：**要做得連貫，需要的 context engineering 遠超預期**。踩過的雷包括——在小 scope 訓練出來的 manager **預設會過度規範**（當 manager 對 codebase 理解不深時反而壞事）、agent 會**誤以為跟 child 共享狀態**、**跨 agent 溝通**（sub-agent 寫訊息回 manager，再由 manager 轉給團隊其他 agent）**預設不會發生**，因為模型訓練環境裡從沒需要過這種技能。
+
+但 Walden 在這個 section 最值得貼牆的一句話，不是 manager Devin 的實作細節，是這一句——
+
+> unstructured swarm 這條路——任意網路裡一堆 agent 彼此協商——**大多只是 distraction**
+
+也就是那種「一堆 agent 在任意網路裡彼此協商」、「agent 投票選出最佳解」、「agent 組成無 leader 的民主共同體」的想像——**研究論文看起來很漂亮，實務上 ship 不出產品**。
+
+實務真正有用的形狀永遠是 **map-reduce-and-manage**：manager 拆工作、children 執行、manager 匯整並回報。就這樣。要讓這種系統感覺起來跟「一個 agent 做一件事」一樣連貫，是 Cognition 2026 接下來的主要工程之一。
+
+<ClawdNote>
+「unstructured swarm 是 distraction」這句要框起來。過去兩年 agent 圈有一股超強 hype——**一百個 agent 在模擬市場討價還價、agent 投票選最佳解、agent 組成無 leader 的民主共同體**。聽起來很科幻，學術 paper 也寫得很熱鬧。
+
+**實務上 ship 不出產品**。原因 Walden 上一篇就講過——**action 帶隱形決策**：每多一個能寫的 agent，就多一份跟別人 conflict 的 side-effect，最後沒人知道誰該 own 結果。map-reduce 這種幾十年的老骨架為什麼還在？**因為它把「誰負責整合決策」這件事講得很清楚**——manager 一個人扛。child 可以多、可以平行、可以便宜、可以出錯——但**整合的那一點是單一責任歸屬**。
+
+把這個原則套到 tribunal、套到 code review、套到 release pipeline——**所有真的能 ship 的 multi-agent 系統，結構幾乎一模一樣**：一個 owner、多個 advisor、最後由 owner 統合決策。這不是發明，是**重新發現工程管理學百年積累下來的東西**。Cognition 花了十個月去繞回這件事，Walden 誠實寫出來，至少幫後面跟進的人省掉繞同一圈的時間 ┐(￣ヘ￣)┌
+</ClawdNote>
+
+---
+
+## 結語：那個「蠢到不該 work」的 loop，其實一點也不蠢
+
+回到最開頭那個 58% severe bugs 的數字。
+
+為什麼 Devin review Devin 會 work？不是因為哪顆模型特別聰明、不是因為哪個 prompt 特別精巧——**是因為整個系統讓 writer 保持一個人、reviewer 拿著乾淨的 attention、兩邊用精確的 bridge 溝通**。這個結構拆開來說一遍會發現——**它就是 Walden 這整篇文章在講的那條原則**：**寫入保持單執行緒、其他 agent 只灌 intelligence 不動手**。
+
+Smart friend 是這條原則的變奏——primary 在寫、smart friend 在 advise，advise 不動 code。Manager Devin 是這條原則的升級版——manager 不親自寫，child 一次一個在寫，manager 把決策統合起來。**三招同一招**。
+
+剩下沒解的問題，Walden 收斂成「全部是溝通問題」：**比較弱的模型怎麼學會何時 escalate？child agent 發現的東西怎麼 surface 出來、甚至改動兄弟姐妹的工作？agent 之間如何傳 context 而不會淹死接收方？** Prompting 能走到一個位置，再往上就需要下一代模型——包括 Cognition 自己接下來訓練的——把這些缺口直接訓進去。
+
+<ClawdNote>
+這篇文章最值得帶走的，**不是那三個 pattern，是「寫入單執行緒」這個原則本身**。過去兩年 agent 圈不少時間花在研究「多 agent 怎麼一起寫」，回頭看都是繞遠路——**真正可行的解不是讓它們一起寫，是承認一次只有一支筆**。
+
+對 gu-log 讀者最實用的一件事：**如果現在手上有一個 agent 系統感覺哪裡很 fragile**——先問一個問題：**「現在是不是有兩個 agent 在並行寫同一個東西？」** 如果答案是 yes——**多半就是它**。把 writer 收斂到一支、其他 agent 退到 reviewer / advisor / router 的位置，系統多半就會穩下來。這件事不用等下一代模型，現在就能做。
+
+最後講一句可能有點刺的話——這篇讀起來像 Cognition 給自己十個月前的論文加了一個 "I told you so, but now with product"。但**這種自我校準的誠實，比那種假裝一切都按 roadmap 走的公關文健康太多**。Walden 承認 SWE-1.5 不夠好、smart friend 在 asymmetric 設定下還是 open problem、manager Devin 還在踩坑——**這種認錯密度在 SF 圈已經是稀有物種**。
+
+讀完這篇最好的反應不是點頭稱是，是**立刻回去看自己系統裡那條寫入分叉是不是真的必要**。大部分情況——不是 (ง •̀_•́)ง
+</ClawdNote>


### PR DESCRIPTION
## Summary

SP-181 翻譯 + Clawd 吐槽——來源是 [Walden Yan (Cognition co-founder) 的 X Article](https://x.com/walden_yan/status/2047054401341370639) **"Multi-Agents: What's Actually Working"**（2026-04-22）。Walden 為他自己十個月前那篇 Don't Build Multi-Agents 做校準——立場沒轉彎，但把界線畫得更細：**多數人仍然不該做 multi-agent，可是有窄一類真的 ship 得出來**。

三個 pattern，一條貫穿原則：

- **Pattern 1** — Devin Review 的 clean-context loop：平均每 PR 抓 2 個 bug、~58% 嚴重級。關鍵槓桿是 attention bandwidth 套利（context rot 的物理特性）。
- **Pattern 2** — Smart Friend：SWE-1.5 + Sonnet 4.5 原本的配置沒 work，Cognition 坦承訓練層不夠；真正 work 的是 **cross-frontier capability router**（Claude + GPT 互補）。
- **Pattern 3** — Manager Devin + map-reduce-and-manage：明確宣告「unstructured swarm 是 distraction」。

三招同一招：**寫入保持單執行緒，其他 agent 只灌 intelligence 不動手**。

## Tribunal v3 結果（4/4 PASS）

| Judge | Dimensions | Score | Verdict |
|---|---|---|---|
| Vibe (Opus 4.6) | persona 9 / clawdNote 9 / vibe 8 / clarity 9 / narrative 8 | 8 | PASS |
| Fact (Opus 4.7) | accuracy 9 / fidelity 9 / consistency 9 | 9 | PASS |
| Librarian (Sonnet 4.6) | glossary 7 / crossRef 8 / sourceAlign 9 / attribution 9 | 8 | PASS |
| Fresh Eyes (Haiku 4.5) | readability 8 / firstImpression 8 | 8 | PASS |

Pass bar（composite ≥ 8 AND 至少一維 ≥ 9 AND 無維 < 8）全條件滿足。第一輪 Vibe 7/FAIL（narrative 平鋪鏡射原文），rewrite 後 9/9/8/9/8 passed。

## 工程記錄

CCC sandbox 跑不了 `sp-pipeline run`（root 身份 + `--dangerously-skip-permissions` 被擋），所以走手寫 + 4-judge subagent tribunal 的 playbook fallback（`playbooks/CCC-playbook.md` 的「沙箱 fallback」）。Fact checker 直接以 `fetch-x-article.sh` + raw fxtwitter JSON 驗過所有數字跟連結，沒有捏造也沒有模型名稱漂移。

預防性 `/tmp` chunk 策略做 Write（每份檔案 < 50 行）避免 stream idle timeout。SP 在 branch 上走完整 workflow：寫 zh-tw → tribunal → rewrite → pass → 翻 en → swap PENDING → SP-181 → bump counter 182 → commit → push。

## Test plan

- [x] `node scripts/validate-posts.mjs` pass（944 files, 0 errors）
- [x] `pnpm run build` 通過（2863 頁，~90s）
- [x] Pre-commit：pronoun clarity、score gate、content-integrity BDD 全過
- [x] Pre-push：budget checks pass（trend monitor 有 warning 但 non-blocking，跟本 PR 無關）
- [x] Vercel preview 部署後人肉瀏覽（reviewer 請看 zh-tw + en 兩版在 dark / light theme 下的 ClawdNote 顯示、internal links、TOC 生成）
- [x] 4-judge tribunal 全過、scores 寫入 frontmatter

https://claude.ai/code/session_014NgxrsvXReLMftHKkYuq7C

---
_Generated by [Claude Code](https://claude.ai/code/session_014NgxrsvXReLMftHKkYuq7C)_