### PR TITLE
test(tribunal): point publish regression at canonical runner

### DIFF
--- a/scripts/tests/test-tribunal-publish-worker-changes.sh
+++ b/scripts/tests/test-tribunal-publish-worker-changes.sh
@@ -105,10 +105,10 @@ same_main_hash_after="$(git -C "$main" hash-object src/content/posts/cp-999-test
 [ "$same_main_hash_before" = "$same_main_hash_after" ] || fail "same-repo publish should be a no-op"
 pass "same-repo publish is safe no-op"
 
-if ! grep -q 'tribunal-publish-worker-changes.sh' "$ROOT_DIR/scripts/tribunal-all-claude.sh"; then
-  fail "tribunal-all-claude.sh does not call publish helper before committing progress"
+if ! grep -q 'tribunal-publish-worker-changes.sh' "$ROOT_DIR/scripts/tribunal.sh"; then
+  fail "tribunal.sh does not call publish helper before committing progress"
 fi
-if ! grep -q 'src/content/posts/\$POST_FILE' "$ROOT_DIR/scripts/tribunal-all-claude.sh"; then
-  fail "tribunal-all-claude.sh does not stage target post files in commit_progress"
+if ! grep -q 'src/content/posts/\$POST_FILE' "$ROOT_DIR/scripts/tribunal.sh"; then
+  fail "tribunal.sh does not stage target post files in commit_progress"
 fi
-pass "tribunal-all-claude.sh wires post publishing into commit_progress"
+pass "tribunal.sh wires post publishing into commit_progress"


### PR DESCRIPTION
## Summary
- Update the Tribunal worker-publish regression test to inspect the canonical runner .
- The old  is now only a deprecated compatibility wrapper, so checking it creates a false safety failure.

## Test plan
- [x] bash -n scripts/tribunal.sh scripts/tribunal-helpers.sh scripts/vibe-scorer.sh scripts/tribunal-all-claude.sh scripts/tests/test-tribunal-safety-contract.sh scripts/tests/test-tribunal-pass-artifact-guards.sh scripts/tests/test-tribunal-publish-worker-changes.sh
- [x] python3 -m py_compile scripts/tribunal-librarian-packet.py
- [x] bash scripts/tests/test-tribunal-safety-contract.sh
- [x] bash scripts/tests/test-tribunal-pass-artifact-guards.sh
- [x] bash scripts/tests/test-tribunal-publish-worker-changes.sh
- [x] git diff --check