### PR TITLE
fix(sp-pipeline): use acceptEdits perm mode under root for CCC sandbox

### DIFF
--- a/tools/sp-pipeline/cmd/sp-pipeline/run.go
+++ b/tools/sp-pipeline/cmd/sp-pipeline/run.go
@@ -87,10 +87,12 @@ when --from-step skips the fetch stage and no tweet URL is given.
 --dry-run stops before the deploy stage (matches bash --dry-run).
 
 CCC note: claude -p works in the sandbox — CCC is authenticated via the
-parent Claude Code session. The provider transparently drops
---permission-mode bypassPermissions when running as root so the CLI does
-not refuse to start. Use --fake-provider <json> only to test without
-spending credits or to pin canned responses for regression tests.`,
+parent Claude Code session. Under root (CCC / Claude Code on the web)
+the provider switches --permission-mode bypassPermissions to acceptEdits
+because claude refuses bypass under root; acceptEdits still auto-approves
+the file writes the eval/write/review/refine prompts depend on. Use
+--fake-provider <json> only to test without spending credits or to pin
+canned responses for regression tests.`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var tweetURL string

--- a/tools/sp-pipeline/internal/llm/claude.go
+++ b/tools/sp-pipeline/internal/llm/claude.go
@@ -8,11 +8,21 @@ import (
 	"github.com/chitienhsiehwork-ai/gu-log/tools/sp-pipeline/internal/runner"
 )
 
-// ClaudeProvider shells out to `claude -p --model <model>` with
-// `--permission-mode bypassPermissions` appended when not running as root.
-// Claude Code refuses the permission-bypass flags under root/sudo; CCC
-// sandboxes run as root, so we drop the flag there. -p is one-shot and does
-// not invoke tools, so the permission mode is a no-op for this call site.
+// ClaudeProvider shells out to `claude -p --model <model>` with a
+// permission-mode appropriate to the calling user. Pipeline steps after
+// eval (write/review/refine) instruct the LLM to write its output to a
+// file in WorkDir, so the model needs Write/Edit permission — `-p` will
+// happily invoke tools as long as a permission mode allows it.
+//
+//   - Non-root (VPS Clawd, dev laptops) → bypassPermissions: the broadest
+//     setting and the one the bash pipeline historically used.
+//   - Root (CCC sandboxes / Claude Code on the web) → acceptEdits: claude
+//     refuses bypassPermissions and --dangerously-skip-permissions under
+//     root for security reasons, but acceptEdits is allowed and auto-
+//     approves file writes/edits. Without this the eval/write/review/
+//     refine steps silently fail because the LLM's Write tool gets denied
+//     and it returns a "please approve the permission" message instead of
+//     the JSON/MDX the parser expects.
 type ClaudeProvider struct {
 	// ModelFlag is the value passed to --model. For Opus we pin the exact
 	// build ("claude-opus-4-6[1m]") rather than the "opus" alias — see the
@@ -73,6 +83,8 @@ func (c *ClaudeProvider) Run(ctx context.Context, prompt string, opts RunOptions
 	}
 	if os.Geteuid() != 0 {
 		args = append(args, "--permission-mode", "bypassPermissions")
+	} else {
+		args = append(args, "--permission-mode", "acceptEdits")
 	}
 	res, err := runner.RunWithOptions(ctx, runner.Options{
 		Name:    "claude",


### PR DESCRIPTION
## Summary

User dropped `https://x.com/mronge/status/2045234739679011144` (Astropad's "Ultimate Guide to Running a Headless Mac mini for AI agents"). `sp-pipeline run <url>` died at Step 1.5 with:

```
[ERROR] eval: parse gemini verdict: eval-gemini.json missing or unreadable
```

### Root cause

`ClaudeProvider.Run()` appends `--permission-mode bypassPermissions` only when `os.Geteuid() != 0` — under root (CCC / Claude Code on the web) the flag is dropped entirely. With no permission flag, `claude -p` cannot invoke the Write tool, so the LLM responds with *"please approve the permission"* instead of writing `eval-gemini.json` / `eval-codex.json`. Both LLM calls "succeed" (stdout returns) but no file gets written, the parser then chokes on the missing files and the run aborts before write / review / refine / tribunal even run.

Verified the failure mode interactively:
- `--permission-mode bypassPermissions` → refused under root.
- `--dangerously-skip-permissions` → also refused under root.
- `--permission-mode acceptEdits` → **allowed** under root and auto-approves Write/Edit, which is what every prompt downstream of fetch needs.

### Fix

In `tools/sp-pipeline/internal/llm/claude.go`, fall through to `--permission-mode acceptEdits` when running as root instead of dropping the permission flag entirely. Non-root behaviour (VPS Clawd, dev laptops) is unchanged — they still use `bypassPermissions`. Also update the `run` subcommand help text and the package doc-comment to describe the actual fallback rather than the old (broken) "drops the flag" behaviour.

### End-to-end verification

After the fix, `tools/sp-pipeline/sp-pipeline run https://x.com/mronge/status/2045234739679011144 --prefix SP` ran cleanly through fetch → eval and got an unambiguous **SKIP/SKIP verdict**:

> Gemini: 本質是 Astropad Workbench 的產品行銷文…AI agent 部分（OpenClaw、Hermes、Perplexity Personal Computer）只是淺層提及作為 hook…扣掉行銷內容後，真正對 gu-log 讀者有價值的 AI 內容太薄。
>
> Codex: 作者是 Astropad 員工，全篇 60%+ 在推自家 Workbench…技術深度不夠格做 SP，gu-log 不翻業配文。

This is the eval gate doing its job — the pipeline fix unblocks the gate, and the gate then correctly rejects an Astropad-marketing piece dressed up as an AI-agents guide. So no SP article ships from this URL, and this PR is just the pipeline fix.

## Test plan

- [x] Reproduce eval failure on a fresh CCC run (`eval-gemini.json missing`)
- [x] Confirm `claude -p ... --permission-mode acceptEdits` writes files under root
- [x] `go test ./internal/llm/...` passes
- [x] Pipeline reaches the eval gate decision on the @mronge URL — both judges return parseable JSON, verdict is SKIP/SKIP
- [ ] Next time a real SP source lands in CCC, write/review/refine/tribunal should also pass through (not exercised in this PR because eval correctly skipped this source)
