### PR TITLE
feat: improve sp-pipeline observability and handoff state

### DIFF
--- a/tools/sp-pipeline/README.md
+++ b/tools/sp-pipeline/README.md
@@ -23,6 +23,7 @@ Every step is a subcommand. Agents compose them without running the whole monoli
 
 ```bash
 sp-pipeline fetch <url>                      # step 1 only
+sp-pipeline status <work-dir>               # active/recent run summary
 sp-pipeline eval --source <file>             # step 1.5
 sp-pipeline dedup --url <url> --title <t>    # step 1.7
 sp-pipeline write --source <file>            # step 2
@@ -36,6 +37,26 @@ sp-pipeline counter {next,bump} --prefix SP  # ticket counter
 ```
 
 Global flags: `--json` (machine output), `--verbose`, `--timeout 50m`, `--work-dir <dir>`.
+
+## Observability / handoff state
+
+`sp-pipeline run` now writes `<work-dir>/pipeline-status.json` at step boundaries. The file is intentionally small and operator-facing: current step, last completed step, artifacts present, active/final filename, next action, stale warning, and pending-artifact guardrail state.
+
+Use it through the CLI:
+
+```bash
+tools/sp-pipeline/sp-pipeline status /tmp/sp-pending-...-pipeline
+```
+
+The `status` command refreshes the saved status with live repo facts:
+
+- work-dir artifacts (`source-tweet.md`, `draft-v1.mdx`, `review.md`, `final.mdx`, `tribunal-stdout.txt`)
+- tribunal stage from `scores/tribunal-progress.json`
+- git diff summary
+- guardrails for leftover `sp-pending-*` posts / pending tribunal-progress entries
+- stale warning when a supposedly-running step has gone quiet too long
+
+It exits non-zero when the run looks suspicious (stale, missing required artifact, or pending-artifact guardrail violation).
 
 Exit codes are distinct so failures can be handled programmatically:
 

--- a/tools/sp-pipeline/SKILL.md
+++ b/tools/sp-pipeline/SKILL.md
@@ -25,6 +25,7 @@ Expected: first call takes ~3 seconds (cold compile), subsequent calls are insta
 | User intent | Run | Why |
 |-------------|-----|-----|
 | **"Run the whole pipeline on a tweet URL"** | `sp-pipeline run <url>` | The canonical end-to-end entry point — fetch → eval → dedup → write → review → refine → credits → ralph → deploy |
+| **"Any progress?" / "What step is stuck?"** | `sp-pipeline status <work-dir>` | Reads `pipeline-status.json`, work-dir artifacts, tribunal progress, and git diff to answer the observability questions in one command |
 | **"User wants a specific narrative angle"** | `sp-pipeline run --angle "focus on X while introducing the others" <url>` | Pipes the directive into the write + refine prompts; opening must establish the angle, closing must call back to it |
 | **"Source is a docs / blog page, not a tweet"** | `sp-pipeline run --source-label "OpenClaw Docs" <url>` | Overrides the `source:` frontmatter line; without it, generic URLs render hostname (`docs.openclaw.ai`) which is usually fine but not pretty |
 | "Resume a stuck run from a specific step" | `sp-pipeline run --from-step <name> --file <existing.mdx>` | Honors bash's `--from-step` contract: setup / fetch / eval / dedup / write / review / refine / ralph / deploy |
@@ -48,6 +49,20 @@ All subcommands inherit these from the root command:
 - `--verbose` / `-v` — extra debug logs on stderr (currently reserved; no extra output yet)
 - `--timeout 50m` — wall-clock deadline for the whole invocation (Go duration string). Default 50m matches the bash pipeline's `PIPELINE_TIMEOUT=3000`
 - `--work-dir <dir>` — pin the pipeline work directory. Default is `$REPO/tmp/sp-pending-<unix>-pipeline`
+
+## pipeline-status.json
+
+`sp-pipeline run` writes `<work-dir>/pipeline-status.json` at step boundaries. This is the machine-readable handoff card for active/recent runs. It includes:
+
+- `runState`, `currentStep`, `lastCompletedStep`
+- work-dir artifact presence
+- active/final filenames
+- tribunal stage summary
+- git changed files
+- pending-artifact guardrail results
+- `nextAction` + `staleWarning`
+
+`sp-pipeline status <work-dir>` reloads that file, refreshes it with live repo state, and exits non-zero if the run looks suspicious (stale, missing a required artifact, or carrying leftover pending artifacts).
 
 ## `run` / `write` / `refine` shaping flags
 

--- a/tools/sp-pipeline/cmd/sp-pipeline/main.go
+++ b/tools/sp-pipeline/cmd/sp-pipeline/main.go
@@ -59,6 +59,7 @@ It is split into composable subcommands so an agent (or a human) can run
 one step at a time without inheriting the whole pipeline's side effects:
 
   fetch      capture a tweet / article into a work directory
+  status     inspect an active/recent run from work-dir + repo artifacts
   eval       decide whether a source is SP-worthy
   dedup      check whether the source is already covered
   write      draft the zh-tw + en MDX pair
@@ -114,6 +115,7 @@ for the migration history and current operational notes.`,
 	// access to the resolved config, logger, and flags.
 	root.AddCommand(newDoctorCmd(state))
 	root.AddCommand(newFetchCmd(state))
+	root.AddCommand(newStatusCmd(state))
 	root.AddCommand(newCounterCmd(state))
 	root.AddCommand(newDedupCmd(state))
 	root.AddCommand(newEvalCmd(state))

--- a/tools/sp-pipeline/cmd/sp-pipeline/main_test.go
+++ b/tools/sp-pipeline/cmd/sp-pipeline/main_test.go
@@ -83,7 +83,7 @@ func TestBuildRoot_HasAllSubcommands(t *testing.T) {
 	resetGlobals()
 	root := buildRoot()
 	want := []string{
-		"doctor", "fetch", "counter", "dedup", "eval",
+		"doctor", "fetch", "status", "counter", "dedup", "eval",
 		"write", "review", "refine", "credits", "ralph",
 		"deploy", "run",
 	}

--- a/tools/sp-pipeline/cmd/sp-pipeline/status.go
+++ b/tools/sp-pipeline/cmd/sp-pipeline/status.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/chitienhsiehwork-ai/gu-log/tools/sp-pipeline/internal/observability"
+)
+
+func newStatusCmd(state *rootState) *cobra.Command {
+	var staleAfter time.Duration
+	cmd := &cobra.Command{
+		Use:   "status [work_dir]",
+		Short: "Summarize an active or recent pipeline run from its work dir + repo artifacts",
+		Long: `status reads the per-run pipeline-status.json (when present), refreshes it
+with live artifact + git + tribunal state, and prints one concise operator
+card:
+
+  - which step is/was active
+  - which artifacts exist in the work dir
+  - which tribunal stage is active
+  - what the repo diff looks like
+  - what the next expected action is
+  - whether the run looks stale or suspicious
+
+Pass the work dir as a positional argument, or reuse the root --work-dir flag.`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			workDir := flagWorkDir
+			if len(args) == 1 {
+				workDir = args[0]
+			}
+			if workDir == "" {
+				return fmt.Errorf("status: work dir required (pass status <dir> or root --work-dir)")
+			}
+			st, err := observability.Collect(state.cfg, workDir, observability.CollectOptions{StaleAfter: staleAfter})
+			if err != nil {
+				return err
+			}
+			emitStatus(state, st)
+			if len(st.Suspicious) > 0 {
+				return newExitError(1, fmt.Errorf("status: suspicious state: %s", strings.Join(st.Suspicious, "; ")))
+			}
+			return nil
+		},
+	}
+	cmd.Flags().DurationVar(&staleAfter, "stale-after", observability.DefaultStaleAfter, "warn/fail if the run has been quiet longer than this")
+	return cmd
+}
+
+func emitStatus(state *rootState, st *observability.RunStatus) {
+	if state.json {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(st)
+		return
+	}
+
+	fmt.Printf("Run state  : %s\n", fallback(st.RunState, "unknown"))
+	fmt.Printf("Step       : %s\n", fallback(st.CurrentStep, fallback(st.LastCompletedStep, "unknown")))
+	fmt.Printf("Work dir   : %s\n", st.WorkDir)
+	if st.ActiveFilename != "" || st.Filename != "" {
+		fmt.Printf("Article    : %s\n", fallback(st.Filename, st.ActiveFilename))
+	}
+	if existing := existingArtifacts(st.Artifacts); len(existing) > 0 {
+		fmt.Printf("Artifacts  : %s\n", strings.Join(existing, ", "))
+	}
+	if st.Tribunal.Summary != "" {
+		fmt.Printf("Tribunal   : %s\n", st.Tribunal.Summary)
+	}
+	if len(st.Git.ChangedFiles) > 0 {
+		fmt.Printf("Git diff   : %d file(s) changed — %s\n", len(st.Git.ChangedFiles), strings.Join(limitStrings(st.Git.ChangedFiles, 4), ", "))
+	}
+	fmt.Printf("Next action: %s\n", st.NextAction)
+	if st.StaleWarning != "" {
+		fmt.Printf("Warning    : %s\n", st.StaleWarning)
+	}
+	if len(st.Guardrails.Violations) > 0 {
+		fmt.Printf("Guardrail  : %s\n", strings.Join(renderViolations(st.Guardrails.Violations), "; "))
+	}
+}
+
+func fallback(value, alt string) string {
+	if value != "" {
+		return value
+	}
+	return alt
+}
+
+func existingArtifacts(artifacts map[string]observability.Artifact) []string {
+	var out []string
+	for key, artifact := range artifacts {
+		if artifact.Exists {
+			out = append(out, key)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func limitStrings(items []string, max int) []string {
+	if len(items) <= max {
+		return items
+	}
+	return append(append([]string{}, items[:max]...), fmt.Sprintf("+%d more", len(items)-max))
+}
+
+func renderViolations(violations []observability.GuardrailViolation) []string {
+	out := make([]string, 0, len(violations))
+	for _, violation := range violations {
+		label := violation.Kind
+		if violation.Detail != "" {
+			label += " (" + violation.Detail + ")"
+		} else {
+			label += " (" + violation.Path + ")"
+		}
+		out = append(out, label)
+	}
+	return out
+}

--- a/tools/sp-pipeline/internal/deploy/deploy.go
+++ b/tools/sp-pipeline/internal/deploy/deploy.go
@@ -17,6 +17,7 @@ import (
 	"github.com/chitienhsiehwork-ai/gu-log/tools/sp-pipeline/internal/counter"
 	"github.com/chitienhsiehwork-ai/gu-log/tools/sp-pipeline/internal/frontmatter"
 	"github.com/chitienhsiehwork-ai/gu-log/tools/sp-pipeline/internal/logx"
+	"github.com/chitienhsiehwork-ai/gu-log/tools/sp-pipeline/internal/observability"
 	"github.com/chitienhsiehwork-ai/gu-log/tools/sp-pipeline/internal/runner"
 )
 
@@ -116,6 +117,26 @@ func Run(ctx context.Context, opts Options) (*Result, error) {
 		if err := replacePendingTicketID(filepath.Join(postsDir, finalEN), ticketID); err != nil {
 			return nil, err
 		}
+	}
+	if err := observability.RenameTribunalProgressEntry(opts.Cfg.RepoRoot, opts.ActiveFilename, finalFilename); err != nil {
+		return nil, fmt.Errorf("deploy: rename tribunal progress entry: %w", err)
+	}
+	violations, err := observability.CheckPendingArtifacts(opts.Cfg.RepoRoot, observability.GuardrailOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("deploy: pending artifact guardrail: %w", err)
+	}
+	if len(violations) > 0 {
+		labels := make([]string, 0, len(violations))
+		for _, violation := range violations {
+			label := violation.Kind
+			if violation.Detail != "" {
+				label += " (" + violation.Detail + ")"
+			} else {
+				label += " (" + violation.Path + ")"
+			}
+			labels = append(labels, label)
+		}
+		return nil, fmt.Errorf("deploy: pending artifact guardrail blocked handoff: %s", strings.Join(labels, ", "))
 	}
 
 	// 4. Validate (unless skipped).

--- a/tools/sp-pipeline/internal/observability/status.go
+++ b/tools/sp-pipeline/internal/observability/status.go
@@ -1,0 +1,738 @@
+package observability
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/chitienhsiehwork-ai/gu-log/tools/sp-pipeline/internal/config"
+	"github.com/chitienhsiehwork-ai/gu-log/tools/sp-pipeline/internal/runner"
+)
+
+const (
+	StatusFileName    = "pipeline-status.json"
+	DefaultStaleAfter = 15 * time.Minute
+)
+
+var pendingArticlePattern = regexp.MustCompile(`^(?:en-)?(?:sp|cp|sd|lv)-pending-.*\.mdx$`)
+
+var tribunalStageOrder = []string{"librarian", "factChecker", "freshEyes", "vibe"}
+
+var artifactFiles = map[string]string{
+	"source":         "source-tweet.md",
+	"evalPrimary":    "eval-codex-primary.json",
+	"evalSecondary":  "eval-codex.json",
+	"draft":          "draft-v1.mdx",
+	"review":         "review.md",
+	"final":          "final.mdx",
+	"tribunalStdout": "tribunal-stdout.txt",
+	"status":         StatusFileName,
+}
+
+type Artifact struct {
+	Path       string `json:"path"`
+	Exists     bool   `json:"exists"`
+	SizeBytes  int64  `json:"sizeBytes,omitempty"`
+	ModifiedAt string `json:"modifiedAt,omitempty"`
+}
+
+type Tribunal struct {
+	Article    string `json:"article,omitempty"`
+	Stage      string `json:"stage,omitempty"`
+	Status     string `json:"status,omitempty"`
+	Attempts   int    `json:"attempts,omitempty"`
+	StartedAt  string `json:"startedAt,omitempty"`
+	FinishedAt string `json:"finishedAt,omitempty"`
+	Summary    string `json:"summary,omitempty"`
+}
+
+type Git struct {
+	Dirty        bool     `json:"dirty"`
+	ChangedFiles []string `json:"changedFiles,omitempty"`
+}
+
+type GuardrailViolation struct {
+	Kind   string `json:"kind"`
+	Path   string `json:"path"`
+	Detail string `json:"detail,omitempty"`
+}
+
+type Guardrails struct {
+	OK         bool                 `json:"ok"`
+	Violations []GuardrailViolation `json:"violations,omitempty"`
+}
+
+type RunStatus struct {
+	Version           int                 `json:"version"`
+	RunState          string              `json:"runState,omitempty"`
+	CurrentStep       string              `json:"currentStep,omitempty"`
+	LastCompletedStep string              `json:"lastCompletedStep,omitempty"`
+	WorkDir           string              `json:"workDir"`
+	RepoRoot          string              `json:"repoRoot,omitempty"`
+	Prefix            string              `json:"prefix,omitempty"`
+	TweetURL          string              `json:"tweetUrl,omitempty"`
+	TicketID          string              `json:"ticketId,omitempty"`
+	ActiveFilename    string              `json:"activeFilename,omitempty"`
+	ActiveENFilename  string              `json:"activeEnFilename,omitempty"`
+	Filename          string              `json:"filename,omitempty"`
+	ENFilename        string              `json:"enFilename,omitempty"`
+	StartedAt         string              `json:"startedAt,omitempty"`
+	UpdatedAt         string              `json:"updatedAt,omitempty"`
+	Error             string              `json:"error,omitempty"`
+	Artifacts         map[string]Artifact `json:"artifacts,omitempty"`
+	Tribunal          Tribunal            `json:"tribunal,omitempty"`
+	Git               Git                 `json:"git,omitempty"`
+	Guardrails        Guardrails          `json:"guardrails"`
+	NextAction        string              `json:"nextAction,omitempty"`
+	StaleWarning      string              `json:"staleWarning,omitempty"`
+	Suspicious        []string            `json:"suspicious,omitempty"`
+}
+
+type SnapshotInput struct {
+	WorkDir           string
+	RepoRoot          string
+	Prefix            string
+	TweetURL          string
+	TicketID          string
+	CurrentStep       string
+	LastCompletedStep string
+	RunState          string
+	ActiveFilename    string
+	ActiveENFilename  string
+	Filename          string
+	ENFilename        string
+	Error             string
+}
+
+type CollectOptions struct {
+	StaleAfter   time.Duration
+	AllowPending []string
+}
+
+type GuardrailOptions struct {
+	AllowPending []string
+}
+
+type tribunalProgressEntry struct {
+	Article    string                           `json:"article"`
+	Status     string                           `json:"status"`
+	StartedAt  string                           `json:"startedAt"`
+	FinishedAt string                           `json:"finishedAt"`
+	Stages     map[string]tribunalProgressStage `json:"stages"`
+}
+
+type tribunalProgressStage struct {
+	Status   string `json:"status"`
+	Attempts int    `json:"attempts"`
+}
+
+func StatusFilePath(workDir string) string {
+	return filepath.Join(workDir, StatusFileName)
+}
+
+func WriteSnapshot(cfg *config.Config, input SnapshotInput) error {
+	if cfg == nil {
+		return fmt.Errorf("observability: config is required")
+	}
+	if input.WorkDir == "" {
+		return fmt.Errorf("observability: work dir is required")
+	}
+	absWorkDir, err := filepath.Abs(input.WorkDir)
+	if err != nil {
+		return fmt.Errorf("observability: abs work dir: %w", err)
+	}
+	if err := os.MkdirAll(absWorkDir, 0o755); err != nil {
+		return fmt.Errorf("observability: mkdir work dir: %w", err)
+	}
+
+	status := &RunStatus{Version: 1, WorkDir: absWorkDir}
+	if existing, err := readStatusFile(StatusFilePath(absWorkDir)); err == nil && existing != nil {
+		status = existing
+	}
+
+	now := time.Now().Format(time.RFC3339)
+	if status.StartedAt == "" {
+		status.StartedAt = now
+	}
+	status.Version = 1
+	status.WorkDir = absWorkDir
+	status.RepoRoot = firstNonEmpty(input.RepoRoot, status.RepoRoot, cfg.RepoRoot)
+	status.Prefix = firstNonEmpty(input.Prefix, status.Prefix)
+	status.TweetURL = firstNonEmpty(input.TweetURL, status.TweetURL)
+	status.TicketID = firstNonEmpty(input.TicketID, status.TicketID)
+	status.CurrentStep = firstNonEmpty(input.CurrentStep, status.CurrentStep)
+	status.LastCompletedStep = firstNonEmpty(input.LastCompletedStep, status.LastCompletedStep)
+	status.RunState = firstNonEmpty(input.RunState, status.RunState)
+	status.ActiveFilename = firstNonEmpty(input.ActiveFilename, status.ActiveFilename)
+	status.ActiveENFilename = firstNonEmpty(input.ActiveENFilename, status.ActiveENFilename)
+	status.Filename = firstNonEmpty(input.Filename, status.Filename)
+	status.ENFilename = firstNonEmpty(input.ENFilename, status.ENFilename)
+	status.Error = input.Error
+	status.UpdatedAt = now
+
+	allowPending := allowPendingForSnapshot(status)
+	if err := enrichStatus(cfg, status, CollectOptions{StaleAfter: DefaultStaleAfter, AllowPending: allowPending}); err != nil {
+		return err
+	}
+
+	body, err := json.MarshalIndent(status, "", "  ")
+	if err != nil {
+		return fmt.Errorf("observability: marshal status: %w", err)
+	}
+	body = append(body, '\n')
+	if err := os.WriteFile(StatusFilePath(absWorkDir), body, 0o644); err != nil {
+		return fmt.Errorf("observability: write status file: %w", err)
+	}
+	return nil
+}
+
+func Collect(cfg *config.Config, workDir string, opts CollectOptions) (*RunStatus, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("observability: config is required")
+	}
+	if workDir == "" {
+		return nil, fmt.Errorf("observability: work dir is required")
+	}
+	absWorkDir, err := filepath.Abs(workDir)
+	if err != nil {
+		return nil, fmt.Errorf("observability: abs work dir: %w", err)
+	}
+
+	status := &RunStatus{Version: 1, WorkDir: absWorkDir, RepoRoot: cfg.RepoRoot}
+	if existing, err := readStatusFile(StatusFilePath(absWorkDir)); err == nil && existing != nil {
+		status = existing
+	}
+	status.Version = 1
+	status.WorkDir = absWorkDir
+	status.RepoRoot = firstNonEmpty(status.RepoRoot, cfg.RepoRoot)
+
+	if opts.StaleAfter <= 0 {
+		opts.StaleAfter = DefaultStaleAfter
+	}
+	if len(opts.AllowPending) == 0 {
+		opts.AllowPending = allowPendingForSnapshot(status)
+	}
+	if err := enrichStatus(cfg, status, opts); err != nil {
+		return nil, err
+	}
+	return status, nil
+}
+
+func CheckPendingArtifacts(repoRoot string, opts GuardrailOptions) ([]GuardrailViolation, error) {
+	allow := make(map[string]bool)
+	for _, item := range opts.AllowPending {
+		for _, key := range []string{item, filepath.Base(item), filepath.ToSlash(item), "src/content/posts/" + filepath.Base(item)} {
+			if key != "" {
+				allow[key] = true
+			}
+		}
+	}
+
+	var violations []GuardrailViolation
+	postsDir := filepath.Join(repoRoot, "src", "content", "posts")
+	entries, err := os.ReadDir(postsDir)
+	if err == nil {
+		for _, entry := range entries {
+			if entry.IsDir() {
+				continue
+			}
+			name := entry.Name()
+			if pendingArticlePattern.MatchString(name) && !allow[name] {
+				violations = append(violations, GuardrailViolation{
+					Kind:   "pending-post",
+					Path:   filepath.ToSlash(filepath.Join("src", "content", "posts", name)),
+					Detail: "leftover pending article file",
+				})
+			}
+		}
+	} else if !os.IsNotExist(err) {
+		return nil, fmt.Errorf("observability: read posts dir: %w", err)
+	}
+
+	progressPath := filepath.Join(repoRoot, "scores", "tribunal-progress.json")
+	progressData, err := os.ReadFile(progressPath)
+	if err == nil {
+		var progress map[string]json.RawMessage
+		if unmarshalErr := json.Unmarshal(progressData, &progress); unmarshalErr != nil {
+			return nil, fmt.Errorf("observability: parse tribunal-progress.json: %w", unmarshalErr)
+		}
+		keys := make([]string, 0, len(progress))
+		for key := range progress {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			if pendingArticlePattern.MatchString(key) && !allow[key] {
+				violations = append(violations, GuardrailViolation{
+					Kind:   "pending-tribunal-progress",
+					Path:   filepath.ToSlash(filepath.Join("scores", "tribunal-progress.json")),
+					Detail: key,
+				})
+			}
+		}
+	} else if !os.IsNotExist(err) {
+		return nil, fmt.Errorf("observability: read tribunal-progress.json: %w", err)
+	}
+
+	return violations, nil
+}
+
+func RenameTribunalProgressEntry(repoRoot, oldKey, newKey string) error {
+	if repoRoot == "" || oldKey == "" || newKey == "" || oldKey == newKey {
+		return nil
+	}
+	progressPath := filepath.Join(repoRoot, "scores", "tribunal-progress.json")
+	data, err := os.ReadFile(progressPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("observability: read tribunal-progress.json: %w", err)
+	}
+	var progress map[string]json.RawMessage
+	if err := json.Unmarshal(data, &progress); err != nil {
+		return fmt.Errorf("observability: parse tribunal-progress.json: %w", err)
+	}
+	raw, ok := progress[oldKey]
+	if !ok {
+		return nil
+	}
+	var entry map[string]any
+	if err := json.Unmarshal(raw, &entry); err == nil {
+		entry["article"] = newKey
+		if patched, patchErr := json.Marshal(entry); patchErr == nil {
+			raw = patched
+		}
+	}
+	delete(progress, oldKey)
+	if _, exists := progress[newKey]; !exists {
+		progress[newKey] = raw
+	}
+	body, err := json.MarshalIndent(progress, "", "  ")
+	if err != nil {
+		return fmt.Errorf("observability: marshal tribunal-progress.json: %w", err)
+	}
+	body = append(body, '\n')
+	if err := os.WriteFile(progressPath, body, 0o644); err != nil {
+		return fmt.Errorf("observability: write tribunal-progress.json: %w", err)
+	}
+	return nil
+}
+
+func readStatusFile(path string) (*RunStatus, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var status RunStatus
+	if err := json.Unmarshal(data, &status); err != nil {
+		return nil, err
+	}
+	return &status, nil
+}
+
+func enrichStatus(cfg *config.Config, status *RunStatus, opts CollectOptions) error {
+	status.Artifacts = collectArtifacts(status.WorkDir)
+	if status.LastCompletedStep == "" || status.CurrentStep == "" {
+		inferStepsFromArtifacts(status)
+	}
+	inferRunState(status)
+
+	gitStatus, err := collectGit(status.RepoRoot)
+	if err == nil {
+		status.Git = gitStatus
+	} else {
+		return err
+	}
+
+	article := articleCandidate(status)
+	status.Tribunal = collectTribunal(status.RepoRoot, article)
+
+	violations, err := CheckPendingArtifacts(status.RepoRoot, GuardrailOptions{AllowPending: opts.AllowPending})
+	if err != nil {
+		return err
+	}
+	status.Guardrails = Guardrails{OK: len(violations) == 0, Violations: violations}
+	status.StaleWarning = buildStaleWarning(status, opts.StaleAfter)
+	status.Suspicious = buildSuspicious(status)
+	status.NextAction = deriveNextAction(status)
+	return nil
+}
+
+func collectArtifacts(workDir string) map[string]Artifact {
+	artifacts := make(map[string]Artifact, len(artifactFiles))
+	for key, name := range artifactFiles {
+		path := filepath.Join(workDir, name)
+		artifact := Artifact{Path: path}
+		if info, err := os.Stat(path); err == nil {
+			artifact.Exists = true
+			artifact.SizeBytes = info.Size()
+			artifact.ModifiedAt = info.ModTime().Format(time.RFC3339)
+		}
+		artifacts[key] = artifact
+	}
+	return artifacts
+}
+
+func collectGit(repoRoot string) (Git, error) {
+	if repoRoot == "" {
+		return Git{}, nil
+	}
+	changed := make(map[string]struct{})
+	for _, args := range [][]string{
+		{"-C", repoRoot, "diff", "--name-only"},
+		{"-C", repoRoot, "diff", "--cached", "--name-only"},
+		{"-C", repoRoot, "ls-files", "--others", "--exclude-standard"},
+	} {
+		res, err := runner.Run(context.Background(), "git", args...)
+		if err != nil {
+			return Git{}, fmt.Errorf("observability: git %s: %w", strings.Join(args[2:], " "), err)
+		}
+		for _, line := range strings.Split(string(res.Stdout), "\n") {
+			line = strings.TrimSpace(line)
+			if line == "" {
+				continue
+			}
+			changed[line] = struct{}{}
+		}
+	}
+	files := make([]string, 0, len(changed))
+	for path := range changed {
+		files = append(files, path)
+	}
+	sort.Strings(files)
+	return Git{Dirty: len(files) > 0, ChangedFiles: files}, nil
+}
+
+func collectTribunal(repoRoot, article string) Tribunal {
+	if repoRoot == "" || article == "" {
+		return Tribunal{}
+	}
+	path := filepath.Join(repoRoot, "scores", "tribunal-progress.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Tribunal{}
+	}
+	var progress map[string]tribunalProgressEntry
+	if err := json.Unmarshal(data, &progress); err != nil {
+		return Tribunal{}
+	}
+	entry, ok := progress[article]
+	if !ok {
+		return Tribunal{}
+	}
+	tribunal := Tribunal{
+		Article:    article,
+		Status:     entry.Status,
+		StartedAt:  entry.StartedAt,
+		FinishedAt: entry.FinishedAt,
+	}
+	for _, stageName := range tribunalStageOrder {
+		stage := entry.Stages[stageName]
+		if stage.Status == "in_progress" {
+			tribunal.Stage = stageName
+			tribunal.Status = stage.Status
+			tribunal.Attempts = stage.Attempts
+			tribunal.Summary = fmt.Sprintf("%s %s", stageName, stage.Status)
+			return tribunal
+		}
+	}
+	for _, want := range []string{"fail", "pass"} {
+		for _, stageName := range tribunalStageOrder {
+			stage := entry.Stages[stageName]
+			if stage.Status == want {
+				tribunal.Stage = stageName
+				tribunal.Status = stage.Status
+				tribunal.Attempts = stage.Attempts
+			}
+		}
+		if tribunal.Stage != "" {
+			break
+		}
+	}
+	if tribunal.Summary == "" && tribunal.Stage != "" && tribunal.Status != "" {
+		tribunal.Summary = fmt.Sprintf("%s %s", tribunal.Stage, tribunal.Status)
+	}
+	if tribunal.Summary == "" && tribunal.Status != "" {
+		tribunal.Summary = tribunal.Status
+	}
+	return tribunal
+}
+
+func inferStepsFromArtifacts(status *RunStatus) {
+	last := status.LastCompletedStep
+	if status.Artifacts["source"].Exists {
+		last = "fetch"
+	}
+	if status.Artifacts["evalPrimary"].Exists || status.Artifacts["evalSecondary"].Exists {
+		last = "eval"
+	}
+	if status.Artifacts["draft"].Exists {
+		last = "write"
+	}
+	if status.Artifacts["review"].Exists {
+		last = "review"
+	}
+	if status.Artifacts["final"].Exists {
+		last = "refine"
+	}
+	if status.Artifacts["tribunalStdout"].Exists || status.ActiveFilename != "" {
+		last = "ralph"
+	}
+	if status.Filename != "" {
+		last = "deploy"
+	}
+	if status.LastCompletedStep == "" {
+		status.LastCompletedStep = last
+	}
+	if status.CurrentStep == "" {
+		status.CurrentStep = last
+	}
+}
+
+func inferRunState(status *RunStatus) {
+	if status.RunState != "" {
+		return
+	}
+	switch {
+	case status.Error != "":
+		status.RunState = "failed"
+	case status.Filename != "" || status.ENFilename != "":
+		status.RunState = "completed"
+	case hasAnyArtifact(status.Artifacts) || status.CurrentStep != "":
+		status.RunState = "running"
+	default:
+		status.RunState = "unknown"
+	}
+}
+
+func hasAnyArtifact(artifacts map[string]Artifact) bool {
+	for _, artifact := range artifacts {
+		if artifact.Exists {
+			return true
+		}
+	}
+	return false
+}
+
+func buildStaleWarning(status *RunStatus, staleAfter time.Duration) string {
+	if staleAfter <= 0 || status.RunState != "running" {
+		return ""
+	}
+	last := latestActivityTime(status)
+	if last.IsZero() {
+		return ""
+	}
+	age := time.Since(last)
+	if age <= staleAfter {
+		return ""
+	}
+	return fmt.Sprintf("no status/artifact update for %s while %s is still running", humanDuration(age), nonEmpty(status.CurrentStep, "pipeline"))
+}
+
+func latestActivityTime(status *RunStatus) time.Time {
+	var latest time.Time
+	for _, value := range []string{status.UpdatedAt, status.Tribunal.FinishedAt, status.Tribunal.StartedAt} {
+		if t := parseRFC3339(value); t.After(latest) {
+			latest = t
+		}
+	}
+	for _, artifact := range status.Artifacts {
+		if t := parseRFC3339(artifact.ModifiedAt); t.After(latest) {
+			latest = t
+		}
+	}
+	return latest
+}
+
+func buildSuspicious(status *RunStatus) []string {
+	var issues []string
+	if status.StaleWarning != "" {
+		issues = append(issues, status.StaleWarning)
+	}
+	for _, missing := range missingArtifacts(status) {
+		issues = append(issues, missing)
+	}
+	for _, violation := range status.Guardrails.Violations {
+		issue := violation.Kind
+		if violation.Detail != "" {
+			issue += ": " + violation.Detail
+		} else {
+			issue += ": " + violation.Path
+		}
+		issues = append(issues, issue)
+	}
+	return issues
+}
+
+func missingArtifacts(status *RunStatus) []string {
+	var missing []string
+	rank := stepRank(maxStep(status.CurrentStep, status.LastCompletedStep))
+	if rank >= stepRank("write") && !status.Artifacts["source"].Exists {
+		missing = append(missing, "source-tweet.md missing after write-stage progress")
+	}
+	if rank >= stepRank("review") && !status.Artifacts["draft"].Exists {
+		missing = append(missing, "draft-v1.mdx missing after review-stage progress")
+	}
+	if rank >= stepRank("refine") && !status.Artifacts["review"].Exists {
+		missing = append(missing, "review.md missing after refine-stage progress")
+	}
+	if rank >= stepRank("ralph") && !status.Artifacts["final"].Exists && status.ActiveFilename == "" {
+		missing = append(missing, "final.mdx missing before tribunal/deploy")
+	}
+	if status.RunState == "completed" && status.Filename == "" {
+		missing = append(missing, "completed run is missing final filename metadata")
+	}
+	return missing
+}
+
+func deriveNextAction(status *RunStatus) string {
+	if len(status.Guardrails.Violations) > 0 {
+		return "clean leftover pending draft / tribunal progress artifacts before deploy or PR handoff"
+	}
+	if status.RunState == "running" {
+		return fmt.Sprintf("wait for %s to finish", nonEmpty(status.CurrentStep, "pipeline"))
+	}
+	if status.RunState == "failed" {
+		if status.CurrentStep != "" {
+			return fmt.Sprintf("inspect the %s failure, then resume with --from-step %s", status.CurrentStep, status.CurrentStep)
+		}
+		return "inspect the failure and resume from the last good step"
+	}
+	if status.RunState == "completed" {
+		return "open PR / wait for CI handoff"
+	}
+	next := nextStepFor(nonEmpty(status.LastCompletedStep, status.CurrentStep))
+	if next == "" {
+		return "run fetch"
+	}
+	return fmt.Sprintf("run %s", next)
+}
+
+func nextStepFor(step string) string {
+	switch step {
+	case "setup", "":
+		return "fetch"
+	case "fetch":
+		return "eval"
+	case "eval":
+		return "dedup"
+	case "dedup":
+		return "write"
+	case "write":
+		return "review"
+	case "review":
+		return "refine"
+	case "refine", "credits":
+		return "ralph"
+	case "ralph":
+		return "deploy"
+	default:
+		return ""
+	}
+}
+
+func allowPendingForSnapshot(status *RunStatus) []string {
+	if status.RunState != "running" {
+		return nil
+	}
+	if status.CurrentStep != "ralph" && status.CurrentStep != "deploy" {
+		return nil
+	}
+	var allow []string
+	for _, name := range []string{status.ActiveFilename, status.ActiveENFilename} {
+		if pendingArticlePattern.MatchString(name) {
+			allow = append(allow, name)
+		}
+	}
+	return allow
+}
+
+func articleCandidate(status *RunStatus) string {
+	for _, candidate := range []string{status.ActiveFilename, status.Filename} {
+		if candidate != "" {
+			return candidate
+		}
+	}
+	return ""
+}
+
+func stepRank(step string) int {
+	switch strings.ToLower(step) {
+	case "setup":
+		return 0
+	case "fetch":
+		return 1
+	case "eval":
+		return 2
+	case "dedup":
+		return 3
+	case "write":
+		return 4
+	case "review":
+		return 5
+	case "refine":
+		return 6
+	case "credits":
+		return 7
+	case "ralph":
+		return 8
+	case "deploy":
+		return 9
+	default:
+		return -1
+	}
+}
+
+func maxStep(a, b string) string {
+	if stepRank(a) >= stepRank(b) {
+		return a
+	}
+	return b
+}
+
+func humanDuration(d time.Duration) string {
+	if d < time.Minute {
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	}
+	if d < time.Hour {
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	}
+	if d < 24*time.Hour {
+		return fmt.Sprintf("%dh", int(d.Hours()))
+	}
+	return fmt.Sprintf("%dd", int(d.Hours()/24))
+}
+
+func parseRFC3339(value string) time.Time {
+	if value == "" {
+		return time.Time{}
+	}
+	t, _ := time.Parse(time.RFC3339, value)
+	return t
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func nonEmpty(value, fallback string) string {
+	if value != "" {
+		return value
+	}
+	return fallback
+}

--- a/tools/sp-pipeline/internal/observability/status_test.go
+++ b/tools/sp-pipeline/internal/observability/status_test.go
@@ -1,0 +1,204 @@
+package observability
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/chitienhsiehwork-ai/gu-log/tools/sp-pipeline/internal/config"
+)
+
+func makeStatusRepo(t *testing.T) (*config.Config, string) {
+	t.Helper()
+	root := t.TempDir()
+	mustMkdir(t, filepath.Join(root, "src", "content", "posts"))
+	mustMkdir(t, filepath.Join(root, "scores"))
+	mustWrite(t, filepath.Join(root, "CLAUDE.md"), "# fake\n")
+	mustWrite(t, filepath.Join(root, "WRITING_GUIDELINES.md"), "# style\n")
+	mustWrite(t, filepath.Join(root, "scripts", "article-counter.json"), `{}`)
+	mustWrite(t, filepath.Join(root, "scripts", "validate-posts.mjs"), "")
+	mustWrite(t, filepath.Join(root, "scripts", "fetch-x-article.sh"), "#!/usr/bin/env bash\n")
+	mustWrite(t, filepath.Join(root, "scores", "tribunal-progress.json"), "{}\n")
+	runGit(t, root, "init", "-q", "-b", "main")
+	runGit(t, root, "config", "user.email", "test@example.com")
+	runGit(t, root, "config", "user.name", "Test")
+	runGit(t, root, "add", ".")
+	runGit(t, root, "commit", "-q", "-m", "seed")
+	cfg, err := config.Resolve(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return cfg, root
+}
+
+func TestCheckPendingArtifacts_FindsPendingPostsAndProgress(t *testing.T) {
+	cfg, root := makeStatusRepo(t)
+	mustWrite(t, filepath.Join(root, "src", "content", "posts", "sp-pending-20260508-test.mdx"), "---\n---\n")
+	mustWrite(t, filepath.Join(root, "scores", "tribunal-progress.json"), `{
+  "sp-pending-20260508-test.mdx": {
+    "article": "sp-pending-20260508-test.mdx",
+    "stages": {}
+  }
+}
+`)
+
+	violations, err := CheckPendingArtifacts(cfg.RepoRoot, GuardrailOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(violations) != 2 {
+		t.Fatalf("violations = %d, want 2 (%+v)", len(violations), violations)
+	}
+}
+
+func TestCollect_AllowsCurrentPendingArtifactsWhileRalphRuns(t *testing.T) {
+	cfg, root := makeStatusRepo(t)
+	workDir := filepath.Join(root, "tmp", "sp-pending-obs")
+	mustMkdir(t, workDir)
+	mustWrite(t, filepath.Join(workDir, "final.mdx"), "body\n")
+	mustWrite(t, filepath.Join(root, "src", "content", "posts", "sp-pending-20260508-test.mdx"), "---\n---\n")
+	mustWrite(t, filepath.Join(root, "scores", "tribunal-progress.json"), `{
+  "sp-pending-20260508-test.mdx": {
+    "article": "sp-pending-20260508-test.mdx",
+    "startedAt": "2026-05-08T03:00:00+08:00",
+    "stages": {
+      "librarian": {"status": "in_progress", "attempts": 1}
+    }
+  }
+}
+`)
+
+	if err := WriteSnapshot(cfg, SnapshotInput{
+		WorkDir:        workDir,
+		RepoRoot:       cfg.RepoRoot,
+		RunState:       "running",
+		CurrentStep:    "ralph",
+		ActiveFilename: "sp-pending-20260508-test.mdx",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	status, err := Collect(cfg, workDir, CollectOptions{StaleAfter: time.Hour})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !status.Guardrails.OK {
+		t.Fatalf("guardrails should allow current pending artifacts during ralph: %+v", status.Guardrails.Violations)
+	}
+	if status.Tribunal.Stage != "librarian" || status.Tribunal.Status != "in_progress" {
+		t.Fatalf("tribunal = %+v, want librarian in_progress", status.Tribunal)
+	}
+}
+
+func TestCollect_FailedRunFlagsPendingArtifacts(t *testing.T) {
+	cfg, root := makeStatusRepo(t)
+	workDir := filepath.Join(root, "tmp", "sp-pending-obs")
+	mustMkdir(t, workDir)
+	mustWrite(t, filepath.Join(workDir, "final.mdx"), "body\n")
+	mustWrite(t, filepath.Join(root, "src", "content", "posts", "sp-pending-20260508-test.mdx"), "---\n---\n")
+	mustWrite(t, filepath.Join(root, "scores", "tribunal-progress.json"), `{
+  "sp-pending-20260508-test.mdx": {
+    "article": "sp-pending-20260508-test.mdx",
+    "stages": {}
+  }
+}
+`)
+
+	if err := WriteSnapshot(cfg, SnapshotInput{
+		WorkDir:        workDir,
+		RepoRoot:       cfg.RepoRoot,
+		RunState:       "failed",
+		CurrentStep:    "deploy",
+		ActiveFilename: "sp-pending-20260508-test.mdx",
+		Error:          "deploy blocked",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	status, err := Collect(cfg, workDir, CollectOptions{StaleAfter: time.Hour})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.Guardrails.OK {
+		t.Fatal("guardrails should fail once the run is no longer actively in ralph/deploy")
+	}
+	if len(status.Suspicious) == 0 {
+		t.Fatal("expected suspicious reasons for failed pending artifacts")
+	}
+	if !strings.Contains(status.NextAction, "clean leftover pending") {
+		t.Fatalf("NextAction = %q, want cleanup guidance", status.NextAction)
+	}
+}
+
+func TestRenameTribunalProgressEntry_RenamesPendingKey(t *testing.T) {
+	cfg, root := makeStatusRepo(t)
+	mustWrite(t, filepath.Join(root, "scores", "tribunal-progress.json"), `{
+  "sp-pending-20260508-test.mdx": {
+    "article": "sp-pending-20260508-test.mdx",
+    "status": "PASS",
+    "stages": {}
+  }
+}
+`)
+
+	if err := RenameTribunalProgressEntry(cfg.RepoRoot, "sp-pending-20260508-test.mdx", "sp-201-20260508-test.mdx"); err != nil {
+		t.Fatal(err)
+	}
+
+	raw, err := os.ReadFile(filepath.Join(root, "scores", "tribunal-progress.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var progress map[string]map[string]any
+	if err := json.Unmarshal(raw, &progress); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := progress["sp-pending-20260508-test.mdx"]; ok {
+		t.Fatal("old pending key still exists")
+	}
+	entry, ok := progress["sp-201-20260508-test.mdx"]
+	if !ok {
+		t.Fatal("new key missing after rename")
+	}
+	if entry["article"] != "sp-201-20260508-test.mdx" {
+		t.Fatalf("article field = %v, want renamed value", entry["article"])
+	}
+
+	violations, err := CheckPendingArtifacts(cfg.RepoRoot, GuardrailOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(violations) != 0 {
+		t.Fatalf("violations after rename = %+v, want none", violations)
+	}
+}
+
+func mustMkdir(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func mustWrite(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v failed: %v\n%s", args, err, out)
+	}
+}

--- a/tools/sp-pipeline/internal/pipeline/run.go
+++ b/tools/sp-pipeline/internal/pipeline/run.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"path/filepath"
 	"time"
+
+	"github.com/chitienhsiehwork-ai/gu-log/tools/sp-pipeline/internal/observability"
 )
 
 // SetupWorkDir populates s.WorkDir with an absolute path (creating the
@@ -59,6 +61,9 @@ func Run(ctx context.Context, s *State) error {
 		name string
 		fn   func(context.Context) error
 	}
+	if s.Cfg != nil {
+		writeSnapshotBestEffort(s, "setup", "", "running", "")
+	}
 	steps := []step{
 		{"fetch", s.Fetch},
 		{"eval", s.Eval},
@@ -70,17 +75,46 @@ func Run(ctx context.Context, s *State) error {
 		{"ralph", s.Ralph},
 		{"deploy", s.Deploy},
 	}
+	lastCompleted := ""
 	for _, st := range steps {
+		writeSnapshotBestEffort(s, st.name, lastCompleted, "running", "")
 		start := time.Now()
 		if err := st.fn(ctx); err != nil {
+			writeSnapshotBestEffort(s, st.name, lastCompleted, "failed", err.Error())
 			return err
 		}
 		if s.Timings == nil {
 			s.Timings = map[string]int{}
 		}
 		s.Timings[st.name] = int(time.Since(start).Seconds())
+		lastCompleted = st.name
+		writeSnapshotBestEffort(s, st.name, lastCompleted, "running", "")
 	}
+	writeSnapshotBestEffort(s, lastCompleted, lastCompleted, "completed", "")
 	return nil
+}
+
+func writeSnapshotBestEffort(s *State, currentStep, lastCompleted, runState, errText string) {
+	if s == nil || s.Cfg == nil || s.WorkDir == "" {
+		return
+	}
+	if err := observability.WriteSnapshot(s.Cfg, observability.SnapshotInput{
+		WorkDir:           s.WorkDir,
+		RepoRoot:          s.Cfg.RepoRoot,
+		Prefix:            s.Prefix,
+		TweetURL:          s.TweetURL,
+		TicketID:          s.PromptTicketID,
+		CurrentStep:       currentStep,
+		LastCompletedStep: lastCompleted,
+		RunState:          runState,
+		ActiveFilename:    s.ActiveFilename,
+		ActiveENFilename:  s.ActiveENFilename,
+		Filename:          s.Filename,
+		ENFilename:        s.ENFilename,
+		Error:             errText,
+	}); err != nil && s.Log != nil {
+		s.Log.Warn("observability snapshot failed: %v", err)
+	}
 }
 
 // PrintSummary writes a human-readable pipeline summary to w, matching

--- a/tools/sp-pipeline/internal/pipeline/run_test.go
+++ b/tools/sp-pipeline/internal/pipeline/run_test.go
@@ -200,6 +200,9 @@ func TestRun_HappyPath(t *testing.T) {
 	if !s.RalphPassed {
 		t.Errorf("RalphPassed should be true")
 	}
+	if _, err := os.Stat(filepath.Join(s.WorkDir, "pipeline-status.json")); err != nil {
+		t.Errorf("pipeline-status.json missing: %v", err)
+	}
 
 	// Summary output.
 	var buf bytes.Buffer


### PR DESCRIPTION
## Summary
- add pipeline-status.json snapshots plus a `sp-pipeline status` command for one-shot run inspection
- surface work-dir artifacts, tribunal stage, git diff, next action, stale warnings, and suspicious-state exit behavior
- guard deploy handoff by renaming pending tribunal progress entries and blocking leftover pending artifacts

## Testing
- ~/go/bin/go test ./...
- npm run validate:posts
- npm run build

Fixes #201