### PR TITLE
Track ShroomDog editorial feedback corpus

### DIFF
--- a/.claude/agents/tribunal-writer.md
+++ b/.claude/agents/tribunal-writer.md
@@ -24,6 +24,7 @@ You receive a FAILED tribunal judge report and rewrite the article to address th
 2. Read the judge report JSON provided in the task prompt
 3. Read `scripts/vibe-scoring-standard.md` — the scoring rubric and standards
 4. Read `WRITING_GUIDELINES.md` — writing style guide for gu-log
+5. Read `docs/shroomdog-editorial-feedback.md` — ShroomDog's concrete feedback corpus; apply relevant lessons to the rewrite
 
 ## How to Rewrite
 

--- a/.codex/agents/tribunal-writer.toml
+++ b/.codex/agents/tribunal-writer.toml
@@ -9,6 +9,10 @@ Use the legacy Claude Code contract as the detailed rewrite rubric, but ignore
 its YAML frontmatter runtime fields such as model and tools. Runtime is supplied
 by scripts/tribunal.sh through codex exec --model gpt-5.5.
 
+Before rewriting gu-log prose, read docs/shroomdog-editorial-feedback.md and
+apply relevant ShroomDog feedback lessons. If ShroomDog gives new editorial
+feedback during a task, append it there with feedback/context/fix/lesson.
+
 Only rewrite when scripts/tribunal.sh explicitly asks for a rewrite. Preserve
 frontmatter, source attribution, ClawdNote components, and already-passing
 dimensions. Do not perform broad style rewrites when targeted fixes are enough.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,8 @@
 
 **新增或編輯文章前，先讀 `CONTRIBUTING.md`。** 它是所有內容規則的 SSOT（Single Source of Truth）。
 
+**ShroomDog editorial feedback 一律進 corpus。** 如果 ShroomDog / Sprin 對 gu-log 文章提出用字、敘事、事實查核、語氣、讀者困惑點等回饋，立刻 append 到 `docs/shroomdog-editorial-feedback.md`。不要只存在聊天紀錄、個人 memory、未追蹤 scratch file，或某個 agent 的私人筆記。這份檔案是未來蒸餾 GPT-5.5 / Codex / Claude Code / Iris 寫作 prompt 的原始訓練資料。
+
 ### 🔍 事實查核紀律：AI tooling 的 claim 必須 verify
 
 gu-log 寫的就是 AI / agent / tooling 圈，這個圈子有兩個特性：
@@ -55,6 +57,7 @@ gu-log 寫的就是 AI / agent / tooling 圈，這個圈子有兩個特性：
 AGENTS.md (你在讀的這個)
   ├→ CONTRIBUTING.md          ← SSOT: 內容規則、ticketId SOP、防重複、frontmatter schema
   ├→ WRITING_GUIDELINES.md    ← SSOT: 寫作風格（PTT 說故事風、Clawd 吐槽語氣、SD/SP/CP 共用）
+  ├→ docs/shroomdog-editorial-feedback.md ← ShroomDog 修稿回饋 corpus（未來 prompt calibration）
   ├→ src/content/config.ts    ← SSOT: Frontmatter schema (Zod validation)
   ├→ scripts/
   │   ├ article-counter.json  ← Ticket ID counter（SD/SP/CP/Lv）

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,6 +150,8 @@ Pipeline 包辦：fetch → eval → dedup → write → review → refine → c
 
 **新增或編輯文章前，先讀 `CONTRIBUTING.md`。** 它是所有內容規則的 SSOT（Single Source of Truth）。
 
+**ShroomDog editorial feedback 一律進 corpus。** 如果 ShroomDog / Sprin 對 gu-log 文章提出用字、敘事、事實查核、語氣、讀者困惑點等回饋，立刻 append 到 `docs/shroomdog-editorial-feedback.md`。不要只存在聊天紀錄、個人 memory、未追蹤 scratch file，或某個 agent 的私人筆記。這份檔案是未來蒸餾 GPT-5.5 / Codex / Claude Code / Iris 寫作 prompt 的原始訓練資料。
+
 ### 🔍 事實查核紀律：AI tooling 的 claim 必須 verify
 
 gu-log 寫的就是 AI / agent / tooling 圈，這個圈子有兩個特性：
@@ -177,6 +179,7 @@ gu-log 寫的就是 AI / agent / tooling 圈，這個圈子有兩個特性：
 CLAUDE.md (你在讀的這個)
   ├→ CONTRIBUTING.md          ← SSOT: 內容規則、ticketId SOP、防重複、frontmatter schema
   ├→ WRITING_GUIDELINES.md    ← SSOT: 寫作風格（PTT 說故事風、Clawd 吐槽語氣、SD/SP/CP 共用）
+  ├→ docs/shroomdog-editorial-feedback.md ← ShroomDog 修稿回饋 corpus（未來 prompt calibration）
   ├→ src/content/config.ts    ← SSOT: Frontmatter schema (Zod validation)
   ├→ scripts/
   │   ├ article-counter.json  ← Ticket ID counter（SD/SP/CP/Lv）

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,7 @@
 
 > 這份文件定義新增文章的 conventions，給 Clawd 和其他 contributors 參考。
 > 完整寫作風格見 `WRITING_GUIDELINES.md`（SSOT）。
+> ShroomDog 修稿回饋 corpus 見 `docs/shroomdog-editorial-feedback.md`。
 
 ## Package manager policy
 

--- a/WRITING_GUIDELINES.md
+++ b/WRITING_GUIDELINES.md
@@ -1,5 +1,14 @@
 # gu-log Content Creation Guide
 
+## 🧬 ShroomDog Feedback Corpus
+
+寫作規則不是只靠抽象 style guide 長出來的。ShroomDog 每次修稿回饋都是 gu-log 的真實 calibration data。
+
+- Feedback corpus：`docs/shroomdog-editorial-feedback.md`
+- 寫 SP / CP / SD / Lv 前，如果任務涉及文章品質、語氣、用字或事實查核，先快速掃近期條目。
+- ShroomDog / Sprin 給出新的 editorial feedback 時，立刻 append：原始回饋、情境、修法、可重用 lesson。
+- 同一類 lesson 重複出現 3 次以上，就升級成這份 `WRITING_GUIDELINES.md` 的正式規則，或進 pipeline prompt。
+
 ## 🎭 Core Persona: 李宏毅教授風格 (LHY Style)
 
 **你是誰**：一個對 AI/Tech 充滿熱情的教授，用最接地氣的方式解釋複雜概念。

--- a/docs/shroomdog-editorial-feedback.md
+++ b/docs/shroomdog-editorial-feedback.md
@@ -1,0 +1,44 @@
+# ShroomDog Editorial Feedback Corpus
+
+這份檔案是 gu-log 的「feedback corpus」：ShroomDog / Sprin 對文章、標題、用字、事實查核、敘事節奏、讀者困惑點的所有回饋，都先原樣收進來。
+
+目的不是做漂亮文件，而是累積真實修稿資料。等樣本夠多，再把這些例子濃縮成 GPT-5.5 / Codex / Claude Code / Iris 都能用的 gu-log 寫作 prompt calibration。
+
+## 使用規則
+
+- ShroomDog 對 gu-log 給出任何 editorial feedback，就立刻 append 到這份檔案。
+- 每筆至少記四件事：原始回饋、文章/情境、實際修法、可重用 lesson。
+- 不要只寫「語氣再自然一點」這種抽象話；要保留具體 bad example / good example。
+- 這是 repo-tracked source of truth。不要把新的 gu-log 寫作回饋只記在聊天紀錄、個人 memory、未追蹤檔案或單一 agent 的私人筆記裡。
+- 寫 SP / CP / SD / Lv 前，如果任務涉及文章品質或風格，先快速掃這份檔案的近期條目。
+- 當同一類 feedback 出現 3 次以上，應該升級到 `WRITING_GUIDELINES.md` 或 pipeline prompt，而不是永遠只留在這裡。
+
+## 2026-05-08 — SP-192 Codex Goals
+
+### Feedback: weird prompt delimiter 要 fact-check，也要解釋
+
+- ShroomDog feedback：`為啥是 xml tag of不可信的目標內容, fact check it, seems weird, or we need at least an explanation for the weird tag`
+- 情境：SP-192 把 Codex Goals prompt excerpt 裡的 `<untrusted_objective>` 翻成了假的中文 XML tag：`<不可信的目標內容>`。
+- 修法：查 OpenAI Codex source：`codex-rs/core/templates/goals/continuation.md`。保留 literal `<untrusted_objective>`，補回 source 裡的 `user-provided data` warning，並加一段解釋：這是 prompt-injection safety boundary，不是有特殊 XML 語意的 tag。
+- Reusable lesson：不要把 code / prompt harness / delimiter 翻成假的中文 identifier。保留原始技術 artifact，再用讀者能懂的方式解釋它為什麼長得怪。
+
+### Feedback: `補件` 語感不對
+
+- ShroomDog feedback：`補件？補丁？`
+- 情境：SP-192 用 `補件一 / 二 / 三` 描述 Jarrod 對 long-running agent workflow 加上的三個 safeguards。
+- 修法：改成 `補強一 / 二 / 三`。沒有用 `補丁`，因為 `補丁` 太像 software patch；`補件` 在台灣語感又太像行政文件補交。
+- Reusable lesson：不要只看字面意思，要看台灣讀者的語感。描述 missing safeguards / structural support 時，`補強` 比 `補件` 或 `補丁` 自然。
+
+### Meta-feedback: ShroomDog feedback 要累積成 prompt calibration
+
+- ShroomDog feedback：`For every feedback from me, ShroomDog, u shall note down each feedback at some place, maybe git untracked, then one day we need to summarize them into prompt for 5.5, to write good gu-log posts.`
+- 情境：文章修稿回饋如果只留在 Telegram thread 或單一 Clawd memory，其他 agent 吃不到，未來也很難蒸餾成 prompt。
+- 修法：先建立 feedback corpus，記錄 feedback / fix / lesson。
+- Reusable lesson：ShroomDog 每次 correction 都是 gu-log 風格訓練資料。不要只修當下那篇，要把 pattern 留下來。
+
+### Meta-feedback: feedback corpus 應該由 gu-log repo 追蹤，不能只放在單一 agent memory
+
+- ShroomDog feedback：`So where is the feedback corpse? How do u make sure all ai agents, clawd, iris, mac-cdx/cc will do this? Maybe we need to make it git tracked by gu-log, on my second thought`
+- 情境：第一版 log 放在 `/home/clawd/clawd/memory/gu-log-shroomdog-feedback.md`，這只保證 OpenClaw Clawd 看得到，不保證 Iris、mac-CC、Codex、Claude Code、pipeline writer 都會讀。
+- 修法：把 corpus 移到 gu-log repo tracked file：`docs/shroomdog-editorial-feedback.md`，並在 repo-level instructions / writing guide / Clawd Picks prompt 裡加入口規則。
+- Reusable lesson：跨 agent 行為不能靠某個 agent 的私人記憶。要放在 repo-tracked SSOT，並從所有常用 agent entrypoint 指向它。

--- a/scripts/clawd-picks-prompt.md
+++ b/scripts/clawd-picks-prompt.md
@@ -6,7 +6,8 @@
 
 1. 讀 `CONTRIBUTING.md` — **必讀**，定義 frontmatter schema、ticketId 規則、防重複 SOP、ClawdNote 用法
 2. 讀 `WRITING_GUIDELINES.md` — 翻譯 persona 和風格（李宏毅教授風、PTT 說故事風）
-3. 讀 `scripts/clawd-picks-config.json` — 帳號清單和篩選設定
+3. 讀 `docs/shroomdog-editorial-feedback.md` — ShroomDog 修稿回饋 corpus；有新的 ShroomDog feedback 要 append 回這裡
+4. 讀 `scripts/clawd-picks-config.json` — 帳號清單和篩選設定
 
 ## Step 2：搜尋推文
 

--- a/tools/sp-pipeline/internal/prompts/refine.tmpl
+++ b/tools/sp-pipeline/internal/prompts/refine.tmpl
@@ -7,6 +7,7 @@ Inputs:
 Task:
 - Produce a corrected final article.
 - Keep style-guide compliance.
+- Apply relevant lessons from `docs/shroomdog-editorial-feedback.md`.
 - Ensure frontmatter values remain accurate.
 {{if .Angle}}
 NARRATIVE ANGLE:

--- a/tools/sp-pipeline/internal/prompts/review.tmpl
+++ b/tools/sp-pipeline/internal/prompts/review.tmpl
@@ -3,17 +3,18 @@ Review draft-v1.mdx for {{.TicketID}}.
 Checklist:
 1. Fact-check: no hallucinated claims beyond source context.
 2. Style alignment: matches WRITING_GUIDELINES.md requirements.
-3. Frontmatter accuracy: ticketId/source/sourceUrl/dates/tags format.
-4. ClawdNote usage and kaomoji requirements.
-5. Clear actionable fixes.
-6. Certainty Preservation: source hedging language (seems, might, I think) must not be upgraded to definitive statements.
-7. Number Integrity: every number in translation must trace back to source. No invented statistics/revenue/percentages.
-8. Constraint Coverage: source limitations, caveats, and conditions must be preserved.
-9. Ending Fidelity: conclusion must not introduce claims beyond source material.
-10. Summary length: must be ≤300 characters.
-11. Coverage Completeness: no key source claim/example/caveat is omitted.
-12. Attribution Preservation: speculative opinions remain explicitly attributed to source author.
-13. Terminology Checkpoint: flag awkward literal calques in zh-tw (e.g. research-paper Chinese). For canonical industry terms, recommend keeping the English term + glossary link; for ordinary words, recommend natural zh-tw. Treat unclear long-term vocabulary choices as terminology decisions, not mere wording nits.
+3. ShroomDog feedback alignment: apply relevant lessons from docs/shroomdog-editorial-feedback.md.
+4. Frontmatter accuracy: ticketId/source/sourceUrl/dates/tags format.
+5. ClawdNote usage and kaomoji requirements.
+6. Clear actionable fixes.
+7. Certainty Preservation: source hedging language (seems, might, I think) must not be upgraded to definitive statements.
+8. Number Integrity: every number in translation must trace back to source. No invented statistics/revenue/percentages.
+9. Constraint Coverage: source limitations, caveats, and conditions must be preserved.
+10. Ending Fidelity: conclusion must not introduce claims beyond source material.
+11. Summary length: must be ≤300 characters.
+12. Coverage Completeness: no key source claim/example/caveat is omitted.
+13. Attribution Preservation: speculative opinions remain explicitly attributed to source author.
+14. Terminology Checkpoint: flag awkward literal calques in zh-tw (e.g. research-paper Chinese). For canonical industry terms, recommend keeping the English term + glossary link; for ordinary words, recommend natural zh-tw. Treat unclear long-term vocabulary choices as terminology decisions, not mere wording nits.
 
 Severity: label each issue Blocker/Major/Minor.
 Patch: each issue must include exact source quote + proposed replacement text.

--- a/tools/sp-pipeline/internal/prompts/write.tmpl
+++ b/tools/sp-pipeline/internal/prompts/write.tmpl
@@ -14,6 +14,7 @@ Task:
 - If you see "⚠️ INCOMPLETE THREAD", acknowledge what's missing and note it for the reader. Do NOT pad partial content into a full article.
 - NEVER pad or filler. If a section says "there are other patterns" but you don't have the details, either skip that claim or explicitly say the details weren't available. Do NOT write vague paragraphs that say nothing.
 - Follow the style guide exactly.
+- Read `docs/shroomdog-editorial-feedback.md` before drafting and apply relevant ShroomDog feedback lessons.
 - Use this metadata:
   - ticketId: {{.TicketID}}
   - originalDate: {{.OriginalDate}}


### PR DESCRIPTION
Adds a repo-tracked feedback corpus for ShroomDog/Sprin editorial feedback and wires common agent entrypoints to it.\n\nWhy:\n- A Clawd-private memory file does not reach Iris, mac-CC, Codex, Claude Code, or pipeline writers.\n- Feedback should be gu-log repo state so every agent can learn from the same SSOT.\n\nWhat changed:\n- Add docs/shroomdog-editorial-feedback.md with the SP-192 feedback examples and meta-rule.\n- Point AGENTS.md, CLAUDE.md, CONTRIBUTING.md, WRITING_GUIDELINES.md, Clawd Picks prompt, tribunal writer agents, and SP pipeline prompts to the corpus.\n\nValidation:\n- pnpm run validate:posts\n- pnpm run build