### PR TITLE
test(sp-pipeline): guard Codex-only provider routing

### DIFF
--- a/tools/sp-pipeline/cmd/sp-pipeline/fetch.go
+++ b/tools/sp-pipeline/cmd/sp-pipeline/fetch.go
@@ -119,10 +119,10 @@ func resolveWorkDir(state *rootState) (string, error) {
 		return abs, nil
 	}
 	// Default: $TMPDIR/sp-pending-<unix>-pipeline. This must NOT be under
-	// the repo because claude -p's CLAUDE.md auto-discovery walks up the
-	// cwd tree and pulls in the gu-log repo CLAUDE.md, which derails the
-	// long write/review/refine prompts and causes silent exit-1 failures.
-	// See pipeline.SetupWorkDir for the same reasoning.
+	// the repo: SP pipeline work dirs are scratch spaces, and the maintained
+	// Codex route explicitly uses --skip-git-repo-check so it can run there
+	// without inheriting repo-level side effects. See pipeline.SetupWorkDir
+	// for the same reasoning.
 	stamp := time.Now().Unix()
 	_ = state // RepoRoot kept reachable for future callers; unused here
 	return filepath.Join(os.TempDir(), fmt.Sprintf("sp-pending-%d-pipeline", stamp)), nil

--- a/tools/sp-pipeline/cmd/sp-pipeline/main.go
+++ b/tools/sp-pipeline/cmd/sp-pipeline/main.go
@@ -100,7 +100,7 @@ for the migration history and current operational notes.`,
 	root.PersistentFlags().DurationVar(&flagTimeout, "timeout", 50*time.Minute,
 		"wall-clock timeout for the entire invocation (e.g. 50m, 1h30m)")
 	root.PersistentFlags().StringVar(&flagWorkDir, "work-dir", "",
-		"override the work directory (default: $TMPDIR/sp-pending-<epoch>-pipeline; lives outside the repo to dodge claude -p CLAUDE.md auto-discovery)")
+		"override the work directory (default: $TMPDIR/sp-pending-<epoch>-pipeline; lives outside the repo; Codex is invoked with --skip-git-repo-check)")
 	root.PersistentFlags().StringVar(&flagFakeProvider, "fake-provider", "",
 		"(test only) path to a JSON file with canned LLM responses; replaces the real provider chain")
 	_ = root.PersistentFlags().MarkHidden("fake-provider")

--- a/tools/sp-pipeline/internal/llm/claude.go
+++ b/tools/sp-pipeline/internal/llm/claude.go
@@ -8,11 +8,10 @@ import (
 	"github.com/chitienhsiehwork-ai/gu-log/tools/sp-pipeline/internal/runner"
 )
 
-// ClaudeProvider shells out to `claude -p --model <model>` with a
-// permission-mode appropriate to the calling user. Pipeline steps after
-// eval (write/review/refine) instruct the LLM to write its output to a
-// file in WorkDir, so the model needs Write/Edit permission — `-p` will
-// happily invoke tools as long as a permission mode allows it.
+// ClaudeProvider shells out to `claude -p --model <model>`. It is retained as
+// a historical compatibility wrapper only; the maintained SP pipeline runtime
+// and doctor probe chain do not include Claude by default because the Clawd VM
+// should not assume Anthropic env/login exists.
 //
 //   - Non-root (VPS Clawd, dev laptops) → bypassPermissions: the broadest
 //     setting and the one the bash pipeline historically used.

--- a/tools/sp-pipeline/internal/llm/codex_test.go
+++ b/tools/sp-pipeline/internal/llm/codex_test.go
@@ -1,0 +1,102 @@
+package llm
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCodexProviderRunUsesGPT55MediumDangerFullAccess(t *testing.T) {
+	binDir := t.TempDir()
+	captureArgs := filepath.Join(t.TempDir(), "args.txt")
+	capturePWD := filepath.Join(t.TempDir(), "pwd.txt")
+	codexPath := filepath.Join(binDir, "codex")
+	script := `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$PWD" > "$CAPTURE_PWD"
+printf '%s\n' "$@" > "$CAPTURE_ARGS"
+out=""
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "-o" ]; then
+    shift
+    out="$1"
+    break
+  fi
+  shift
+done
+if [ -z "$out" ]; then
+  echo "missing -o" >&2
+  exit 2
+fi
+printf 'codex-ok\n' > "$out"
+`
+	if err := os.WriteFile(codexPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake codex: %v", err)
+	}
+
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("CAPTURE_ARGS", captureArgs)
+	t.Setenv("CAPTURE_PWD", capturePWD)
+
+	workDir := t.TempDir()
+	out, err := NewCodexGPT55Medium().Run(context.Background(), "hello prompt", RunOptions{WorkDir: workDir})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if out != "codex-ok" {
+		t.Fatalf("output = %q, want codex-ok", out)
+	}
+
+	pwd, err := os.ReadFile(capturePWD)
+	if err != nil {
+		t.Fatalf("read captured pwd: %v", err)
+	}
+	if strings.TrimSpace(string(pwd)) != workDir {
+		t.Fatalf("codex cwd = %q, want %q", strings.TrimSpace(string(pwd)), workDir)
+	}
+
+	rawArgs, err := os.ReadFile(captureArgs)
+	if err != nil {
+		t.Fatalf("read captured args: %v", err)
+	}
+	args := strings.Split(strings.TrimSpace(string(rawArgs)), "\n")
+	joined := strings.Join(args, " ")
+
+	mustContain := []string{
+		"exec",
+		"--model gpt-5.5",
+		"-c model_reasoning_effort=\"medium\"",
+		"--sandbox danger-full-access",
+		"--skip-git-repo-check",
+		"-- hello prompt",
+	}
+	for _, want := range mustContain {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("codex args %q missing %q", joined, want)
+		}
+	}
+	for _, forbidden := range []string{"--full-auto", "workspace-write", "claude", "gemini"} {
+		if strings.Contains(joined, forbidden) {
+			t.Fatalf("codex args %q unexpectedly contain %q", joined, forbidden)
+		}
+	}
+}
+
+func TestDefaultChainsAreCodexGPT55Only(t *testing.T) {
+	for name, chain := range map[string][]Provider{
+		"writing": DefaultWritingChain(),
+		"probe":   DefaultProbeChain(),
+	} {
+		if len(chain) != 1 {
+			t.Fatalf("%s chain length = %d, want 1", name, len(chain))
+		}
+		if chain[0].Name() != "codex-gpt-5.5" {
+			t.Fatalf("%s provider = %q, want codex-gpt-5.5", name, chain[0].Name())
+		}
+		if chain[0].Model() != ModelGPT55 {
+			t.Fatalf("%s model = %q, want %q", name, chain[0].Model(), ModelGPT55)
+		}
+	}
+}

--- a/tools/sp-pipeline/internal/llm/defaults.go
+++ b/tools/sp-pipeline/internal/llm/defaults.go
@@ -1,0 +1,19 @@
+package llm
+
+// DefaultWritingChain returns the provider ordering used for article writing
+// and review/refine steps. Codex GPT-5.5 medium is the only default provider:
+// Anthropic and Gemini subscriptions are not assumed to exist on the Clawd VM.
+func DefaultWritingChain() []Provider {
+	return []Provider{
+		NewCodexGPT55Medium(),
+	}
+}
+
+// DefaultProbeChain returns the providers the doctor subcommand should ping.
+// Keep this aligned with the production default chain so doctor does not fail
+// or warn on intentionally unavailable Claude/Gemini subscriptions.
+func DefaultProbeChain() []Provider {
+	return []Provider{
+		NewCodexGPT55Medium(),
+	}
+}

--- a/tools/sp-pipeline/internal/llm/gemini.go
+++ b/tools/sp-pipeline/internal/llm/gemini.go
@@ -7,11 +7,10 @@ import (
 	"github.com/chitienhsiehwork-ai/gu-log/tools/sp-pipeline/internal/runner"
 )
 
-// GeminiProvider shells out to the Gemini CLI. In sp-pipeline today this is
-// used ONLY for the tribunal (AI judges) and the eval step's second opinion,
-// never for article writing. The Go port preserves that policy: NewDefaults
-// does not include Gemini in the writing chain, but constructing one
-// directly for a tribunal-style invocation is fully supported.
+// GeminiProvider shells out to the Gemini CLI. It is retained as a historical
+// compatibility wrapper only; the maintained SP pipeline runtime and doctor
+// probe chain do not include Gemini by default because the Clawd VM should not
+// assume a Gemini subscription or login exists.
 type GeminiProvider struct {
 	// ModelName is passed as --model, defaults to "gemini-3.1-pro-preview".
 	ModelName string
@@ -61,23 +60,4 @@ func (g *GeminiProvider) modelName() string {
 		return "gemini-3.1-pro-preview"
 	}
 	return g.ModelName
-}
-
-// DefaultWritingChain returns the provider ordering used for article
-// writing (write / review / refine steps). Codex GPT-5.5 medium is the
-// only default provider: Anthropic and Gemini subscriptions are no longer
-// assumed to exist on the VM.
-func DefaultWritingChain() []Provider {
-	return []Provider{
-		NewCodexGPT55Medium(),
-	}
-}
-
-// DefaultProbeChain returns the providers the doctor subcommand should ping.
-// Keep this aligned with the production default chain so doctor does not fail
-// or warn on intentionally unavailable Claude/Gemini subscriptions.
-func DefaultProbeChain() []Provider {
-	return []Provider{
-		NewCodexGPT55Medium(),
-	}
 }

--- a/tools/sp-pipeline/internal/pipeline/run.go
+++ b/tools/sp-pipeline/internal/pipeline/run.go
@@ -14,14 +14,10 @@ import (
 // directory on clean exit unless s.KeepWorkDir is true.
 //
 // The default work directory lives OUTSIDE the repo (under os.TempDir())
-// rather than under <repo>/tmp/. Reason: when claude -p runs with cwd
-// inside a git repo it walks up the directory tree, auto-discovers the
-// parent CLAUDE.md, and on long pipeline prompts (write step embeds the
-// 340-line WRITING_GUIDELINES.md plus the source body) the discovered
-// CLAUDE.md instructions ("first run detect-env.sh", etc) derail the
-// model and it exits 1 with empty stderr. Putting WorkDir under
-// os.TempDir() means the cwd walk-up terminates at /tmp without
-// discovering anything, and the prompt drives the run cleanly.
+// rather than under <repo>/tmp/. These are disposable scratch dirs, not git
+// worktrees. The maintained Codex route therefore runs with
+// --skip-git-repo-check and writes requested artifacts into this directory
+// without inheriting repo-level side effects.
 //
 // The deploy step still copies final.mdx into <repo>/src/content/posts,
 // so this only affects intermediate scratch files.


### PR DESCRIPTION
## Summary
- add regression coverage for the Codex GPT-5.5 medium argv shape
- assert default writing/probe chains are Codex-only
- move default provider chain out of gemini.go and mark Claude/Gemini wrappers as historical compatibility only
- update work-dir comments/help text to describe the current Codex --skip-git-repo-check route

## Verification
- go test ./... (tools/sp-pipeline)
- go run ./cmd/sp-pipeline doctor --probe-llm
- git diff --check
- normal pre-commit hooks passed
- normal pre-push hooks passed

## Notes
- doctor --probe-llm reports only codex-gpt-5.5 / GPT-5.5 ok
- bundle trend warnings appeared during pre-push but blocking budgets passed