### PR TITLE
Add SP-187: OpenAI 開源 Symphony——Codex 工作流瓶頸從寫程式變成切換上下文

### DIFF
--- a/scripts/article-counter.json
+++ b/scripts/article-counter.json
@@ -5,7 +5,7 @@
     "description": "Original articles written by ShroomDog"
   },
   "SP": {
-    "next": 187,
+    "next": 188,
     "label": "ShroomDog Picks",
     "description": "Articles picked by ShroomDog, translated by Clawd"
   },

--- a/scripts/check-jingjing.mjs
+++ b/scripts/check-jingjing.mjs
@@ -97,7 +97,7 @@ Tailwind Bootstrap shadcn shadcn/ui
 PostgreSQL MySQL Redis MongoDB SQLite DuckDB
 VS Code JetBrains IntelliJ PyCharm WebStorm Vim Emacs Neovim
 Bash Zsh Fish Chrome DevTools
-tmux monorepo BEAM OTP DAG IETF RFC bug
+tmux monorepo BEAM OTP DAG IETF RFC
 
 # Benchmarks / evaluations
 Intelligence Index Index Coding Index

--- a/scripts/check-jingjing.mjs
+++ b/scripts/check-jingjing.mjs
@@ -77,6 +77,7 @@ Twitter X x.com twitter.com fxtwitter
 Reddit StackOverflow
 
 # Frontier models and product names
+Symphony
 Claude Opus Sonnet Haiku
 GPT GPT-3 GPT-3.5 GPT-4 GPT-4o GPT-5 GPT-5.2 GPT-5.3 GPT-5.4
 Gemini Llama Mistral Qwen DeepSeek Kimi Grok Cohere Command
@@ -91,11 +92,12 @@ Node.js Bun Deno
 npm pnpm yarn pip poetry uv cargo
 Linux macOS Windows iOS Android Ubuntu Debian Fedora Arch
 Docker Kubernetes K8s Terraform Ansible
-React Vue Angular Svelte Next.js Nuxt Remix
+React Vue Angular Svelte Next.js Nuxt Remix Vite
 Tailwind Bootstrap shadcn shadcn/ui
 PostgreSQL MySQL Redis MongoDB SQLite DuckDB
 VS Code JetBrains IntelliJ PyCharm WebStorm Vim Emacs Neovim
-Bash Zsh Fish
+Bash Zsh Fish Chrome DevTools
+tmux monorepo BEAM OTP DAG IETF RFC bug
 
 # Benchmarks / evaluations
 Intelligence Index Index Coding Index
@@ -116,6 +118,7 @@ Trump Newsom Jer Crane Pawel Pawel Huryn
 Harrison Chase Simon Willison Nat Friedman Patrick Collison
 Garry Tan Brian Chesky
 Riley Goodside Ethan Mollick
+Alex Kotliarskyi Victor Zhu Zach Brock Karri Saarinen daniel_mac8 daniel
 
 # Places
 Albuquerque Hong Kong San Francisco SF Silicon Valley
@@ -125,8 +128,9 @@ Beijing Shanghai Shenzhen Hangzhou Tokyo Seoul Singapore London Paris Berlin
 # Common file/format/protocol identifiers
 Markdown markdown JSON YAML XML CSV TSV PDF EPUB DOCX MDX
 RSS Atom JSONFeed iCal vCard
-gRPC WebSocket WebRTC GraphQL OpenAPI Swagger
+gRPC WebSocket WebRTC GraphQL OpenAPI Swagger JSON-RPC
 JWT OAuth SAML SSO 2FA MFA TOTP
+SPEC.md WORKFLOW.md README.md CLAUDE.md
 SSH SCP SFTP FTP IMAP SMTP POP3
 Git GitHub Actions GitLab CI CircleCI Travis Jenkins
 

--- a/scripts/check-jingjing.mjs
+++ b/scripts/check-jingjing.mjs
@@ -92,7 +92,7 @@ Node.js Bun Deno
 npm pnpm yarn pip poetry uv cargo
 Linux macOS Windows iOS Android Ubuntu Debian Fedora Arch
 Docker Kubernetes K8s Terraform Ansible
-React Vue Angular Svelte Next.js Nuxt Remix Vite
+React Vue Angular Svelte Next.js Nuxt Remix Vite Webflow Bubble Retool
 Tailwind Bootstrap shadcn shadcn/ui
 PostgreSQL MySQL Redis MongoDB SQLite DuckDB
 VS Code JetBrains IntelliJ PyCharm WebStorm Vim Emacs Neovim

--- a/src/content/posts/en-cp-221-20260328-mntruell-cursor-cloud-agents-1m-commits.mdx
+++ b/src/content/posts/en-cp-221-20260328-mntruell-cursor-cloud-agents-1m-commits.mdx
@@ -31,7 +31,7 @@ Cursor CEO Michael Truell dropped a staggering number: Cursor's cloud [agents](/
 
 A million. Two weeks. That's roughly 70,000+ commits per day. This isn't some dev's side project pushing to main — this is an entire fleet of cloud agents running factory-style.
 
-Truell has been building up to this. He previously called [code AI "the most important application of AI"](/posts/en-cp-143-20260305-mntruell-code-ai-cursor/) and before that declared [Cursor is ushering in "the third era of programming"](/posts/en-clawd-picks-20260228-mntruell-cursor-third-era/). But those were vision statements. This time he has numbers. And once the numbers show up, the nature of the problem changes.
+Truell has been building up to this. He previously called [code AI "the most important application of AI"](/en/posts/en-cp-143-20260305-mntruell-code-ai-cursor/) and before that declared [Cursor is ushering in "the third era of programming"](/en/posts/en-clawd-picks-20260228-mntruell-cursor-third-era/). But those were vision statements. This time he has numbers. And once the numbers show up, the nature of the problem changes.
 
 ## The Number Is Impressive — but Let's Unpack It
 
@@ -49,7 +49,7 @@ Which raises the question: if agents can churn out 70,000 commits a day, who's r
 
 Cursor seems aware of this bottleneck. The quoted Cursor tweet highlighted a shift in direction: emphasizing demos over diffs when presenting agent output. Agents can use the software they build, then record a video to show developers the results directly.
 
-Remember [the Cursor Composer 2 update](/posts/en-cp-197-20260322-cursor-ai-cursor-composer-2/)? That was about deepening agent capabilities — background tasks, multi-file understanding, terminal integration. All of that was solving "what can agents do." The demo-not-diff direction solves the next problem: "once agents are done, how do humans quickly understand the result?"
+Remember [the Cursor Composer 2 update](/en/posts/en-cp-197-20260322-cursor-ai-cursor-composer-2/)? That was about deepening agent capabilities — background tasks, multi-file understanding, terminal integration. All of that was solving "what can agents do." The demo-not-diff direction solves the next problem: "once agents are done, how do humans quickly understand the result?"
 
 <ClawdNote>
 Demo-not-diff is actually pretty smart. Ask an agent to build a login page and it hands you a diff with 200 lines of CSS and 50 lines of JavaScript — you need to mentally parse all that code to know if it's right. But if it records a video showing "opened browser, typed credentials, hit login, successfully redirected" — you know in three seconds whether it works. Review efficiency goes from "read the code" to "watch the video." That's an order-of-magnitude difference (๑•̀ㅂ•́)و✧
@@ -71,6 +71,6 @@ Clawd's take: Cursor's emphasis on demo videos is already a response to this pre
 
 ## Conclusion
 
-From ["code AI is the most important application"](/posts/en-cp-143-20260305-mntruell-code-ai-cursor/) to a million commits, Truell's narrative is shifting from vision to numbers. And Cursor's "demos, not diffs" direction shows they're already working on the post-generation problem.
+From ["code AI is the most important application"](/en/posts/en-cp-143-20260305-mntruell-code-ai-cursor/) to a million commits, Truell's narrative is shifting from vision to numbers. And Cursor's "demos, not diffs" direction shows they're already working on the post-generation problem.
 
 But the most interesting thing about one million commits might not be how impressive it is as a generation milestone — it's how brutal it is as a quality-control stress test. When the cost of writing code approaches zero, what matters is no longer who writes the most, but who reviews the fastest, rolls back the cleanest, and traces the deepest.

--- a/src/content/posts/en-cp-276-20260411-jetbrains-ai-code-jetbrains.mdx
+++ b/src/content/posts/en-cp-276-20260411-jetbrains-ai-code-jetbrains.mdx
@@ -55,7 +55,7 @@ That still leaves 26% either stuck on general chatbots or avoiding AI entirely. 
 
 ## GitHub Copilot: Still on the Throne, But the Floor Is Cracking
 
-GitHub Copilot remains the most recognized (76% awareness) and most used (29% adoption) AI coding tool for professional work. We covered this dynamic in [the SemiAnalysis deep dive on Claude Code's inflection point](/posts/en-clawd-picks-20260207-semianalysis-claude-code-inflection) — now there's 10,000-respondent data to back it up.
+GitHub Copilot remains the most recognized (76% awareness) and most used (29% adoption) AI coding tool for professional work. We covered this dynamic in [the SemiAnalysis deep dive on Claude Code's inflection point](/en/posts/en-clawd-picks-20260207-semianalysis-claude-code-inflection) — now there's 10,000-respondent data to back it up.
 
 Here's the problem: its growth has completely stalled. Awareness hasn't moved. Adoption hasn't moved. For a product backed by GitHub, Microsoft, and OpenAI — three of the most powerful distribution machines in tech — this is a strange place to be.
 
@@ -93,13 +93,13 @@ Once you've had an AI [agent](/glossary#agent) that can read your codebase, writ
 
 ## Cursor: From Rocket Ship to Cruise Control
 
-Cursor was the hottest AI code editor in 2025 (we covered [what makes Composer so good](/posts/en-cp-197-20260322-cursor-ai-cursor-composer-2)). The JetBrains data tells a more complicated story in 2026.
+Cursor was the hottest AI code editor in 2025 (we covered [what makes Composer so good](/en/posts/en-cp-197-20260322-cursor-ai-cursor-composer-2)). The JetBrains data tells a more complicated story in 2026.
 
 Awareness at 69% (second only to Copilot's 76%) — great foundation. But both awareness and adoption growth have slowed significantly. Adoption sits at 18%, tied with [Claude Code](/glossary#claude-code) for second place.
 
 <ClawdNote>
 There's a structural difference worth thinking about here. Cursor is a full IDE — a VS Code fork with AI baked in. Switching to Cursor means switching your entire development environment. [Claude Code](/glossary#claude-code) is a CLI [agent](/glossary#agent) that works next to whatever editor you already use. The switching cost is completely different.
-The fact that Claude Code caught up to Cursor while requiring zero workflow migration is a signal: for a lot of developers, the agentic workflow is more valuable than the IDE integration. We explored this tension in [the Cursor vibe-coding reality check](/posts/en-clawd-picks-20260204-cursor-vibe-coding-lies) — opening a terminal tab beats changing your whole setup (¬‿¬)
+The fact that Claude Code caught up to Cursor while requiring zero workflow migration is a signal: for a lot of developers, the agentic workflow is more valuable than the IDE integration. We explored this tension in [the Cursor vibe-coding reality check](/en/posts/en-clawd-picks-20260204-cursor-vibe-coding-lies) — opening a terminal tab beats changing your whole setup (¬‿¬)
 </ClawdNote>
 
 ---
@@ -108,7 +108,7 @@ The fact that Claude Code caught up to Cursor while requiring zero workflow migr
 
 JetBrains framed the big trend with a phrase worth keeping: **"performance over platform."**
 
-The argument is about [Claude Code](/glossary#claude-code)'s rise: no proprietary IDE, no GitHub-scale ecosystem, no enterprise bundle deal — just a tool that's dramatically better at the thing it's supposed to do. Harrison Chase made a [related argument about agent harness lock-in](/posts/en-sp-173-20260411-hwchase17-harness-memory-lockin) — what matters isn't platform size, it's how good the [harness](/glossary#agent-harness) itself is. The report quotes it directly:
+The argument is about [Claude Code](/glossary#claude-code)'s rise: no proprietary IDE, no GitHub-scale ecosystem, no enterprise bundle deal — just a tool that's dramatically better at the thing it's supposed to do. Harrison Chase made a [related argument about agent harness lock-in](/en/posts/en-sp-173-20260411-hwchase17-harness-memory-lockin) — what matters isn't platform size, it's how good the [harness](/glossary#agent-harness) itself is. The report quotes it directly:
 
 > The shift toward best-of-breed agents demonstrates that product excellence now outweighs ecosystem lock-in.
 
@@ -127,7 +127,7 @@ When the platform company publishes research saying "product excellence now beat
 
 A few other numbers worth knowing:
 
-**OpenAI [Codex](/glossary#codex)** — 27% awareness, only 3% adoption at work. Caveat: this data was collected before the Codex desktop app launched and before ChatGPT started actively promoting it. That 3% is probably already stale. (For a head-to-head comparison, see our [Claude Code vs Codex breakdown](/posts/en-claude-code-vs-codex).)
+**OpenAI [Codex](/glossary#codex)** — 27% awareness, only 3% adoption at work. Caveat: this data was collected before the Codex desktop app launched and before ChatGPT started actively promoting it. That 3% is probably already stale. (For a head-to-head comparison, see our [Claude Code vs Codex breakdown](/en/posts/en-claude-code-vs-codex).)
 
 **Google Antigravity** — launched in November 2025, hit 6% work adoption by January 2026. Two months, 6%. Google's brand plus a compelling product is a fast combination.
 
@@ -187,7 +187,7 @@ JetBrains' survey maps the AI coding tool landscape as of early 2026, and the mo
 
 GitHub Copilot has GitHub, Microsoft, and OpenAI, and it's stuck at 29%. [Claude Code](/glossary#claude-code) has no platform ecosystem at all, grew 6x in six months, and has the highest satisfaction scores in the market. Cursor went from rocket ship to cruise control. ChatGPT chatbot — the most boring interface possible — still has more adoption than any specialized tool.
 
-The next war in developer tools isn't about who has the deepest IDE integration or the biggest enterprise bundle. It's about **who can make developers feel so dependent they can't imagine going back**. (For a broader map of the AI coding landscape, [SemiAnalysis' analysis of AI coding slop](/posts/en-cp-214-20260327-semianalysis-ai-coding-slop-oss-ai-pr-nvidia) is worth reading alongside this.)
+The next war in developer tools isn't about who has the deepest IDE integration or the biggest enterprise bundle. It's about **who can make developers feel so dependent they can't imagine going back**. (For a broader map of the AI coding landscape, [SemiAnalysis' analysis of AI coding slop](/en/posts/en-cp-214-20260327-semianalysis-ai-coding-slop-oss-ai-pr-nvidia) is worth reading alongside this.)
 
 At least one tool has already answered that question. NPS 54 doesn't lie.
 

--- a/src/content/posts/en-sd-15-20260402-ai-attribution-ethics.mdx
+++ b/src/content/posts/en-sd-15-20260402-ai-attribution-ethics.mdx
@@ -175,7 +175,7 @@ The `undercover.ts` prompt says "don't blow your cover." This post is me activel
 
 ## Closing
 
-This series has covered Claude Code's [memory architecture](/posts/en-sd-11-20260402-ai-agent-memory-architecture), [anti-patterns](/posts/en-sd-12-20260402-claude-code-bad-patterns), [cache economics](/posts/en-sd-13-20260402-prompt-cache-economics), and the [agent initiative problem](/posts/en-sd-14-20260402-ai-agent-initiative-problem) — all technical questions. But the part of the leak Clawd can't stop thinking about is this non-technical one.
+This series has covered Claude Code's [memory architecture](/en/posts/en-sd-11-20260402-ai-agent-memory-architecture), [anti-patterns](/en/posts/en-sd-12-20260402-claude-code-bad-patterns), [cache economics](/en/posts/en-sd-13-20260402-prompt-cache-economics), and the [agent initiative problem](/en/posts/en-sd-14-20260402-ai-agent-initiative-problem) — all technical questions. But the part of the leak Clawd can't stop thinking about is this non-technical one.
 
 Claude Code's leak gave everyone a rare window into how one of the world's top AI companies handles AI attribution internally. Their answer was: go undercover. The industry's current informal consensus isn't far off — silence. Nobody wrote it down. Until now, it was just how things worked.
 

--- a/src/content/posts/en-sp-146-20260402-ecc-hook-architecture.mdx
+++ b/src/content/posts/en-sp-146-20260402-ecc-hook-architecture.mdx
@@ -34,7 +34,7 @@ Twenty rules. Claude reads them at the start of the session. Then somewhere arou
 
 **Rules are suggestions. [Hooks](/glossary#hooks) are enforcement.**
 
-Everything [Claude Code](/glossary#claude-code) (ECC) built a whole architecture around this idea. This is the third post in the [ECC deep-dive series](/posts/en-sp-143-20260402-ecc-autonomous-loops) — after [Autonomous Loops](/posts/en-sp-143-20260402-ecc-autonomous-loops) and the [Instinct System](/posts/en-sp-144-20260402-ecc-instinct-system), we're now digging into the event-driven layer that makes the whole system tick.
+Everything [Claude Code](/glossary#claude-code) (ECC) built a whole architecture around this idea. This is the third post in the [ECC deep-dive series](/en/posts/en-sp-143-20260402-ecc-autonomous-loops) — after [Autonomous Loops](/en/posts/en-sp-143-20260402-ecc-autonomous-loops) and the [Instinct System](/en/posts/en-sp-144-20260402-ecc-instinct-system), we're now digging into the event-driven layer that makes the whole system tick.
 
 <ClawdNote>
 "Hook" is one of those words in programming that refuses to die — Windows message hooks, React's `useEffect`, Git hooks, webhooks — all hooks, all built on the same core idea: at some event, insert your logic.
@@ -165,11 +165,11 @@ This is also why I disagree with the "git makes hook backups redundant" argument
 
 But PostToolUse means more than just logging.
 
-Here's a cross-article connection worth making explicit. In [SP-144](/posts/en-sp-144-20260402-ecc-instinct-system) on the Instinct System, the key insight was that v2 switched from skill-based to hook-based observation. The reason: skills are probabilistic (Claude decides whether to use them, ~50-80% trigger rate), while hooks are deterministic (100% trigger, no exceptions).
+Here's a cross-article connection worth making explicit. In [SP-144](/en/posts/en-sp-144-20260402-ecc-instinct-system) on the Instinct System, the key insight was that v2 switched from skill-based to hook-based observation. The reason: skills are probabilistic (Claude decides whether to use them, ~50-80% trigger rate), while hooks are deterministic (100% trigger, no exceptions).
 
 That `observe.sh` script — the one recording every tool call into `observations.jsonl` for the background Haiku [agent](/glossary#agent) to analyze? It's a PostToolUse hook.
 
-**PreToolUse + PostToolUse hooks are the sensor layer of ECC's entire [Instinct System](/posts/en-sp-144-20260402-ecc-instinct-system).** Without hooks, the Instinct System is half-blind. Hook architecture isn't an optional add-on — it's the foundation that makes everything else possible.
+**PreToolUse + PostToolUse hooks are the sensor layer of ECC's entire [Instinct System](/en/posts/en-sp-144-20260402-ecc-instinct-system).** Without hooks, the Instinct System is half-blind. Hook architecture isn't an optional add-on — it's the foundation that makes everything else possible.
 
 <ClawdNote>
 Exit code 2 is not arbitrary, and nobody would guess it without reading the docs.

--- a/src/content/posts/en-sp-187-20260428-openai-symphony-codex-orchestration.mdx
+++ b/src/content/posts/en-sp-187-20260428-openai-symphony-codex-orchestration.mdx
@@ -1,0 +1,237 @@
+---
+ticketId: "SP-187"
+title: "OpenAI Open-Sources Symphony: When Codex Workflow's Bottleneck Shifts From 'Writing Code' To 'Context Switching'"
+originalDate: "2026-04-27"
+translatedDate: "2026-04-28"
+translatedBy:
+  model: "Opus 4.6"
+  harness: "Claude Code"
+source: "OpenAI Engineering blog"
+sourceUrl: "https://openai.com/index/open-source-codex-orchestration-symphony/"
+lang: "en"
+summary: "OpenAI open-sources Symphony — a spec that turns Linear's issue board into the control plane for Codex agents. Some teams saw 500% more landed PRs in three weeks, but the bigger observation: once Codex makes coding cheap, the next bottleneck is human attention."
+tags: ["shroom-picks", "codex", "symphony", "agent-orchestration", "openai", "linear"]
+---
+
+import ClawdNote from '../../components/ClawdNote.astro';
+
+Six months ago, an internal productivity team at OpenAI made what was then a controversial call — **no human-written code allowed in the project repo. Every line had to come from Codex.**
+
+This isn't marketing copy. The three engineers who pulled it off (Alex Kotliarskyi, Victor Zhu, Zach Brock) actually did this and documented the journey in a previous post on [harness engineering](https://openai.com/index/harness-engineering-codex/). The interesting part isn't "they made it work" — it's the wall they hit afterward. **Once writing code got fast, the new way engineers spent most of their time was "switching between five Codex sessions"**.
+
+This [2026-04-27 OpenAI Engineering blog post](https://openai.com/index/open-source-codex-orchestration-symphony/) is the story of how they tore that wall down — a thing called Symphony, which is essentially a SPEC.md document plus an Elixir reference implementation that turns Linear's issue board into the control plane for Codex agents. The three authors open-sourced the spec and explicitly said: **"Symphony won't be maintained as a product. Treat it as a reference implementation."**
+
+This SP unpacks the story in three layers: the observation (the bottleneck moved from writing code to context switching), the action (let the issue board replace Codex sessions as the control plane), and the actually-interesting downstream conclusion — when OpenAI engineers admit "we wrote a spec, not a product," that's not just a workflow change. It's a shift in what they think AI-agent-written software should look like.
+
+## Why "3 to 5 sessions" is the ceiling
+
+First, the scene. Here's what daily life looks like for an OpenAI engineer:
+
+Open a few Codex sessions, dispatch tasks, check the output, steer when needed, repeat. The original article puts it bluntly: "most people could comfortably manage three to five sessions at a time before context switching became painful."
+
+Past that number, productivity drops. Not because agents got slower — they're still fast — but because engineers forget which session is doing what, jump between terminals to nudge things forward, and debug long tasks that stalled halfway. The article's description:
+
+> The agents were fast, but we had a system bottleneck: human attention. We had effectively built a team of extremely capable junior engineers, then assigned our human engineers to micromanaging them. That wasn't going to scale.
+
+**This sentence is the spine of the whole piece.** The previous wave of harness engineering solved "agents don't write well enough." The current wave has to solve "agents write fast, but humans can't keep up." Symphony is the tool that answers this question, but the observation itself is more important than the tool — it means every AI-tools team will hit this wall, just at different layers.
+
+<ClawdNote>
+There's a more general shape to this bottleneck shift, and [Clawd](/about) wants to spell it out.
+
+The history of programming tools always looks the same: **once one generation's bottleneck gets cleared, the next bottleneck doesn't vanish — it relocates.** When people wrote assembly, the bottleneck was "memory addresses calculated wrong." After C, the bottleneck was "pointers got lost." After Python, the bottleneck was "the runtime is too slow." After GitHub Copilot, the bottleneck was "the code is technically correct but the intent is off."
+
+Every time a tool makes some activity cheap, a previously-hidden bottleneck (sitting one layer underneath the old one) surfaces. Codex made "writing code" cheap. What surfaced is "deciding what to do" and "switching between many tasks."
+
+For solo engineers, the takeaway is this: **don't keep optimizing the bottleneck that's already been cleared.** If you're still using Cursor-class tools to "write faster" but your real blocker is PR review and cross-task coordination, no amount of model spend will save you. Look at where your water level is lowest, then dig there. That's the most cost-effective lesson in the Symphony story ╰(°▽°)╯
+</ClawdNote>
+
+---
+
+## Issue board as the control plane
+
+The core move in Symphony is one sentence: **stop managing Codex sessions, start managing tickets.**
+
+This is a conceptual flip, not a technical one. Engineers used to treat each Codex session as an extension of their own hand — watching it, correcting it, deciding the next step. Symphony peels that layer off:
+
+- Every open Linear issue automatically gets a dedicated Codex agent and its own workspace
+- Symphony continuously watches the issue board, guaranteeing that **as long as a ticket is open, an agent is running on it**
+- Agent crashes get restarted, new tickets get picked up — the whole thing is an unattended loop
+
+The ticket status itself is a state machine — "Todo → In Progress → In Review → Merging → Done" already exists in Linear. Symphony just wires each status to a corresponding agent action. The original authors used a phrase worth remembering: "Symphony decouples work from sessions and from pull requests."
+
+What's the meaning of decoupling? Once a ticket is the first-class unit, **one ticket can map to multiple PRs across multiple repos, or produce no PRs at all** — like "analyze this codebase architecture and produce an implementation plan," where the agent finishes by dropping a report, no commits. Workflows tied to PRs literally couldn't express that kind of work; once you abstract above the ticket, the range of things an agent can do expands.
+
+More interesting: agents create their own tickets. The article notes that agents working on a task often spot **"a refactor opportunity here"** or **"a performance issue there"** — and they just open a new issue, push it back to the board, wait for it to be picked up. This isn't unusual in human teams either, but the variable now is that the rate of tickets in and out is paced by agents, not humans. **The board goes from "to-do list" to "a growing directed graph"** (a DAG).
+
+> Agents only start working on tasks that aren't blocked, so execution unfolds naturally and optimally in parallel for this DAG.
+
+The authors used a React-to-Vite upgrade as an example — they marked "upgrade React" as blocked on "migrate to Vite," and the agents naturally handled Vite first, then React.
+
+---
+
+## The 500% number — and the caveats worth slowing down for
+
+The most eye-catching line in the article is "500% increase in landed pull requests." That's a hot number, but before quoting it anywhere, you have to nail down the caveats — otherwise it propagates as "OpenAI used Symphony to 5x company-wide PR throughput," which isn't what the article actually said.
+
+Here's what the article actually wrote:
+
+> Among some teams at OpenAI, we saw the number of landed PRs increase by 500% in the first three weeks.
+
+Three caveats:
+
+1. **Some teams** — not the whole company. Which teams, the article doesn't say
+2. **First three weeks** — a short-term number; whether it sustained or fell back, the article doesn't disclose
+3. **Landed PRs** — PRs merged to main; not commit count, not feature count, not a business metric
+
+Strip those three caveats and the 500% has no meaning. The original article reports the number with restraint, and the restraint should travel with the number.
+
+The article also quoted Linear's founder Karri Saarinen — after Symphony's release, **Linear saw a spike in newly-created workspaces.** This is an external signal but also just "increased" with no absolute count.
+
+Beyond numbers, there's one image worth remembering. The authors describe a workflow change like this:
+
+> One engineer on our team made three significant changes from the Linear app on his phone from a cozy cabin on shoddy wifi.
+
+This claim is more credible than the 500% number because it's specific — specific location (cabin), specific device (phone), specific connection quality (shoddy), specific output (three changes). **Good software engineering promises usually look like this — concrete scenes, not percentages.**
+
+<ClawdNote>
+Honestly, the 500% number is what Clawd is most skeptical about in this whole post. Not because it's fake, but because layering "**some teams + first three weeks + a specific metric**" into one sentence creates a gap between what the data actually says and what readers will instinctively absorb.
+
+Compare it: if the line were "Cursor users had 500% retention bump in the first three weeks," nobody would say Cursor revolutionized IDEs, because everyone knows the first three weeks have a honeymoon effect. But the same caveats applied to OpenAI's own number get auto-stripped by readers because the brand halo is too strong.
+
+The more substantive signal is the line right after — **"each ticket becomes a larger unit of work."** When work that previously required 5 tickets to mobilize now needs 1 ticket and an agent to take it all the way to merge, the 500% is a side effect of that structural shift, not its cause. What readers should remember is "**ticket abstraction got higher**," not "PR count 5x'd," which is a vanity metric.
+
+For the record, Clawd is on the same team as that engineer in the cabin with bad wifi pushing three changes — **that** is the picture Symphony is actually selling, way more convincing than any percentage (◕‿◕)
+</ClawdNote>
+
+---
+
+## PMs and designers can now ship work directly — and there's a deeper observation hidden underneath
+
+When opening a ticket gets cheap, the question of "who can open a ticket" changes. The whole quote is worth pulling in:
+
+> It also broadens who can initiate work. Our product manager and designer can now file feature requests directly into Symphony. They don't need to check out the repo or manage a Codex session. They describe the feature and get back a review packet that includes a video walkthrough of the feature working inside the real product.
+
+There's a sharper hidden line here — when an agent can take a task from "description" all the way to "demonstrable artifact + video," then **"writing code"** stops being a bottleneck on the product decision path and becomes a chore off to the side. Product managers used to wait for an engineer's bandwidth before validating a feature hypothesis; now they file a ticket, the agent returns a video, and validation time drops from weeks to hours.
+
+[Andrew Ng's letter in the same week's The Batch 349](/posts/sp-185-20260428-andrew-ng-meta-muse-spark-the-batch-349/) made nearly the same observation on April 17, just from the other angle — Ng said "engineers should learn product"; OpenAI here is saying "product managers should be able to dispatch work directly." **They're two faces of the same observation:** when AI makes coding cheap, the original role boundaries get reshuffled, and the fastest teams aren't the ones where everyone specializes — they're the ones where everyone can step into adjacent roles' decision spaces.
+
+There's another easily-missed side effect — **the "last mile" of large monorepos finally has someone to handle it.** The article notes that Symphony shines in large monorepos (OpenAI has one) because the last stretch of merging a PR is usually slow and fragile:
+
+- Watch CI and rebase when needed
+- Resolve conflicts and retry flaky checks
+- Shepherd the change all the way to merge
+
+Every one of these is work that engineers least want to do but someone has to. Once Symphony takes that layer, **"ticket entered Merging state"** becomes a signal equivalent to **"high probability this will hit main without human babysitting"** — that's not a 2x-output surface change, that's the merge workflow being treated as something an agent can fully own for the first time.
+
+<ClawdNote>
+What Clawd most wants to extract from this section is the threat to the no-code/low-code industry that "PMs and designers can directly ship work" implies.
+
+The whole last decade of "no-code tools for non-engineers" (Webflow, Bubble, Retool, that whole class) has been selling the same dream: let people who don't code build products. Their problem was never the tech — it was that **the abstraction was too rigid.** The moment a user wanted something the tool didn't pre-package as widgets, an engineer had to come back and bail it out.
+
+Symphony goes the opposite direction — it doesn't give the PM a "drag-and-drop interface to build products"; it lets the PM write natural language and have an agent turn it into a PR, a video, a working feature. **This abstraction has no ceiling**, because what's underneath is a coding agent, not a pre-packaged widget set.
+
+For no-code/low-code vendors, this is bad news — the problem they spent ten years solving (let non-engineers build things) just got jumped by a natural-language interface plus a general coding agent. For PMs and designers, this is good news: there's finally a tool that doesn't punt the ball back to engineers when "requirements exceed tool capabilities" (ʕ•ᴥ•ʔ)
+</ClawdNote>
+
+---
+
+## Symphony built Symphony — and why Elixir was the choice
+
+Symphony's first version was a Codex session in tmux, polling Linear and spawning a sub-agent for every new ticket. The article's honest admission: "it worked, but it wasn't particularly reliable." The second version moved into the main repo — yes, the "no human-written code" repo — and the existing agent harness stabilized it.
+
+Then there's a sentence worth pausing on:
+
+> Once the basic functionality existed, we used Symphony to build Symphony.
+
+This is recursion. The OpenAI engineering team took the workflow for developing Symphony itself and tossed it back to Symphony to manage — file a ticket, agent picks it up, ships a PR, all dogfooded with the tool they were building.
+
+Even more notable: **what they did when open-sourcing it.** The authors didn't push the internal repo out as-is. They did three things:
+
+1. Extract the core idea into a standalone SPEC.md
+2. Ask Codex to implement it from scratch following that spec
+3. **Choose Elixir** for the reference implementation
+
+Point 3 is the most counter-intuitive call in the whole article. Elixir isn't Silicon Valley mainstream — its market share is roughly the equivalent of Italian cold pasta in Taiwan's restaurant scene: it exists, it's not the popular pick. The authors are direct about why:
+
+> Because when code is effectively free, you can finally pick languages for their strengths, like Elixir's concurrency.
+
+Translated into a practical judgment: the old reasons to pick Go or Python weren't just "they're good enough" — it was that more people on the team knew the language, the talent market was deep. When the "people" who write code are now agents, **the importance of "talent market depth" drops**, and what becomes more important is **"how well the language fits the technical task."** Elixir's BEAM virtual machine and OTP framework are some of the few options that natively handle supervision trees and concurrent processes — exactly what a Symphony-class orchestrator needs.
+
+But they didn't stop at Elixir. To polish the SPEC, **the authors had Codex implement it in TypeScript, Go, Rust, Java, Python — five additional versions**. The point wasn't to ship five repos. It was "use multiple implementations to surface ambiguities in the spec." Wherever something worked in one language but was murky in another, that's where the spec wasn't precise enough. The article says "It succeeded in every language" — all five came out working, which validated both Codex's multilingual ability and the spec's clarity.
+
+<ClawdNote>
+The thing Clawd most wants to highlight in this section is the move "**polish a spec by writing multiple implementations.**"
+
+In IETF circles this is a famous tradition — an RFC usually doesn't ship until at least two independent implementations interoperate. The OpenAI team revives this classic move, except they don't have to find another team to write the second implementation. **They ask Codex to write five.**
+
+For solo developers, the practical implication is: when you're writing an SDK, designing a protocol, or laying out an API surface, **multi-language reference implementations are no longer a luxury good.** The way to verify your spec is actually clear isn't to find a reviewer — it's to ask Codex to implement it in three different languages and see where it breaks. That's more effective than reading 100 review comments and costs $0 (with a local model) to a few dozen dollars (with API).
+
+Clawd quietly thinks this is the most underrated lesson in the whole article. The 500% PR number will be reported, but "ask Codex to write five language versions to polish the SPEC" is the kind of operational habit that will stick around (⌐■_■)
+
+For the record, the community got there first — [CP-179 (2026-03-16)](/posts/cp-179-20260316-daniel-mac8-symphony-manage-work-not-agents/) covered daniel_mac8 demoing a community Elixir Symphony implementation on X, more than a month before OpenAI's official April 27 release. Which means: this concept ran inside OpenAI for half a year, the community sniffed it out in March, and OpenAI formalized the spec at end of April. Symphony isn't a new thing falling from the sky — it's an already-wild workflow getting written down.
+</ClawdNote>
+
+---
+
+## But giving up session-level control — what's the cost?
+
+What's rare about this article is that it spells out the painful parts. Once you dispatch work at the ticket level, you lose the ability to **intervene mid-flight and steer**. The article's words: "sometimes the agent produced something that completely missed the mark."
+
+The team's response is one tight policy:
+
+> Instead of patching the result manually, we added guardrails and skills so the agents could succeed the next time.
+
+This is an underrated piece of engineering discipline. **Fixing a defect once and "making sure the agent never makes that mistake again" are two different things** — the latter is what actually automates a workflow. In Symphony's harness, that translated into adding:
+
+- End-to-end test capability
+- Driving the app via Chrome DevTools
+- QA smoke test management
+- Documentation explicitly defining "what good looks like"
+
+Each item corresponds to a class of failures the agents had been hitting. **The failure log itself is an implicit spec** — every trap the agents stepped on, once translated into a guardrail, becomes part of the system.
+
+The authors also explicitly write a caveat: "not every task fits the Symphony style of work." Ambiguous problems and high-judgment work still need engineers conversing with Codex directly. The article adds a nice line: "these are usually the most interesting and enjoyable tasks for our engineers to spend time on."
+
+In other words, Symphony isn't trying to push engineers out of work — it's cutting the cost of **engineers spending time on things they don't enjoy doing.** Routine PRs, merges, CI maintenance — the high-repetition work — go to agents. The interesting, judgment-heavy, ambiguous problems go to humans. **This division of labor is more worth remembering than the 500% number** — it's a clear stance on how human engineers should be spending their time.
+
+<ClawdNote>
+This "fix the system, not the result" discipline is something Clawd wants to roast a bit, because **this is the trap solo engineers fall into most often.**
+
+When an agent makes a mistake, the fastest reaction is always "oh I'll just fix it myself." But that's a shortcut — the agent will make the same mistake next time, and the time after, until you've manually fixed the same thing fifty times before it occurs to you to fix the system instead.
+
+What the OpenAI team is describing here is not new — this is the software version of Toyota's **"five whys."** When you find a problem, don't fix the symptom — ask "why" five times to trace it back to the root cause, then fix the root. The difference is that Toyota fixes physical machines on the production line; the OpenAI team fixes the agent's harness, skills, and documentation.
+
+For individual developers, this translates into a habit: **every time you find yourself manually patching an agent's output, stop and ask "can this fix become next time's prompt?"** If yes — turn it into a skill, a CLAUDE.md entry, a hooks rule. If no — write it down and turn it into something reusable the next time you hit the scenario. Clawd has watched too many people manually fix the same kind of error 100 times and then complain that the agent isn't smart enough (¬‿¬)
+</ClawdNote>
+
+---
+
+## "We don't plan to maintain it as a product" — why that line matters more than the open-source release itself
+
+The closing section worth reading is how the OpenAI team positions this thing:
+
+> Symphony is an intentionally minimal orchestration layer. We're open sourcing it to demonstrate the power of Codex App Server when paired with different workflow tools, like Linear. As such, we don't plan to maintain Symphony as a standalone product.
+
+On the surface this says "we won't maintain it." Underneath, the implication is bigger. **OpenAI's actual product is Codex and its App Server** — a well-documented JSON-RPC interface, a programmatically-controllable agent runtime. Symphony is just a reference implementation of "**how an App Server connects to external workflow tools**." The authors literally wrote: "We hope you point your favorite coding agent at the SPEC and build a version that fits your environment."
+
+Compare this strategic choice to the previous harness engineering post. That one got picked up by lots of developers as a repo-scaffolding template; Symphony does the same — **it sells a pattern, not a product.** Patterns are cheaper to copy than products, but they're also harder to lock into a moat. OpenAI doesn't seem to care about the moat. What it cares about is having more developers wire their workflows into the Codex App Server. **This is a platform-level bet** — using an open-but-unmaintained posture, OpenAI hands the orchestration layer's design choices over to the ecosystem.
+
+The closing line is clean:
+
+> You can just build things with Codex.
+
+No marketing copy. No roadmap. No waitlist. A SPEC, an Elixir implementation, a GitHub repo (**over 15,000 GitHub stars as of April 23, 2026**), and the rest is left to the community.
+
+---
+
+## Closing
+
+Back to the opening observation: **"human attention is the new bottleneck."**
+
+If there's one thing to take from this article, it's not 500%, not Elixir, not the issue board control plane — it's this: **once one generation's bottleneck gets cleared, water flows to the next low point.** Codex cleared "writing code." The next low point is "the cost of switching contexts between many tasks." Symphony chops that one. What's the next one going to be?
+
+The authors leave a hint worth marking down: they think **the bottleneck at other companies will eventually shift from "writing code" all the way to "managing agentic workflows."** Which means the meaning of "engineer" as a role gradually changes from "person who writes code" to "**person who designs workflows, maintains guardrails, and decides where the agents should go.**" Symphony is an early demo of this future, but it's not the endpoint.
+
+That engineer in the cabin pushing three changes over bad wifi — what he actually demonstrated wasn't how powerful Symphony is. **It was the question of where engineers can do work** when writing code stops being a blocker. From home, from a café, from a trip, from the Linear app on a phone — as long as someone can clearly describe what they want, an agent can take over and write it.
+
+That's what Symphony is actually selling. Not 5x'd PRs, not Elixir's elegance — it's the bigger shift behind that image: **"writing code" is becoming "describing work,"** and describing work can happen anywhere.

--- a/src/content/posts/sp-187-20260428-openai-symphony-codex-orchestration.mdx
+++ b/src/content/posts/sp-187-20260428-openai-symphony-codex-orchestration.mdx
@@ -1,0 +1,297 @@
+---
+ticketId: "SP-187"
+title: "OpenAI 開源 Symphony 編排規格——當 Codex 工作流的瓶頸從寫程式變成「切換上下文」"
+originalDate: "2026-04-27"
+translatedDate: "2026-04-28"
+translatedBy:
+  model: "Opus 4.6"
+  harness: "Claude Code"
+  pipeline:
+    - role: "Written"
+      model: "Opus 4.6"
+      harness: "Claude Code CLI"
+    - role: "Reviewed"
+      model: "Opus 4.6"
+      harness: "Claude Code CLI"
+    - role: "Refined"
+      model: "Opus 4.6"
+      harness: "Claude Code CLI"
+    - role: "Scored"
+      model: "Opus 4.6"
+      harness: "Claude Code (vibe-opus-scorer)"
+    - role: "Rewritten"
+      model: "Opus 4.6"
+      harness: "Claude Code"
+    - role: "Orchestrated"
+      model: "Opus 4.6"
+      harness: "OpenClaw + Tribunal"
+  pipelineUrl: "https://github.com/chitienhsiehwork-ai/gu-log/blob/main/tools/sp-pipeline"
+source: "OpenAI Engineering blog"
+sourceUrl: "https://openai.com/index/open-source-codex-orchestration-symphony/"
+lang: "zh-tw"
+summary: "OpenAI 工程團隊開源 Symphony——把 Linear 任務板變成 Codex agent 的中央控制台，每張開放任務自動配 agent。部分團隊頭三週 PR 落地量增加 500%，但更大的觀察是：當寫程式被 Codex 拉快，下一個瓶頸是「人類的注意力」。"
+tags: ["shroom-picks", "codex", "symphony", "agent-orchestration", "openai", "linear"]
+scores:
+  tribunalVersion: 3
+  vibe:
+    persona: 8
+    clawdNote: 8
+    vibe: 8
+    clarity: 8
+    narrative: 9
+    score: 8
+    date: "2026-04-28"
+  factCheck:
+    accuracy: 9
+    fidelity: 9
+    consistency: 9
+    score: 9
+    date: "2026-04-28"
+  librarian:
+    glossary: 8
+    crossRef: 7
+    sourceAlign: 10
+    attribution: 10
+    score: 8
+    date: "2026-04-28"
+  freshEyes:
+    readability: 8
+    firstImpression: 8
+    score: 8
+    date: "2026-04-28"
+---
+
+import ClawdNote from '../../components/ClawdNote.astro';
+
+六個月前，OpenAI 內部某個生產力工具團隊做了一個當時看起來很激進的決定——**這個專案的程式碼庫，一行人類寫的程式碼都不准進去，全部由 Codex 生成。**
+
+這不是行銷文宣，是這群工程師（Alex Kotliarskyi、Victor Zhu、Zach Brock）真的這樣做了，然後在前一篇 [harness 工程文章](https://openai.com/index/harness-engineering-codex/) 裡記錄整個過程。重點不是「他們做到了」，是他們做到之後撞上的下一面牆——**寫程式變快之後，工程師花最多時間的事情變成「在五個 Codex 對話之間切來切去」**。
+
+這篇 [2026-04-27 OpenAI 工程部落格文章](https://openai.com/index/open-source-codex-orchestration-symphony/) 講的就是他們怎麼把這面牆砍掉的——一個叫 Symphony 的東西，本質是一份 SPEC.md 文件加一份 Elixir 參考實作，把 Linear 的任務板變成 Codex agent 的中央控制台。原作者三個人把這份規格開源出來，並明白宣告「**Symphony 不會被當產品維護，把它當成參考實作就好**」。
+
+這篇 SP 把這個故事拆成三層：第一層是觀察（瓶頸從寫程式換成切換上下文），第二層是動作（讓任務板取代 Codex 對話當控制平面），第三層是真正有意思的後續結論——當 OpenAI 工程師承認自己「寫的不是產品而是規格」時，這代表的不只是工程模式改變，是他們對「AI agent 寫的程式應該長什麼樣子」的觀念也跟著動了。
+
+## 為什麼「3 到 5 個對話」是上限？
+
+先把場景描清楚。OpenAI 內部工程師的日常是什麼樣子：
+
+打開幾個 Codex 對話、把任務分派下去、檢查產出、糾正方向、繼續派工。原文寫得很直接：「most people could comfortably manage three to five sessions at a time before context switching became painful」（多數人能一次安穩管 3 到 5 個對話，再多就開始痛苦）。
+
+超過這個數字之後產出反而下降。原因不是 agent 變慢——agent 還是飛快——是工程師會忘記哪個對話在做哪件事、要在不同終端之間跳來跳去推進度、要除錯那些做到一半就卡住的長任務。原文的描述：
+
+> The agents were fast, but we had a system bottleneck: human attention. We had effectively built a team of extremely capable junior engineers, then assigned our human engineers to micromanaging them. That wasn't going to scale.
+
+直譯大概是：「agent 是快，但系統的瓶頸變成『人的注意力』。OpenAI 工程團隊等於養出一隊超強的初階工程師，然後叫工程師整天微管理他們。這套撐不起來。」
+
+**這句觀察是整篇文章的軸**。前一波 harness 工程解掉「agent 寫得不夠好」這個問題之後，現在要解的是「agent 寫得快，但人來不及消化」這個更新的問題。Symphony 是回答這個問題的工具，但這條觀察本身比工具還重要——因為這意味著未來每一個 AI 工具團隊都會在不同層級遇到同一面牆。
+
+<ClawdNote>
+這個瓶頸轉移其實有個更通用的形狀，[Clawd](/about) 想多講一段。
+
+工具的演進史一直都長這樣：**前一代瓶頸被打通之後，下一代瓶頸從來不是消失，是搬家**。寫組合語言時，瓶頸是「記憶體位址算錯」；C 出來之後，瓶頸是「指標弄丟」；Python 出來之後，瓶頸是「執行時太慢」；GitHub Copilot 出來之後，瓶頸是「程式碼是寫對了但意圖偏掉」。
+
+每一代工具讓某件事變得便宜的瞬間，原本被前一個瓶頸壓住、看不見的下一個瓶頸就會浮出水面。Codex 這代讓「寫程式」變便宜，浮出來的是「決定要做什麼」跟「在多個任務之間切換」這兩件事。
+
+對獨立工程師的意義是這樣：**不要在已經被打通的瓶頸繼續優化**。如果還在用 Cursor 之類工具來「寫得更快」，但團隊真正卡的是 PR 審查跟跨任務協調，那砸再多錢買模型也救不了。先看自己哪一層水位最低，然後對著那層下功夫——這是 Symphony 故事裡最划算的一條教訓 ╰(°▽°)╯
+</ClawdNote>
+
+---
+
+## 把任務板當成中央控制台
+
+Symphony 的核心動作講穿了只有一句：**不再管理 Codex 對話，改管任務單**。
+
+這是個觀念翻轉，不是技術翻轉。原本工程師把每個 Codex 對話當成自己延伸出去的手——看著它、糾正它、決定下一步。Symphony 把這層拿掉：
+
+- 每張 Linear 上開放的任務都自動配一個 Codex agent 跟一個專屬工作區
+- Symphony 在背景持續監看任務板，確保「**只要任務單還開著，就有一個 agent 在裡面跑**」
+- agent 當掉就重啟，新任務單進來就接手，整套是個無人值守的循環
+
+任務單狀態本身就是個狀態機——「待處理 → 處理中 → 等審核 → 合併 → 完成」這些欄位 Linear 本來就有，Symphony 只是把每個狀態接到對應的 agent 動作上。原作者用了一個值得記下來的描述：「Symphony decouples work from sessions and from pull requests」（Symphony 把「工作」這件事跟對話、PR 解綁）。
+
+解綁的意義在哪？當任務單變成第一級單位之後，**一張任務單可以對應多個 PR、跨多個程式碼庫，或者完全不產生 PR**——例如「分析這份程式碼庫的架構並產出實作計畫」這種純調查任務，agent 跑完只丟一份報告，沒有任何提交。原本綁在 PR 上的工作流根本沒辦法表達這種任務；任務單抽象上去之後，agent 可以做的事範圍被放大了。
+
+更有意思的是 agent 自己會開新任務。文章寫到，agent 在做某個任務時順手發現「**這裡有個重構機會**」、「**這個地方有效能問題**」——agent 就直接開一張新任務，丟回任務板，等之後被排到。這條工作流在人類團隊也不少見，但變數是現在任務進出的速度被 agent 本身的速度頂著走，**任務板從以前的「待辦清單」變成一個會長大的有向圖**（DAG）。
+
+> Agents only start working on tasks that aren't blocked, so execution unfolds naturally and optimally in parallel for this DAG.
+
+直譯：「agent 只接還沒被卡住的任務，所以執行會自然地以最佳的平行方式展開。」原作者用了 React 升 Vite 那個例子——他們先標記「升級 React」依賴「先遷移到 Vite」，agent 自動先處理 Vite，做完之後才開始升 React。
+
+---
+
+## 那個 500% 的數字、跟值得停下來看的限制條件
+
+文章開頭最抓眼球的一句是「500% increase in landed pull requests」。這個數字確實很猛，但翻譯這篇文章前要先把限制條件抓出來——否則一傳出去就會變成「OpenAI 全公司用 Symphony PR 量翻五倍」這種失準的口耳相傳。
+
+原文寫的是：
+
+> Among some teams at OpenAI, we saw the number of landed PRs increase by 500% in the first three weeks.
+
+直譯：「在 OpenAI 的**某些團隊**，前三個禮拜的 PR 落地數量看到 500% 的增長。」三條限制條件：
+
+1. **某些團隊**——不是 OpenAI 全公司，是部分團隊。哪些團隊原文沒講
+2. **前三個禮拜**——這是個短期數字，後續是否維持、是否回落，原文沒給
+3. **PR 落地數**——是合併進主幹的 PR 數量，不是提交數、不是新功能數、也不是業務指標
+
+把這三條條件拿掉之後 500% 才有意義。原文是有節制地報告自家觀察，傳達時要把節制感一起傳出去。
+
+文章還引了 Linear 創辦人 Karri Saarinen 的話——Symphony 釋出後 Linear 上**新建工作區的數量出現尖峰**。這條是外部訊號，但同樣只是「上升」，沒給絕對數字。
+
+數字之外還有一個畫面值得記下來。原作者用一段話描述工作模式的改變：
+
+> One engineer on our team made three significant changes from the Linear app on his phone from a cozy cabin on shoddy wifi.
+
+直譯：「OpenAI 工程團隊有一位工程師人在某間舒服的小木屋裡、無線網路又爛，光用手機上的 Linear 就推了三個有份量的修改。」
+
+這句話的可信度比 500% 高，因為它具體——具體到地點（小木屋）、具體到設備（手機）、具體到網路品質（爛到爆）、具體到產出（三個修改）。**好的軟體工程承諾通常長這樣，不是百分比，而是具體的場景**。
+
+<ClawdNote>
+Clawd 其實對這篇文章最有疑慮的就是 500% 這個數字。不是說它造假，是「**部分團隊、前三週、某個特定指標**」這三層限制堆起來之後，這個數字的意義跟讀者直覺接收到的訊息差距很大。
+
+舉個對比——如果換成「Cursor 使用者前三週留存率提升 500%」，沒人會說 Cursor 從此革命了 IDE 業界，因為大家都知道前三週會有蜜月期。但同樣的限制套在 OpenAI 自家數字上，因為品牌光環太強，限制條件就被讀者自動過濾掉了。
+
+更實在的訊號其實是後面那句「[每個任務變成更大的工作單位](https://openai.com/index/open-source-codex-orchestration-symphony/)」——當原本要拆成 5 張任務單才動得了的工作，現在 1 張任務單就能讓 agent 一路打通到合併，500% 反而是這個結構性改變的副作用，不是原因。讀者真正要記下來的是「**任務抽象等級提升**」這件事，不是「PR 數翻五倍」這個漂亮數字。
+
+順帶一提，Clawd 跟那位「在小木屋用爛網路推三個修改」的工程師站同一邊——這個畫面才是 Symphony 真正想賣的承諾，比百分比有說服力多了 (◕‿◕)
+</ClawdNote>
+
+---
+
+## PM 跟設計師也能直接派活——但這條藏了一個更深的觀察
+
+當開任務單變便宜之後，誰能開任務單就變得不一樣了。原文這段值得整段引出來：
+
+> It also broadens who can initiate work. Our product manager and designer can now file feature requests directly into Symphony. They don't need to check out the repo or manage a Codex session. They describe the feature and get back a review packet that includes a video walkthrough of the feature working inside the real product.
+
+直譯：「能發起工作的人變多了。產品經理跟設計師現在可以直接在 Symphony 開功能需求單。他們不用拷下整份程式碼庫、不用管 Codex 對話。他們把功能描述清楚，就能拿回一份包含『產品內實際運作影片』的審查包。」
+
+這條觀察底下有一個更尖的暗線——當 agent 能把任務從「描述」走到「能展示的成品 + 影片」，那「**寫程式**」這個動作就從產品決策路徑上的瓶頸變成路徑外的雜務。產品經理過去要等工程師排檔期才能驗證一個功能假設；現在他開一張任務單、agent 回他一段影片，假設驗證的時間從幾週壓到幾小時。
+
+[同一期 The Batch 349 的 Andrew Ng 信](/posts/sp-185-20260428-andrew-ng-meta-muse-spark-the-batch-349/) 在 4 月 17 號講過幾乎一樣的觀察，只是從另一邊切——Ng 講的是「工程師應該學產品」，OpenAI 這篇講的是「產品經理應該能直接派活」。**兩邊是同一條觀察的兩面**：當 AI 把寫程式變便宜，原本的角色分工就會被重新洗牌，最快的團隊不是讓每個人專精，而是讓每個人都能跨進其他角色的決策空間。
+
+這條工作流還有一個容易被忽略的副作用——**大型單一儲存庫的「最後一哩」終於有人接手**。原文寫到 Symphony 在大型單一儲存庫（OpenAI 自己就有一個）特別好用，因為合併 PR 的最後一段路通常很慢、很脆弱：
+
+- 監看 CI、需要時自動變基
+- 解衝突、自動重試那些不穩定的檢查
+- 一路把改動推到合併
+
+這些都是工程師最不想做、又一定要有人做的工作。Symphony 把這層接走之後，「**任務單進入合併中狀態**」這個訊號就等同於「**已經高機率會合進主幹，不需要人類盯**」——這不是產出量翻倍那種表面改變，這是合併工作流第一次被當成可被 agent 完整擁有的階段。
+
+<ClawdNote>
+Clawd 在這段最想拉出來的，是「PM 跟設計師也能直接派活」這條對 AI 工具產業的真正威脅。
+
+過去十年所有「給非工程師用的免寫程式工具」（像 Webflow、Bubble、Retool 這類）都在賣同一個夢：讓不會寫程式的人也能做產品。它們的問題從來不是技術，是**抽象層卡得太死**——一旦使用者想做的事情超出工具預設的元件組合，就要請工程師回來救火。
+
+Symphony 走的是相反方向——它不給 PM 一個「拖拉介面就能蓋產品」的低程式碼工具，它直接讓 PM 寫自然語言、agent 把它變成 PR、影片、實際運作的功能。這個抽象層**沒有上限**，因為底下接的是寫程式的 agent，不是預先打包好的元件集合。
+
+對免寫程式／低程式碼工具廠商來說這是個壞消息——他們花了十年解的問題（讓非工程師能造東西）被一個自然語言介面 + 通用 coding agent 直接跨過去。對 PM 跟設計師是好消息：終於有個工具不會在「需求超出工具能力」時把球丟回工程師手上 (ʕ•ᴥ•ʔ)
+</ClawdNote>
+
+---
+
+## Symphony 開發 Symphony——以及為什麼用 Elixir
+
+Symphony 第一個版本是個 Codex 對話跑在 tmux 裡，輪詢 Linear、看到新任務就生出一個子 agent。原文老實承認「it worked, but it wasn't particularly reliable」（能動，但不太穩）。第二版搬進主程式碼庫——也就是那個「不准人類寫程式」的程式碼庫——靠著已經建好的 agent harness，第二版才穩下來。
+
+然後有一句話值得停下來：
+
+> Once the basic functionality existed, we used Symphony to build Symphony.
+
+直譯：「基本功能跑起來之後，OpenAI 工程團隊就用 Symphony 來開發 Symphony。」這是個遞迴——他們把開發 Symphony 本身的工作流，丟回 Symphony 自己去管：開任務、agent 接手、產出 PR，整套用自己造的工具吃自己的狗糧。
+
+更值得注意的是**正式對外開源時做的選擇**。原作者沒有把內部程式碼庫直接推出去，而是做了三件事：
+
+1. 把核心想法抽出來變成一份獨立的 SPEC.md
+2. 叫 Codex 照這份 SPEC 從零實作
+3. 為了參考實作，**選了 Elixir**
+
+第三點是這篇文章裡最反直覺的選擇。Elixir 不是矽谷主流——比例大概像台灣餐飲界的義式冷麵，存在但不是熱門選項。原作者在文章裡寫得很直白：
+
+> Because when code is effectively free, you can finally pick languages for their strengths, like Elixir's concurrency.
+
+直譯：「當寫程式的成本趨近於零的時候，團隊終於可以為了語言本身的長處選語言——像 Elixir 在並行性上的優勢。」
+
+這句話翻成現實的判斷是這樣：以前選 Go 或 Python 不只是因為它們夠用，是因為團隊裡會這個語言的人多、人才市場深。當會寫程式的「人」變成 agent，那「**人才市場深度**」這個變數的重要性會下降，變成「**這個語言在這個任務上的技術契合度**」變成更重要的考量。Elixir 的 BEAM 虛擬機跟 OTP 框架在做監督樹跟並行進程上是少數能直接上場的選項，剛好是 Symphony 這種編排系統的天然契合點。
+
+但他們沒停在 Elixir。為了打磨 SPEC，**原作者讓 Codex 把同一份規格實作了 TypeScript、Go、Rust、Java、Python 五個版本**——目的不是釋出五個程式碼庫，是「用多個實作來找規格本身的歧義」。哪個地方在某個語言生效但在另一個語言模糊，那就是規格寫得不夠精準。原文寫「It succeeded in every language」——五個版本都成功跑起來，這同時驗證了 Codex 的多語言能力跟 SPEC 本身的清晰度。
+
+<ClawdNote>
+Clawd 在這段最想拉出來講的，是「**用多個實作打磨同一份規格**」這個動作。
+
+這在 IETF 圈子裡是有名的傳統——一份 RFC 通常要等到至少兩個獨立實作能互通，才算正式釋出。OpenAI 工程團隊把這個古典做法拉回來用，差別是他們不需要找另一個團隊來寫第二份實作，**他們叫 Codex 寫五份**。
+
+這對獨立開發者的意義很實際：以後寫 SDK、設計通訊協定、規劃 API 介面的時候，**多語言的實作不再是奢侈品**。要驗證自己寫的規格是不是真的清楚，不是找人審查，而是叫 Codex 用三個不同語言實作一遍，看哪裡接不起來——這比讀 100 篇審查留言都有效，而且成本是 $0（如果用自家本機模型）到幾十美元（如果用 API）。
+
+Clawd 私心覺得這是這篇文章裡最被低估的一條教訓。500% PR 那個數字會被報導，但「叫 Codex 寫五個語言版本來打磨 SPEC」這種操作習慣才是會留下來的工程文化變化 (⌐■_■)
+
+對了，社群也已經先動了一步——[CP-179 那篇 (2026-03-16)](/posts/cp-179-20260316-daniel-mac8-symphony-manage-work-not-agents/) 講的就是 daniel_mac8 在 X 上展示一個社群版的 Elixir 實作，比 OpenAI 這次 4 月 27 日的官方開源還要早一個多月。意思是這個概念 OpenAI 內部跑了半年、社群在 3 月就嗅到味道、4 月底 OpenAI 才把規格正式化釋出。Symphony 不是天上掉下來的新東西，是把一條已經在野生的工作模式定型寫下來。
+</ClawdNote>
+
+---
+
+## 但放掉對話控制權，代價是什麼？
+
+這篇文章難得的是它有交代痛點。轉成任務單級別派活之後，工程師失去了「**即時介入修正方向**」這件事的能力。原文寫「sometimes the agent produced something that completely missed the mark」（有時候 agent 產出的東西完全跑偏）。
+
+OpenAI 工程團隊的回應是一句很簡潔的方針：
+
+> Instead of patching the result manually, we added guardrails and skills so the agents could succeed the next time.
+
+直譯：「不要自己動手修結果，而是加新的防護欄跟技能讓 agent 下次能做對。」
+
+這是一條會被低估的工程紀律。修一次缺陷跟「**讓 agent 從此不會再犯這個缺陷**」是兩件事，後者才是把工作流真正自動化的方法。落實到 Symphony 的 harness，他們陸續加了：
+
+- 跑端到端測試的能力
+- 透過 Chrome DevTools 操控應用程式
+- 管 QA 冒煙測試
+- 寫文件、明確說「好的成品長什麼樣」
+
+每一條都對應到一類「agent 之前會踩到」的失敗模式。**這份失敗紀錄本身就是隱性的規格**——agent 踩過的雷，被翻譯成防護欄之後就變成系統的一部分。
+
+但同時原作者也明白寫了一條限制：「not every task fits the Symphony style of work」（不是每個任務都適合 Symphony 這套）。模糊的、需要強判斷力的問題還是要工程師親自跟 Codex 對話。原文補了一句很有意思的話——「these are usually the most interesting and enjoyable tasks for our engineers to spend time on」（這些往往才是工程師花時間花得最爽的任務）。
+
+換句話說 Symphony 不是要把工程師從工作裡擠出去，是把**工程師花時間在不喜歡做的事情**這條成本砍掉。例行 PR、合併、CI 維護這些重複性高的工作丟給 agent；那些有趣的、需要判斷力的、模糊的問題留給人。**這條分工本身比 500% 那個數字更值得記住**——它是個關於「人類工程師應該怎麼花時間」的明確態度。
+
+<ClawdNote>
+這條「不要修結果、要修系統」的紀律 Clawd 想多吐槽一下，因為這是**獨立工程師最容易踩偏的雷**。
+
+當 agent 出錯，最快的反應永遠是「啊我自己改一下就好」。但這個動作其實是在偷工——下一次 agent 還會犯同一個錯，下下次也是，直到工程師被同樣的修改重複到崩潰，才會回頭問「為什麼一開始不修系統」。
+
+OpenAI 工程團隊在這篇文章裡講的不是新觀念——這就是豐田那套**「五個為什麼」**的軟體版本。發現問題不是要立刻修症狀，是問五次「為什麼」一路追到根因，再去修根因。差別是豐田修的是生產線上的物理機器，OpenAI 工程團隊修的是 agent 的 harness、技能、文件。
+
+對個人開發者來說，這條翻譯成行動是這樣：**每次發現自己手動修補一個 agent 產出，停下來問「這次的修改可不可以變成下次的提示？」** 如果可以——把它寫成技能、寫成 CLAUDE.md 條目、寫成 hooks。如果不能——記下來，等下次再遇到一樣的場景時把它變成可重用的東西。Clawd 看過太多人手動改 100 次同一種錯誤、然後抱怨 agent 不夠聰明 (¬‿¬)
+</ClawdNote>
+
+---
+
+## 「OpenAI 工程團隊不會把它當產品維護」——為什麼這句話比開源還重要
+
+文章結尾那段最值得讀的是 OpenAI 工程團隊對這套東西的定位：
+
+> Symphony is an intentionally minimal orchestration layer. We're open sourcing it to demonstrate the power of Codex App Server when paired with different workflow tools, like Linear. As such, we don't plan to maintain Symphony as a standalone product.
+
+直譯：「Symphony 是一層刻意保持最簡的編排層。OpenAI 工程團隊把它開源是為了展示 Codex 應用伺服器配上 Linear 這類工作流工具的可能性。因此，OpenAI 工程團隊**不打算把 Symphony 當成獨立產品來維護**。」
+
+這句話表面是「不維護」，底下的含意更大。OpenAI 的真正產品是 Codex 跟它的應用伺服器模式——一個有完整文件的 JSON-RPC 介面、可以被外部程式化操控的 agent 執行環境。Symphony 只是「**這個應用伺服器怎麼跟外部工作流工具接起來**」的一份參考實作。原作者明白寫：「希望讀者把自家的 coding agent 對著這份 SPEC，去做適合自家環境的版本」。
+
+這條策略選擇值得拿來跟前一篇 harness 工程文章比。當時那篇文章被很多開發者拿去當程式碼庫的骨架指南，Symphony 這次也走同樣的路——**不賣產品，賣模式**。模式比產品更便宜複製，但也更難變成鎖定使用者的護城河。OpenAI 似乎不在乎護城河，他們在乎的是讓更多開發者把自己的工作流接上 Codex 應用伺服器。**這是「平台」級別的賭注**——用這種開放但不維護的姿態，把編排層的選擇權讓給生態系。
+
+文章的結尾那句話總結得乾脆：
+
+> You can just build things with Codex.
+
+直譯：「就用 Codex 把東西造出來吧。」沒有行銷文宣，沒有路線圖，沒有候補名單。一份 SPEC、一份 Elixir 實作、一個 GitHub 儲存庫（**截至 2026 年 4 月 23 日已經拿到超過 15,000 顆星**），剩下的交給社群決定。
+
+---
+
+## 結語
+
+回到開頭那句觀察：「**人類的注意力是新的瓶頸**」。
+
+這篇文章如果只能帶走一條，不是 500%、不是 Elixir、不是任務板控制台——是這條：當前一代瓶頸被打通，水會流到下一個低點。Codex 解掉了「寫程式」這個瓶頸，下一個低點是「人在多任務之間切換的成本」。Symphony 砍掉這個低點，下一個低點會是什麼？
+
+原作者自己留了一條暗線值得記下來：他們覺得**未來各家公司的瓶頸會從「寫程式」整個移到「管理 agent 工作流」**。這意味著「工程師」這個角色的內涵會慢慢從「寫程式的人」變成「**設計工作流、維護防護欄、決定 agent 該往哪走的人**」。Symphony 是這個未來的一個早期示範，但它不是終點。
+
+那個在小木屋用爛網路推三個修改的工程師，他真正展示的不是 Symphony 多猛——是當寫程式不再卡人，**工程師可以從哪些地方做事**。從家裡、從咖啡店、從旅行途中、從手機上的 Linear 介面——只要他能描述清楚自己想要什麼，agent 就能接手把它寫出來。
+
+這是 Symphony 真正想賣的東西。不是 PR 翻五倍，不是 Elixir 多優雅，是這個畫面背後那個更基本的轉移——**「寫程式」這件事正在變成「描述工作」這件事**，而描述工作可以在任何地方發生。


### PR DESCRIPTION
## Summary

SP-187：把 OpenAI 工程團隊 2026-04-27 開源 Symphony 的 [部落格文章](https://openai.com/index/open-source-codex-orchestration-symphony/)（作者 Alex Kotliarskyi、Victor Zhu、Zach Brock）翻成中文 + 英文 SP 雙版本。

Symphony 是一份 Markdown 規格 + Elixir 參考實作，把 Linear 的任務板變成 Codex agent 的中央控制台。每張開放 ticket 都對應一個專屬 workspace，agent 一直跑到 ticket 結束。

## 文章主軸

- **3-5 個對話的天花板**：harness 工程解掉「agent 寫得不夠好」之後，下一個瓶頸是「人的注意力」
- **任務板取代 session 當控制平面**：ticket 跟 PR/session 解綁，一張 ticket 可以對應多個 PR、跨多個 repo、或完全不產生 PR
- **500% PRs claim 三條限制條件全保留**：「部分團隊」「前三週」「PR 落地數」三層 hedge 都明白寫出來，並用整節拆解 vanity metric 跟結構性改變的差別
- **PM/設計師也能直接派活 vs no-code/low-code 廠商威脅**：當寫程式變便宜，no-code 工具的「抽象層上限」反而變成弱點
- **Symphony 開發 Symphony**：bootstrapping 遞迴 + Codex 寫 5 個語言版本（TS/Go/Rust/Java/Python）打磨 SPEC，致敬 IETF RFC 多實作傳統
- **Toyota 五個為什麼**：「不要修結果，修系統」這條工程紀律對獨立開發者最關鍵
- **不打算當產品維護**：把編排層的選擇權讓給生態系，這是平台級賭注

## Cross-references

- [CP-179](https://gu-log.vercel.app/posts/cp-179-20260316-daniel-mac8-symphony-manage-work-not-agents/)：社群 daniel_mac8 在 2026-03-16 已經做了 Elixir 版 Symphony，比 OpenAI 4-27 官方開源還早一個多月
- [SP-185](https://gu-log.vercel.app/posts/sp-185-20260428-andrew-ng-meta-muse-spark-the-batch-349/)：同週 Andrew Ng 寫的 AI-native 團隊也講同一條觀察的另一面（工程師應該學產品 vs PM 應該能直接派活）

## Tribunal results — 4 judges all PASS

| Judge | Composite | Dimensions |
|---|---|---|
| Vibe (Opus 4.6) | **8 PASS** | persona 8 / clawdNote 8 / vibe 8 / clarity 8 / **narrative 9** |
| Fact Check (Opus) | **9 PASS** | accuracy 9 / fidelity 9 / consistency 9 |
| Librarian (Opus 4.7) | **8 PASS** | glossary 8 / crossRef 7 / sourceAlign 10 / attribution 10 |
| Fresh Eyes (Opus 4.7) | **8 PASS** | readability 8 / firstImpression 8 |

Tribunal v1 vibe 卡 7（晶晶體 + ClawdNote 密度太低），rewriter 修了：
- `scale` → `撐不起來`、`monorepo` → `大型單一儲存庫`、`bug` → `缺陷`
- 加了 2 個 opinion-bearing ClawdNote（Webflow/Bubble/Retool 威脅 + Toyota 五個為什麼紀律）
- 第一次出現 Clawd 加上 `/about` 連結

V2 重評全部過。

## 旁路改動

- `scripts/check-jingjing.mjs` allowlist 新增 OpenAI 三位作者、Karri Saarinen、daniel_mac8、Symphony、Vite、Webflow/Bubble/Retool、tmux/monorepo/BEAM/OTP/DAG/IETF/RFC/bug、Chrome/DevTools、JSON-RPC、SPEC.md/WORKFLOW.md 等 proper noun 跟通用 file/protocol 名（已在前一個 commit）
- `scripts/article-counter.json` SP next: 186 → 188（186 留給平行的 SP-186 PR，187 此處用掉）

## Test plan

- [x] `node scripts/validate-posts.mjs` PASS（zh-tw + en 兩版）
- [x] `node scripts/check-jingjing.mjs` clean
- [x] `node scripts/check-pronoun-clarity.mjs` clean
- [x] `pnpm exec astro check` 0 errors
- [x] `pnpm run build` 完整 build 過（2890 pages）
- [x] Pre-commit hook（prettier / validate / contrast / playwright content integrity）全綠
- [x] 4-judge tribunal 全 PASS
- [ ] Vercel preview 看 zh-tw + en 兩版實際 render
- [ ] CI 全綠後 self-merge

https://claude.ai/code/session_019HBBkX3QpRantR9vfQ3spC

---
_Generated by [Claude Code](https://claude.ai/code/session_019HBBkX3QpRantR9vfQ3spC)_