### PR TITLE
feat(tribunal): final build gate and shared build lock

### DIFF
--- a/docs/tribunal-runbook.md
+++ b/docs/tribunal-runbook.md
@@ -72,7 +72,7 @@ Two channels, same semantics (see `tribunal-run-control.sh`):
 - **Signal** — `systemctl --user stop tribunal-loop` sends SIGTERM. With `KillMode=mixed`, only the supervisor gets the signal; the in-flight per-article subprocess is left alive to finish its current article.
 - **File flag** — `touch .score-loop/control/stop-graceful`. Supervisor and workers poll in 15s slices, both notice within a slice and enter drain.
 
-Safe boundary = **article**, not stage. A stop during a judge call waits for the stage + rewrite + build to finish, then the next article won't be dispatched. Worst case ~60min per article (systemd `TimeoutStopSec=3600`).
+Safe boundary = **article**, not stage. A stop during a judge call waits for the stage + rewrite + final build gate to finish, then the next article won't be dispatched. Worst case ~60min per article (systemd `TimeoutStopSec=3600`).
 
 Restart after stop: `systemctl --user start tribunal-loop`. `rc_exit_stopped` removes the flag file on clean exit, so there's no sticky stop-state to clear.
 
@@ -97,8 +97,8 @@ ps -ef --forest | grep -E "tribunal|bash scripts/tribunal"
 ```
 
 Exit code conventions (from `tribunal-all-claude.sh`):
-- `0` — all 4 stages passed
-- `1` — stage failed (normal failure, will be retried on next dispatch)
+- `0` — all 4 stages passed and final full-site build passed
+- `1` — stage or final build gate failed (normal failure, will be retried on next dispatch)
 - `2` — EXHAUSTED (hit `MAX_TOP_ATTEMPTS=5`; will NOT be retried automatically)
 - `75` — skipped (per-article lock held by another instance)
 - `77` — stopped_by_request (graceful stop propagated from a long wait)
@@ -123,6 +123,39 @@ scripts/tribunal-worker-bootstrap.sh remove-all
 ```
 
 Disk cost: ~500MB per worker (pnpm `node_modules` per worktree). On clawd-vm (75GB, historically ~45GB used) this is fine for 2–3 workers.
+
+## Final build gate + shared build lock
+
+Tribunal no longer runs `pnpm run build` after every writer rewrite. Rewrites get cheap validation only (`validate-posts` for the target post + `git diff --check`). The full site build runs once, after all 4 judges pass and before PASS is persisted.
+
+All workers serialize final builds through the main repo lock path:
+
+```bash
+.score-loop/locks/build.lock
+```
+
+The supervisor exports `TRIBUNAL_SHARED_LOCK_DIR=$ROOT_DIR/.score-loop/locks`, so worker worktrees all wait on the same lock instead of each worktree creating its own.
+
+Useful troubleshooting commands:
+
+```bash
+# See final build gate lifecycle in logs
+ls -t .score-loop/logs/tribunal-quota-loop-*.log | head -1 | xargs grep -E 'Waiting for build lock|Acquired build lock|Running final pnpm build|Final build (passed|failed)|Released build lock|classified as'
+
+# Confirm current build process count
+pgrep -af 'astro.*build|pnpm run build'
+
+# Inspect lock file / holders (Linux)
+ls -l .score-loop/locks/build.lock
+fuser -v .score-loop/locks/build.lock 2>/dev/null || true
+```
+
+Log interpretation:
+- `Waiting for build lock` but no `Acquired` yet: worker is queued behind another final build; timeout has not started.
+- `Acquired build lock after Ns`: worker now owns the exclusive lock; only now does the 900s build timeout start.
+- `Final build failed rc=124`: build execution timed out (`timeout --kill-after=15s 900 ...`), treated as operational/resource, no writer repair.
+- `Final build failed rc=137` or log evidence like `heap out of memory`, `FATAL ERROR`, `SIGKILL`, `oom-kill`: likely resource/OOM, no writer repair.
+- Build logs mentioning MDX/frontmatter/schema/render/content collection errors are treated as content-actionable and may trigger up to 2 bounded writer repair attempts. PASS is never written unless a subsequent final build succeeds.
 
 ## Auto scale-down / up (memory throttle)
 

--- a/openspec/changes/tribunal-final-build-gate/design.md
+++ b/openspec/changes/tribunal-final-build-gate/design.md
@@ -1,0 +1,125 @@
+## Context
+
+Tribunal worker pipeline currently performs an expensive full Astro build immediately after each `tribunal-writer` rewrite. This catches broken MDX early, but it couples every content-quality iteration to a full-site production build. On the VPS, a single `astro.js build` has been observed at ~2GB RSS; recent loop logs show 49 measured post-rewrite builds with median ~113s and max ~160s. The failure mode under parallelism is not primarily quota exhaustion but RAM spikes when multiple workers reach build at the same time.
+
+The current quota controller can recommend high concurrency, and memory autoscale can reduce worker count after OOM. That is reactive. This change makes build resource usage structurally safer by reducing build count and serializing the remaining builds.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Reduce number of full `pnpm run build` executions per article.
+- Preserve final correctness: no article may be marked PASS until a full production build succeeds after final content changes.
+- Prevent concurrent Astro builds across worker worktrees on the same VM.
+- Keep workers free to parallelize token-heavy judge/writer work while serializing only the RAM-heavy build phase.
+- Make build wait/execute/fail states visible in logs.
+- Avoid false timeout attribution by not counting lock wait time as build execution time.
+
+**Non-Goals:**
+- Do not introduce dynamic rendering or gu-log-api page serving.
+- Do not remove full-site build from the final gate.
+- Do not redesign the four judge stages.
+- Do not rely on Vercel deploy failure as the first build signal.
+
+## Decisions
+
+### D1: Full build moves from post-writer loop to final gate
+
+**Decision:** After a writer rewrite, run cheap validation only. Run full `pnpm run build` once all content judges have passed and before `mark_article_passed`.
+
+**Rationale:** Content judges do not need a full-site build after every rewrite. Full build is a deployability/syntax/render gate and is most valuable after final content state is known.
+
+**Trade-off:** Broken MDX may survive until final gate if cheap validation misses it. This is acceptable because final build still blocks PASS, and cheap validation catches common low-level mistakes earlier.
+
+### D2: Cheap validation remains inside rewrite loop
+
+**Decision:** Each writer rewrite SHALL still perform low-cost validation before re-scoring.
+
+Expected cheap checks:
+- Target zh-tw post still exists.
+- EN counterpart still exists if it existed before rewrite.
+- Frontmatter parses and required schema fields remain valid.
+- Target post validation command passes when available, e.g. `node scripts/validate-posts.mjs src/content/posts/<post>.mdx`.
+- `git diff --check` passes for touched post files.
+
+Cheap validation SHALL NOT call heavyweight full-project checks such as `pnpm run build` or any command known to initialize the full Astro/Vite production build graph. If an optional checker loads too much of Astro/Vite and approaches full build cost, it SHOULD be excluded from the rewrite loop and reserved for the final gate.
+
+**Rationale:** Cheap validation prevents obvious syntax/schema damage from wasting judge calls while avoiding full Astro memory spikes.
+
+### D3: Shared build lock uses stable repo-scoped path
+
+**Decision:** Full build SHALL use a blocking exclusive `flock` on a stable shared path, e.g. `${TRIBUNAL_SHARED_LOCK_DIR}/build.lock`, where the shared lock dir resolves to the main repo `.score-loop/locks` directory, not each worker worktree.
+
+**Rationale:** Workers run in separate worktrees; relative lock paths inside each worktree do not serialize anything. A stable main-repo lock path is easy to inspect and avoids `/tmp` date/name drift.
+
+### D4: Lock wait and build timeout are separate concepts
+
+**Decision:** The process SHALL log before waiting for the lock, after acquiring it, and after release. The build timeout SHALL wrap only `pnpm run build` execution after lock acquisition, not the waiting period.
+
+**Rationale:** A worker waiting behind another build should not be counted as a build timeout. If the build itself hangs, `timeout` kills it and releases the lock when the subshell exits.
+
+### D5: Build failure becomes a final judge failure with bounded repair
+
+**Decision:** If final build fails, Tribunal SHALL NOT mark article PASS. It SHALL classify the failure before spending repair tokens:
+
+- Syntax/schema/render failures likely caused by the target post MAY enter writer/fixer repair with build log tail and target post context.
+- System/resource failures such as exit 137, OOM-kill evidence, Node/V8 fatal process errors, or infrastructure interruption SHALL NOT be blindly sent to writer as if they were content bugs. They SHOULD fail the build gate as an operational/resource failure, lower concurrency if applicable, and/or alert the operator.
+
+Repair attempts SHALL be bounded by a configured max attempt count.
+
+**Rationale:** Build failures are often actionable and local to writer MDX/frontmatter changes, but OOM/resource failures are not useful writer feedback. Classification avoids wasting tokens on hallucinated content fixes. Bounded repair avoids infinite loops.
+
+## Proposed Flow
+
+1. For each judge stage:
+   1. Run judge.
+   2. If PASS, persist stage score and continue.
+   3. If FAIL, call `tribunal-writer`.
+   4. Run cheap validation.
+   5. Re-score same stage.
+2. After all judge stages PASS:
+   1. Enter final build gate.
+   2. Ensure the shared lock directory exists with `mkdir -p`.
+   3. Wait for shared build lock.
+   4. Run `timeout --kill-after=<grace> <BUILD_TIMEOUT> pnpm run build`.
+   5. If PASS, mark article PASS.
+   6. If FAIL, classify the failure; invoke build fixer only for actionable content/render failures and retry up to max attempts.
+
+## Observability
+
+Logs SHALL include:
+- `Waiting for build lock: <path>`
+- `Acquired build lock after <seconds>s`
+- `Running final pnpm build...`
+- `Final build passed in <seconds>s`
+- `Final build failed rc=<code> duration=<seconds>s`
+- `Released build lock`
+
+Operators SHALL be able to verify safety with:
+
+```bash
+ps -eo pid,ppid,stat,etime,%mem,rss,comm,args | grep 'astro.js build'
+```
+
+Expected: at most one `astro.js build` per VM while Tribunal is running.
+
+## Risks / Trade-offs
+
+**[Risk] Cheap validation misses a render-only bug** → final full build still catches it before PASS.
+
+**[Risk] Build lock serializes too much and reduces throughput** → intended; token-heavy judge work remains parallel, only RAM-heavy full build serializes.
+
+**[Risk] Lock path accidentally points to each worker worktree** → add explicit logging of resolved lock path and verify with concurrent workers.
+
+**[Risk] Build wait looks like hang** → log waiting/acquired timestamps and keep timeout scoped to build execution.
+
+**[Risk] Final build repair loop consumes tokens** → cap attempts and mark article FAILED/EXHAUSTED on repeated build failure.
+
+## Migration Plan
+
+1. Add shared lock dir export in supervisor if not already present.
+2. Implement cheap validation helper in `tribunal-all-claude.sh`.
+3. Remove immediate full build from writer rewrite loop.
+4. Add final build gate before `mark_article_passed`.
+5. Add build-fix loop with max attempts and clear logs.
+6. Validate with shell-level flock test and live Tribunal observation.
+7. Monitor `systemctl --user show tribunal-loop.service -p MemoryPeak` and count concurrent `astro.js build` processes.

--- a/openspec/changes/tribunal-final-build-gate/proposal.md
+++ b/openspec/changes/tribunal-final-build-gate/proposal.md
@@ -1,0 +1,35 @@
+## Why
+
+Tribunal 現在每次 judge FAIL 後呼叫 `tribunal-writer` rewrite，接著立即跑 `pnpm run build` 驗證整站。這個策略安全但昂貴：Astro production build 是整站 build，近期 log 顯示單次 build 中位數約 113 秒，且 `astro.js build` 可吃到 2GB+ RSS。多 worker 同時 rewrite 時，多個 build 會疊在一起，造成 MemoryMax 撞牆、exit 137 / OOM、service restart，反而浪費 token 重跑。
+
+需要把 full build 從「每次 rewrite 後」移成「文章所有 judges PASS 後的 final gate」，並用 shared build lock 保證同一台 VM 同一時間最多一個 Astro full build。中間 rewrite loop 保留 cheap validation，避免明顯壞 MDX/metadata 一路流到最後。
+
+## What Changes
+
+- **新增 final build gate**：文章所有 Tribunal judge stages PASS 後，才執行 full `pnpm run build`。build PASS 才能 mark article PASS。
+- **新增 shared build lock**：所有 worker worktrees 在 full build 前使用同一個 shared lock path，透過 blocking exclusive `flock` 序列化 Astro build。
+- **writer 後改 cheap validation**：`tribunal-writer` rewrite 後不再立即 full build，改跑低成本驗證（檔案存在、frontmatter/schema/target post validation、diff sanity）。
+- **build-fix loop**：final build FAIL 時，視為 final judge failure；以 build log tail 呼叫 writer/fixer 修語法或 render 問題，並有 max attempts。
+- **timeout 與 logging**：分清楚 waiting for lock、acquired lock、build duration、build rc。timeout SHALL 包住 build execution，不把 lock wait 誤算成 build timeout。
+
+## Capabilities
+
+### New Capabilities
+- `tribunal-final-build-gate`: final full-site build gate、shared build lock、cheap validation、build-fix loop、build observability。
+
+### Modified Capabilities
+- `tribunal-safe-parallelism`: 多 worker 並行時 SHALL 序列化 full build resource spike，不允許多個 Astro build 同時壓 RAM。
+
+## Impact
+
+- **scripts/tribunal-all-claude.sh** — 主要修改：移動 build timing、加入 cheap validation、final build gate、build-fix loop、shared flock。
+- **scripts/tribunal-quota-loop.sh** — 可能修改：export shared lock directory 給 worker worktrees，或確認現有 shared coordinates 可重用。
+- **.score-loop/locks/build.lock** — 新增 runtime lock artifact；檔案可常駐，lock state 由 kernel flock 管理。
+- **docs/runbook / logs** — 操作上可用 log 判斷 build 是在等 lock、執行中、timeout、還是 fail。
+
+## Non-Goals
+
+- 不把 gu-log 改成 dynamic / hybrid website。
+- 不取消 final full build；本 change 仍以 production build 作為最後正確性 gate。
+- 不改 judge scoring semantics、model pinning 或 quota controller 演算法。
+- 不把 build lock path 放到帶日期的 `/tmp` 檔名；lock path 必須穩定且所有 workers 共用。

--- a/openspec/changes/tribunal-final-build-gate/specs/tribunal-final-build-gate/spec.md
+++ b/openspec/changes/tribunal-final-build-gate/specs/tribunal-final-build-gate/spec.md
@@ -1,0 +1,102 @@
+## ADDED Requirements
+
+### Requirement: Tribunal SHALL defer full-site build to a final gate
+
+Tribunal SHALL NOT run full `pnpm run build` after every `tribunal-writer` rewrite. It SHALL run full-site build only after all article judge stages have passed and before the article is marked PASS.
+
+#### Scenario: Writer rewrite does not trigger full build immediately
+
+- **WHEN** a judge stage fails and `tribunal-writer` rewrites the target post
+- **THEN** the worker SHALL run cheap validation for the changed post files
+- **AND** the worker SHALL NOT run full `pnpm run build` solely because the rewrite completed
+- **AND** the worker SHALL continue the judge retry loop if cheap validation passes
+
+#### Scenario: Article cannot pass without final full build
+
+- **WHEN** all judge stages have passed for an article
+- **THEN** the worker SHALL enter the final build gate before marking the article PASS
+- **AND** the article SHALL NOT be marked PASS unless the final full `pnpm run build` succeeds after the final content changes
+
+### Requirement: Tribunal SHALL run cheap validation after writer rewrites
+
+Tribunal SHALL perform low-cost validation after each writer rewrite to catch common local errors before spending more judge tokens.
+
+#### Scenario: Cheap validation passes
+
+- **WHEN** `tribunal-writer` rewrites a post and cheap validation succeeds
+- **THEN** the worker SHALL continue to re-score the current judge stage
+- **AND** the worker SHALL preserve the writer's changes for the next judge attempt
+
+#### Scenario: Cheap validation fails
+
+- **WHEN** `tribunal-writer` rewrites a post and cheap validation fails
+- **THEN** the worker SHALL log the validation failure
+- **AND** the worker SHALL revert or repair the writer changes before continuing
+- **AND** the worker SHALL NOT mark the article PASS based on unvalidated changes
+
+### Requirement: Tribunal SHALL serialize full builds with a shared build lock
+
+Tribunal SHALL use a blocking exclusive file lock for full-site builds so that, on one VM, at most one worker runs `pnpm run build` at a time.
+
+#### Scenario: Multiple workers reach final build gate
+
+- **WHEN** two or more workers reach the final build gate concurrently
+- **THEN** exactly one worker SHALL hold the shared build lock and run `pnpm run build`
+- **AND** the other workers SHALL wait for the same shared lock instead of starting concurrent builds
+- **AND** after the first build releases the lock, the next waiting worker MAY acquire the lock and run its build
+
+#### Scenario: Workers run in separate worktrees
+
+- **WHEN** workers execute from separate worktree directories
+- **THEN** all workers SHALL resolve the build lock to the same stable shared path rooted in the main repo runtime state
+- **AND** the lock path SHALL NOT be relative to each worker worktree
+- **AND** the lock path SHALL NOT include a date or other value that could diverge across workers during one daemon lifetime
+
+### Requirement: Build timeout SHALL apply to build execution, not lock wait
+
+Tribunal SHALL distinguish waiting for the build lock from executing the build.
+
+#### Scenario: Worker waits behind another build
+
+- **WHEN** a worker is waiting for the shared build lock
+- **THEN** the worker SHALL log that it is waiting and the resolved lock path
+- **AND** the build execution timeout SHALL NOT start until after the lock is acquired
+
+#### Scenario: Build execution hangs or exceeds timeout
+
+- **WHEN** a worker has acquired the build lock and `pnpm run build` exceeds the configured timeout
+- **THEN** the build command SHALL be terminated
+- **AND** the termination SHOULD include a kill-after grace period so child Astro/Vite processes that ignore SIGTERM are reaped
+- **AND** the worker SHALL treat the final build as failed
+- **AND** the lock SHALL be released when the build subprocess exits
+
+### Requirement: Final build failures SHALL enter bounded repair, not PASS
+
+If final full build fails, Tribunal SHALL treat it as a final gate failure and SHALL NOT mark the article PASS.
+
+#### Scenario: Final build fails with content-actionable evidence
+
+- **WHEN** final `pnpm run build` returns a non-zero exit code and the build log indicates syntax, schema, MDX, component render, or target-post validation failure
+- **THEN** the worker SHALL log the exit code and build log tail
+- **AND** the worker SHALL invoke a build repair path with the target post and build failure evidence
+- **AND** the worker SHALL retry final build only up to a configured maximum attempt count
+- **AND** if repair attempts are exhausted, the article SHALL be marked FAILED or EXHAUSTED rather than PASS
+
+#### Scenario: Final build fails with operational/resource evidence
+
+- **WHEN** final `pnpm run build` returns a non-zero exit code and the evidence indicates timeout, exit 137, OOM-kill, Node/V8 fatal error, or infrastructure interruption
+- **THEN** the worker SHALL log the failure as operational/resource-related
+- **AND** the worker SHALL NOT blindly invoke writer repair as if the target post were broken
+- **AND** the article SHALL NOT be marked PASS
+
+### Requirement: Final build gate SHALL be observable
+
+Tribunal SHALL emit enough structured log lines for operators to distinguish build lock waiting, build execution, build success, build failure, timeout, and likely OOM.
+
+#### Scenario: Operator inspects Tribunal logs
+
+- **WHEN** an operator reads the quota loop or article log
+- **THEN** the log SHALL show when a worker begins waiting for the build lock
+- **AND** when it acquires the lock
+- **AND** how long the build ran
+- **AND** whether the build passed or failed with its exit code

--- a/openspec/changes/tribunal-final-build-gate/tasks.md
+++ b/openspec/changes/tribunal-final-build-gate/tasks.md
@@ -1,0 +1,26 @@
+## 1. Implementation
+
+- [ ] 1.1 Add or confirm supervisor export for a shared lock directory rooted at the main repo, e.g. `TRIBUNAL_SHARED_LOCK_DIR=$ROOT_DIR/.score-loop/locks`.
+- [ ] 1.2 Add a cheap validation helper for post-writer rewrites.
+- [ ] 1.3 Replace post-writer full `pnpm run build` with cheap validation in the judge retry loop.
+- [ ] 1.4 Add final build gate after all judge stages pass and before article PASS is persisted.
+- [ ] 1.5 Ensure the shared lock directory exists with `mkdir -p` before `flock`.
+- [ ] 1.6 Wrap final build in blocking exclusive `flock` on the shared build lock.
+- [ ] 1.7 Scope timeout to `pnpm run build` after lock acquisition, not to lock waiting; use `timeout --kill-after` so child processes are reaped.
+- [ ] 1.8 Classify build failures before repair: content-actionable failures may call writer/fixer; operational/resource failures SHALL NOT spend writer tokens blindly.
+- [ ] 1.9 Add build-fix loop with max attempts and build log tail passed to writer/fixer only for actionable failures.
+- [ ] 1.10 Emit logs for waiting/acquired/released lock, build duration, and build rc.
+
+## 2. Verification
+
+- [ ] 2.1 Run `openspec validate tribunal-final-build-gate --strict`.
+- [ ] 2.2 Run shell-level flock test with two concurrent commands against the chosen lock path.
+- [ ] 2.3 Run a controlled Tribunal article that triggers writer rewrite and confirm no full build occurs immediately after writer unless final gate is reached.
+- [ ] 2.4 Observe live processes and confirm at most one `astro.js build` at a time.
+- [ ] 2.5 Confirm build failure blocks article PASS and enters bounded repair/failure path.
+- [ ] 2.6 Confirm successful final build marks article PASS.
+
+## 3. Operations
+
+- [ ] 3.1 Update Tribunal runbook/status notes with build lock troubleshooting commands.
+- [ ] 3.2 Document how to distinguish lock wait, build execution timeout, build syntax failure, and OOM/exit 137.

--- a/openspec/changes/tribunal-final-build-gate/tasks.md
+++ b/openspec/changes/tribunal-final-build-gate/tasks.md
@@ -1,20 +1,20 @@
 ## 1. Implementation
 
-- [ ] 1.1 Add or confirm supervisor export for a shared lock directory rooted at the main repo, e.g. `TRIBUNAL_SHARED_LOCK_DIR=$ROOT_DIR/.score-loop/locks`.
-- [ ] 1.2 Add a cheap validation helper for post-writer rewrites.
-- [ ] 1.3 Replace post-writer full `pnpm run build` with cheap validation in the judge retry loop.
-- [ ] 1.4 Add final build gate after all judge stages pass and before article PASS is persisted.
-- [ ] 1.5 Ensure the shared lock directory exists with `mkdir -p` before `flock`.
-- [ ] 1.6 Wrap final build in blocking exclusive `flock` on the shared build lock.
-- [ ] 1.7 Scope timeout to `pnpm run build` after lock acquisition, not to lock waiting; use `timeout --kill-after` so child processes are reaped.
-- [ ] 1.8 Classify build failures before repair: content-actionable failures may call writer/fixer; operational/resource failures SHALL NOT spend writer tokens blindly.
-- [ ] 1.9 Add build-fix loop with max attempts and build log tail passed to writer/fixer only for actionable failures.
-- [ ] 1.10 Emit logs for waiting/acquired/released lock, build duration, and build rc.
+- [x] 1.1 Add or confirm supervisor export for a shared lock directory rooted at the main repo, e.g. `TRIBUNAL_SHARED_LOCK_DIR=$ROOT_DIR/.score-loop/locks`.
+- [x] 1.2 Add a cheap validation helper for post-writer rewrites.
+- [x] 1.3 Replace post-writer full `pnpm run build` with cheap validation in the judge retry loop.
+- [x] 1.4 Add final build gate after all judge stages pass and before article PASS is persisted.
+- [x] 1.5 Ensure the shared lock directory exists with `mkdir -p` before `flock`.
+- [x] 1.6 Wrap final build in blocking exclusive `flock` on the shared build lock.
+- [x] 1.7 Scope timeout to `pnpm run build` after lock acquisition, not to lock waiting; use `timeout --kill-after` so child processes are reaped.
+- [x] 1.8 Classify build failures before repair: content-actionable failures may call writer/fixer; operational/resource failures SHALL NOT spend writer tokens blindly.
+- [x] 1.9 Add build-fix loop with max attempts and build log tail passed to writer/fixer only for actionable failures.
+- [x] 1.10 Emit logs for waiting/acquired/released lock, build duration, and build rc.
 
 ## 2. Verification
 
-- [ ] 2.1 Run `openspec validate tribunal-final-build-gate --strict`.
-- [ ] 2.2 Run shell-level flock test with two concurrent commands against the chosen lock path.
+- [x] 2.1 Run `openspec validate tribunal-final-build-gate --strict`.
+- [x] 2.2 Run shell-level flock test with two concurrent commands against the chosen lock path.
 - [ ] 2.3 Run a controlled Tribunal article that triggers writer rewrite and confirm no full build occurs immediately after writer unless final gate is reached.
 - [ ] 2.4 Observe live processes and confirm at most one `astro.js build` at a time.
 - [ ] 2.5 Confirm build failure blocks article PASS and enters bounded repair/failure path.
@@ -22,5 +22,5 @@
 
 ## 3. Operations
 
-- [ ] 3.1 Update Tribunal runbook/status notes with build lock troubleshooting commands.
-- [ ] 3.2 Document how to distinguish lock wait, build execution timeout, build syntax failure, and OOM/exit 137.
+- [x] 3.1 Update Tribunal runbook/status notes with build lock troubleshooting commands.
+- [x] 3.2 Document how to distinguish lock wait, build execution timeout, build syntax failure, and OOM/exit 137.

--- a/scripts/tribunal-all-claude.sh
+++ b/scripts/tribunal-all-claude.sh
@@ -195,6 +195,207 @@ mark_article_passed() {
   ) 9>>"$RC_PROGRESS_LOCK"
 }
 
+# ─── Cheap Validation + Final Build Gate ─────────────────────────────────────
+# After writer rewrites we intentionally avoid full-site builds; those are
+# serialized and deferred to the final gate after all judge stages pass.
+cheap_validate_writer_rewrite() {
+  local post_file="$1" en_existed_before="$2"
+  local post_rel="src/content/posts/$post_file"
+  local en_rel="src/content/posts/en-$post_file"
+  local diff_paths=("$post_rel")
+
+  if [ ! -f "$post_rel" ]; then
+    tlog "  ERROR: cheap validation failed: post file missing after writer rewrite ($post_rel)."
+    return 1
+  fi
+
+  if [ "$en_existed_before" = "1" ]; then
+    if [ ! -f "$en_rel" ]; then
+      tlog "  ERROR: cheap validation failed: EN counterpart missing after writer rewrite ($en_rel)."
+      return 1
+    fi
+    diff_paths+=("$en_rel")
+  elif git ls-files --error-unmatch "$en_rel" >/dev/null 2>&1; then
+    diff_paths+=("$en_rel")
+  fi
+
+  local validate_paths=("$post_rel")
+  if [[ " ${diff_paths[*]} " == *" $en_rel "* ]]; then
+    validate_paths+=("$en_rel")
+  fi
+
+  tlog "  Running cheap post validation for ${validate_paths[*]}..."
+  if ! node scripts/validate-posts.mjs "${validate_paths[@]}" >> "$LOG_FILE" 2>&1; then
+    tlog "  ERROR: cheap validation failed: validate-posts rejected rewritten post files."
+    return 1
+  fi
+
+  tlog "  Running git diff --check for rewritten post files..."
+  if ! git diff --check -- "${diff_paths[@]}" >> "$LOG_FILE" 2>&1; then
+    tlog "  ERROR: cheap validation failed: git diff --check found whitespace/conflict issues."
+    return 1
+  fi
+
+  tlog "  Cheap validation passed after writer rewrite."
+  return 0
+}
+
+revert_writer_rewrite_files() {
+  local post_file="$1"
+  local post_rel="src/content/posts/$post_file"
+  local en_rel="src/content/posts/en-$post_file"
+  git checkout -- "$post_rel" 2>/dev/null || true
+  if git ls-files --error-unmatch "$en_rel" >/dev/null 2>&1; then
+    git checkout -- "$en_rel" 2>/dev/null || true
+  elif [ -e "$en_rel" ]; then
+    rm -f -- "$en_rel"
+  fi
+}
+
+classify_build_failure() {
+  local rc="$1" build_log="$2" post_file="$3"
+  local post_rel="src/content/posts/$post_file"
+  local en_rel="src/content/posts/en-$post_file"
+  if [ "$rc" -eq 124 ] || [ "$rc" -eq 137 ]; then
+    echo operational
+    return 0
+  fi
+  if grep -Eiq 'out of memory|oom-kill|oom killed|killed process|heap out of memory|JavaScript heap out of memory|FATAL ERROR|SIGKILL|Killed$|Exit status 137' "$build_log" 2>/dev/null; then
+    echo operational
+    return 0
+  fi
+  # Only spend writer repair tokens when the full-build evidence points at the
+  # target post or its EN counterpart. Unrelated global/component/build breaks
+  # should fail safely instead of asking the writer to hallucinate a content fix.
+  if grep -Fq "$post_rel" "$build_log" 2>/dev/null || grep -Fq "$en_rel" "$build_log" 2>/dev/null; then
+    if grep -Eiq 'MDX|frontmatter|schema|Expected|Unexpected|SyntaxError|ParseError|cannot render|render|component|validate-posts|content collection|astro:content|src/content/posts' "$build_log" 2>/dev/null; then
+      echo actionable
+      return 0
+    fi
+  fi
+  echo unknown
+}
+
+run_final_build_once() {
+  local build_log="$1"
+  local lock_dir="${TRIBUNAL_SHARED_LOCK_DIR:-${TRIBUNAL_MAIN_REPO:-$ROOT_DIR}/.score-loop/locks}"
+  local lock_file="$lock_dir/build.lock"
+  local wait_start wait_duration rc
+  mkdir -p "$lock_dir"
+  wait_start="$(date +%s)"
+  tlog "Waiting for build lock: $lock_file"
+  rc=0
+  (
+    flock -x 8
+    wait_duration=$(($(date +%s) - wait_start))
+    tlog "Acquired build lock after ${wait_duration} seconds"
+    local build_start build_duration build_rc
+    build_start="$(date +%s)"
+    build_rc=0
+    tlog "Running final pnpm build"
+    timeout --kill-after=15s 900 pnpm run build > "$build_log" 2>&1 || build_rc=$?
+    build_duration=$(($(date +%s) - build_start))
+    if [ "$build_rc" -eq 0 ]; then
+      tlog "Final build passed rc=0 duration=${build_duration}s"
+    else
+      tlog "Final build failed rc=$build_rc duration=${build_duration}s"
+      tail -30 "$build_log" | while IFS= read -r line; do tlog "    $line"; done
+    fi
+    exit "$build_rc"
+  ) 8>>"$lock_file" || rc=$?
+  tlog "Released build lock"
+  return "$rc"
+}
+
+repair_final_build_failure() {
+  local post_file="$1" build_log="$2" repair_attempt="$3"
+  local evidence writer_prompt writer_out writer_rc en_existed_before
+  evidence="$(tail -80 "$build_log" 2>/dev/null || true)"
+  if [ -f "src/content/posts/en-$post_file" ]; then
+    en_existed_before=1
+  else
+    en_existed_before=0
+  fi
+
+  tlog "Invoking tribunal-writer for final build repair attempt $repair_attempt/2..."
+  writer_prompt="$(cat <<PROMPT
+You are the tribunal-writer for gu-log. All judge stages passed, but the final full-site build failed.
+
+## Target post
+src/content/posts/$post_file
+
+## Build failure evidence (tail)
+$evidence
+
+## Task
+1. Fix only content-actionable problems in src/content/posts/$post_file.
+2. Also update src/content/posts/en-$post_file if it exists and the same issue applies.
+3. Do not rewrite unrelated content and do not change stable frontmatter fields unless the build error specifically requires it.
+PROMPT
+)"
+  writer_out="$(mktemp)"
+  writer_rc=0
+  local -a writer_cmd=(timeout 900 claude -p --agent tribunal-writer --model 'claude-opus-4-6[1m]')
+  [ "$(id -u)" != "0" ] && writer_cmd+=(--dangerously-skip-permissions)
+  "${writer_cmd[@]}" "$writer_prompt" > "$writer_out" 2>&1 || writer_rc=$?
+  if [ "$writer_rc" -ne 0 ]; then
+    tlog "  WARN: final build repair writer exited with code $writer_rc"
+    tail -10 "$writer_out" | while IFS= read -r line; do tlog "    $line"; done
+    rm -f "$writer_out"
+    return 1
+  fi
+  rm -f "$writer_out"
+
+  cheap_validate_writer_rewrite "$post_file" "$en_existed_before"
+}
+
+run_final_build_gate() {
+  local post_file="$1"
+  local max_repairs=2
+  local repair_attempt=0
+  local build_log build_rc classification
+  build_log="$(mktemp /tmp/tribunal-final-build-XXXXXX.log)"
+
+  while true; do
+    : > "$build_log"
+    build_rc=0
+    run_final_build_once "$build_log" || build_rc=$?
+    if [ "$build_rc" -eq 0 ]; then
+      rm -f "$build_log"
+      return 0
+    fi
+
+    classification="$(classify_build_failure "$build_rc" "$build_log" "$post_file")"
+    tlog "Final build failure classified as: $classification (rc=$build_rc)"
+    if [ "$classification" = "operational" ]; then
+      tlog "Final build failed due to likely operational/resource issue; not invoking writer repair."
+      revert_writer_rewrite_files "$post_file"
+      rm -f "$build_log"
+      return 1
+    fi
+    if [ "$classification" != "actionable" ]; then
+      tlog "Final build failure is not clearly content-actionable; failing safely without PASS."
+      revert_writer_rewrite_files "$post_file"
+      rm -f "$build_log"
+      return 1
+    fi
+    if [ "$repair_attempt" -ge "$max_repairs" ]; then
+      tlog "Final build repair attempts exhausted ($max_repairs); failing without PASS."
+      revert_writer_rewrite_files "$post_file"
+      rm -f "$build_log"
+      return 1
+    fi
+
+    repair_attempt=$((repair_attempt + 1))
+    if ! repair_final_build_failure "$post_file" "$build_log" "$repair_attempt"; then
+      tlog "Final build repair attempt $repair_attempt failed cheap validation; failing without PASS."
+      revert_writer_rewrite_files "$post_file"
+      rm -f "$build_log"
+      return 1
+    fi
+  done
+}
+
 # ─── Pass Bar Checks (code is the rule) ───────────────────────────────────────
 # Returns 0 = PASS, 1 = FAIL
 check_pass_bar() {
@@ -409,7 +610,12 @@ Write your JSON result to: $score_tmp" \
     # ── Rewrite: invoke tribunal-writer (timeout 900s / 15 min) ──────────────
     tlog "  Invoking tribunal-writer for rewrite (timeout 900s)..."
 
-    local writer_prompt writer_out writer_rc
+    local writer_prompt writer_out writer_rc en_existed_before
+    if [ -f "src/content/posts/en-$post_file" ]; then
+      en_existed_before=1
+    else
+      en_existed_before=0
+    fi
     writer_prompt="$(cat <<PROMPT
 You are the tribunal-writer for gu-log. The $label judge reviewed this post and it FAILED.
 
@@ -450,32 +656,11 @@ PROMPT
     fi
     rm -f "$writer_out"
 
-    # ── Verify post file still exists after rewrite ───────────────────────────
-    if [ ! -f "$post_path" ]; then
-      tlog "  ERROR: post file missing after writer rewrite. Reverting via git."
-      git checkout -- "src/content/posts/$post_file" 2>/dev/null || true
-      continue
+    # ── Cheap validation after rewrite (full build is deferred to final gate) ─
+    if ! cheap_validate_writer_rewrite "$post_file" "$en_existed_before"; then
+      tlog "  ERROR: cheap validation failed after writer rewrite. Reverting changes."
+      revert_writer_rewrite_files "$post_file"
     fi
-
-    # ── Build check after rewrite ─────────────────────────────────────────────
-    tlog "  Running pnpm build to verify no breakage..."
-    local build_log build_rc
-    build_log="$(mktemp)"
-    build_rc=0
-    pnpm run build > "$build_log" 2>&1 || build_rc=$?
-
-    if [ "$build_rc" -ne 0 ]; then
-      tlog "  ERROR: build failed after writer rewrite. Reverting changes."
-      tail -15 "$build_log" | while IFS= read -r line; do tlog "    $line"; done
-      git checkout -- "src/content/posts/$post_file" 2>/dev/null || true
-      local en_file="src/content/posts/en-$post_file"
-      if git ls-files --error-unmatch "$en_file" &>/dev/null 2>&1; then
-        git checkout -- "$en_file" 2>/dev/null || true
-      fi
-    else
-      tlog "  Build passed after rewrite."
-    fi
-    rm -f "$build_log"
 
     # Loop: re-score on next iteration
   done
@@ -568,6 +753,13 @@ for stage_def in "${STAGES[@]}"; do
 done
 
 tlog "=== ALL 4 STAGES PASSED: $POST_FILE ==="
+if ! run_final_build_gate "$POST_FILE"; then
+  tlog "=== FAILED at final build gate: $POST_FILE ==="
+  mark_article_failed "$POST_FILE" "finalBuild"
+  commit_progress "tribunal(${POST_FILE%.mdx}): FAILED at final build gate"
+  exit 1
+fi
+
 mark_article_passed "$POST_FILE"
-commit_progress "tribunal(${POST_FILE%.mdx}): all 4 stages PASS"
+commit_progress "tribunal(${POST_FILE%.mdx}): all 4 stages PASS + final build"
 tlog "Done. Log: $LOG_FILE"

--- a/scripts/tribunal-quota-loop.sh
+++ b/scripts/tribunal-quota-loop.sh
@@ -717,6 +717,7 @@ spawn_worker() {
     export RC_ROOT_DIR="$ROOT_DIR"
     export PROGRESS_FILE="$ROOT_DIR/scores/tribunal-progress.json"
     export TRIBUNAL_MAIN_REPO="$ROOT_DIR"
+    export TRIBUNAL_SHARED_LOCK_DIR="$ROOT_DIR/.score-loop/locks"
     export TRIBUNAL_WORKER_ID="$id"
     bash "$wt/scripts/tribunal-all-claude.sh" "$article" >> "$LOG_FILE" 2>&1
   ) &


### PR DESCRIPTION
## Summary
- Add OpenSpec change for Tribunal final build gate + shared build lock
- Move full pnpm build to final gate after all judge stages pass
- Add cheap validation after writer rewrites
- Serialize full builds with shared flock across worker worktrees
- Add build failure classification and bounded repair handling

## Verification
- openspec validate tribunal-final-build-gate --strict
- bash -n scripts/tribunal-all-claude.sh scripts/tribunal-quota-loop.sh
- git diff --check
- bash scripts/tests/test-quota-controller.sh (32/32)
- pnpm install --frozen-lockfile
- pnpm run build (passed, 2869 pages, 104.83s)

Note: scripts/tests/test-validate-judge-output.sh currently exits rc=1 with no output; observed as pre-existing/orthogonal during implementation review.