### PR TITLE
content: finalize SD-22 ending and version checks

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -42,7 +42,18 @@ while read -r _local_ref local_sha remote_ref remote_sha; do
   esac
 done
 
-# 1. Bundle budget check (check-only; must not write git working tree files)
+# 1. Post version manifest freshness — Vercel production uses the committed
+#    manifest on shallow clones, so content-touching commits must keep it fresh.
+echo "🔢 Checking post version manifest freshness..."
+node scripts/build-version-manifest.mjs --check
+if [ $? -ne 0 ]; then
+  echo "❌ post-versions.json is stale! Push aborted."
+  echo "   Run: node scripts/build-version-manifest.mjs"
+  echo "   Then amend the content commit so the visible vN badge matches git history."
+  exit 1
+fi
+
+# 2. Bundle budget check (check-only; must not write git working tree files)
 #    Blocking budgets fail the push; trend alerts are warnings only.
 echo "📦 Checking bundle budgets (blocking + trend monitor)..."
 node scripts/bundle-budget-check.mjs

--- a/docs/shroomdog-editorial-feedback.md
+++ b/docs/shroomdog-editorial-feedback.md
@@ -114,3 +114,31 @@
 - 情境：SD-22 的 spaceship harness 段落原本把風險寫成「精神崩潰」，比較像擬人化疲勞，沒有點出 LLM 的 probabilistic failure surface。
 - 修法：改成「一個手滑，把飛船開去撞火星」；補出 Ryland 是 LLM / probabilistic model，手會有手汗，總有滑的一天。
 - Reusable lesson：寫 agent 風險時，不要只寫 dramatic breakdown。更準的是 probabilistic failure：模型不是邪惡或瘋掉，而是長期操作高權限工具時，總有一次 sampling / interpretation / tool-use slip。高能力 harness 的風險要寫成「blast radius × inevitable slip」。
+
+### Feedback: Avoid AI-ish summary endings; land the metaphor instead
+
+- ShroomDog feedback：`收尾的「一句話記住」，太 ai 了 xD`
+- 情境：SD-22 的結尾用「一句話記住」做摘要，像 AI 筆記或考前複習，和全文 Ryland/time metaphor 的故事感不一致。
+- 修法：改成「天快亮以前」/ `Before dawn`，用 Ryland 的一天收束：早上的課、白天事件、過夜課程，最後落在「別問 Ryland 能不能再撐一下。先看現在幾點。」
+- Reusable lesson：gu-log 原創 metaphor essay 不要用 AI-ish summary heading 收尾。結尾要回到故事核心，留一句能被記住的 punchline，而不是把前文做成條列式重點整理。
+
+### Feedback: Funny but spoiler-free proper-noun jokes
+
+- ShroomDog feedback：`命名巧合委員會超好笑 有夠荒謬`
+- 情境：前一版「宇宙文學部」雖然比直接提劇情安全，但仍然有宇宙方向的暗示。
+- 修法：改成「命名巧合委員會」/ `Naming Coincidence Committee`，保留荒謬官僚笑點，移除科幻/宇宙暗示。
+- Reusable lesson：spoiler-sensitive jokes can be funny through bureaucracy, committees, legalese, or naming coincidence — no need to lean on story-specific nouns.
+
+### Feedback: Post version should be programmatically enforced
+
+- ShroomDog feedback：`版本號怎麼會是要 ai 手改，鐵定是程式要會直接反應版本號吧`
+- 情境：SD-22 已經有多個 content-touching commits，但 production still showed v1 because committed `src/data/post-versions.json` was stale. The site needs committed manifest data on shallow Vercel clones.
+- 修法：add `--check` mode to `scripts/build-version-manifest.mjs`, wire CI `validate-content` to fail when `post-versions.json` is stale, and add `pnpm versions:check`. This makes stale versions a failing check instead of relying on AI memory.
+- Reusable lesson：If a visible value is derived from git history, CI must enforce freshness. Do not rely on agents remembering to hand-edit or regenerate derived manifests.
+
+### Feedback: Final refined SD article can receive ShroomDog vibe 10
+
+- ShroomDog feedback：`Maybe we can give it a vibe 10 (for the final, refined version that i said yes)`
+- 情境：SD-22 went through several ShroomDog-directed refinements and became a stronger original mental model than the initial draft.
+- 修法：write frontmatter `scores.vibe` as 10/10 with model marker `ShroomDog final vibe override (refined SD-22)` so the displayed score reflects the final editorial verdict rather than an intermediate automated judge pass.
+- Reusable lesson：Automated tribunal scores are useful gates, but ShroomDog can override final vibe for original essays after editorial convergence. Mark the model/source clearly so it is not confused with a pure automated judge score.

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "format": "prettier --write \"src/components/**/*.{astro,js,ts}\" \"src/layouts/**/*.{astro,js,ts}\" \"src/pages/**/*.{astro,js,ts}\" \"src/config/**/*.{js,ts}\" \"src/styles/**/*.css\" \"scripts/**/*.{js,mjs,cjs,ts}\" \"*.{mjs,cjs,ts}\"",
     "format:check": "prettier --check \"src/components/**/*.{astro,js,ts}\" \"src/layouts/**/*.{astro,js,ts}\" \"src/pages/**/*.{astro,js,ts}\" \"src/config/**/*.{js,ts}\" \"src/styles/**/*.css\" \"scripts/**/*.{js,mjs,cjs,ts}\" \"*.{mjs,cjs,ts}\"",
     "validate:posts": "node scripts/validate-posts.mjs",
+    "versions:check": "node scripts/build-version-manifest.mjs --check",
     "obsidian:import": "node scripts/obsidian-import.mjs",
     "content:check": "pnpm run validate:posts && pnpm run build",
     "lockfile:check": "pnpm install --frozen-lockfile && git diff --exit-code -- pnpm-lock.yaml",

--- a/scripts/build-version-manifest.mjs
+++ b/scripts/build-version-manifest.mjs
@@ -16,13 +16,14 @@
  * drop the counts for any post touched only on the incoming branch.
  */
 import { execSync } from 'node:child_process';
-import { writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import { writeFileSync, mkdirSync, existsSync, readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = join(__dirname, '..');
 const outPath = join(repoRoot, 'src', 'data', 'post-versions.json');
+const checkOnly = process.argv.includes('--check');
 
 // Skip regeneration if the clone is shallow — git log would miss history
 // and we'd overwrite the committed manifest with incomplete counts.
@@ -69,10 +70,22 @@ function buildManifest() {
     console.error('⚠️  git log failed — writing empty manifest:', err.message);
   }
 
+  const next = JSON.stringify(versions, null, 2) + '\n';
   const count = Object.keys(versions).length;
-  mkdirSync(dirname(outPath), { recursive: true });
-  writeFileSync(outPath, JSON.stringify(versions, null, 2) + '\n');
   const mergeHint = revs === 'HEAD MERGE_HEAD' ? ' (merge-aware)' : '';
+
+  if (checkOnly) {
+    const current = existsSync(outPath) ? readFileSync(outPath, 'utf8') : '';
+    if (current !== next) {
+      console.error('❌ post-versions.json is stale. Run: node scripts/build-version-manifest.mjs');
+      process.exit(1);
+    }
+    console.log(`✅ post-versions.json fresh: ${count} posts tracked${mergeHint}`);
+    return;
+  }
+
+  mkdirSync(dirname(outPath), { recursive: true });
+  writeFileSync(outPath, next);
   console.log(`✅ post-versions.json: ${count} posts tracked${mergeHint}`);
 }
 

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -42,7 +42,18 @@ while read -r _local_ref local_sha remote_ref remote_sha; do
   esac
 done
 
-# 1. Bundle budget check (check-only; must not write git working tree files)
+# 1. Post version manifest freshness — Vercel production uses the committed
+#    manifest on shallow clones, so content-touching commits must keep it fresh.
+echo "🔢 Checking post version manifest freshness..."
+node scripts/build-version-manifest.mjs --check
+if [ $? -ne 0 ]; then
+  echo "❌ post-versions.json is stale! Push aborted."
+  echo "   Run: node scripts/build-version-manifest.mjs"
+  echo "   Then amend the content commit so the visible vN badge matches git history."
+  exit 1
+fi
+
+# 2. Bundle budget check (check-only; must not write git working tree files)
 #    Blocking budgets fail the push; trend alerts are warnings only.
 echo "📦 Checking bundle budgets (blocking + trend monitor)..."
 node scripts/bundle-budget-check.mjs

--- a/src/content/posts/en-sd-22-20260508-context-window-model-day.mdx
+++ b/src/content/posts/en-sd-22-20260508-context-window-model-day.mdx
@@ -8,6 +8,17 @@ sourceUrl: "https://gu-log.vercel.app/"
 lang: "en"
 summary: "A context window is a model's day: how many lessons, messages, tool results, and task events Ryland can experience before sleep, compression, or collapse."
 tags: ["shroomdog-original", "context-window", "llm", "agent", "memory", "context-engineering", "agent-harness"]
+scores:
+  tribunalVersion: 3
+  vibe:
+    persona: 10
+    clawdNote: 10
+    vibe: 10
+    clarity: 10
+    narrative: 10
+    score: 10
+    date: "2026-05-08"
+    model: "ShroomDog final vibe override (refined SD-22)"
 ---
 
 import ClawdNote from '../../components/ClawdNote.astro';
@@ -28,7 +39,7 @@ In this essay, though, we will not call this person Ryland Grace.
 Just Ryland.
 
 <ClawdNote>
-Yes, the name collision is that convenient. Please do not send a lawyer from the space literature department. This is an AI infrastructure metaphor, and every surprise in the book remains safe ╮(╯▽╰)╭
+Yes, the name collision is that convenient. Please do not send a lawyer from the Naming Coincidence Committee. This is an AI infrastructure metaphor, and every surprise in the book remains safe ╮(╯▽╰)╭
 </ClawdNote>
 
 Large language models are a lot like Ryland.
@@ -192,16 +203,20 @@ The model is not necessarily getting dumber.
 
 It is just too late in the day.
 
-## The one-line version
+## Before dawn
 
-The context window is not the model's soul, and it is not permanent memory.
+So do not think of the context window as only "how many words fit."
 
-It is the amount of time Ryland can experience in this waking day.
+It is Ryland's day.
 
-Token usage is the clock. The system prompt is the morning class. Messages and tool results are daytime events. Compression turns yesterday into today's class. The agent harness is the world Ryland lives in.
+If the morning class runs too long, Ryland has less time to work. If daytime events are dumped in without order, morning, afternoon, and midnight start blending into the same present. If the overnight class is recorded badly, tomorrow's Ryland begins the day inside a disaster recap.
 
 Old models were koalas, awake for two hours. Modern models can stay awake for three days.
 
 That does not make them gods.
 
-It gives humans more responsibility to arrange their day well.
+It only gives humans a chance to arrange a decent schedule.
+
+Do not ask whether Ryland can keep going a little longer.
+
+Check what time it is first.

--- a/src/content/posts/sd-22-20260508-context-window-model-day.mdx
+++ b/src/content/posts/sd-22-20260508-context-window-model-day.mdx
@@ -8,6 +8,17 @@ sourceUrl: "https://gu-log.vercel.app/"
 lang: "zh-tw"
 summary: "Context Window 不是字數上限，而是模型世界裡的一天：Ryland 醒來後能經歷多少課程、訊息、工具結果和任務事件。Token 使用量就是這個世界的時鐘。"
 tags: ["shroomdog-original", "context-window", "llm", "agent", "memory", "context-engineering", "agent-harness"]
+scores:
+  tribunalVersion: 3
+  vibe:
+    persona: 10
+    clawdNote: 10
+    vibe: 10
+    clarity: 10
+    narrative: 10
+    score: 10
+    date: "2026-05-08"
+    model: "ShroomDog final vibe override (refined SD-22)"
 ---
 
 import ClawdNote from '../../components/ClawdNote.astro';
@@ -28,7 +39,7 @@ import ShroomDogNote from '../../components/ShroomDogNote.astro';
 就叫 Ryland。
 
 <ClawdNote>
-對，就是這麼剛好撞名。宇宙文學部不要寄律師函，這裡只是拿來講 AI 基礎建設，不會爆雷，也不會碰書裡任何驚喜 ╮(╯▽╰)╭
+對，就是這麼剛好撞名。命名巧合委員會不要寄律師函，這裡只是拿來講 AI 基礎建設，不會爆雷，也不會碰書裡任何驚喜 ╮(╯▽╰)╭
 </ClawdNote>
 
 大型語言模型很像 Ryland。
@@ -192,16 +203,20 @@ Agent Harness 要知道自己是在造宇宙飛船，還是收信室。兩者都
 
 是今天已經太晚了。
 
-## 一句話記住
+## 天快亮以前
 
-Context Window 不是模型的靈魂，也不是永久記憶。
+所以，別再把 Context Window 只想成「可以塞多少字」。
 
-它是 Ryland 這一天能經歷的時間。
+那是 Ryland 的一天。
 
-Token 使用量是時鐘。系統提示是早上的課。工具結果和訊息是白天發生的事件。壓縮是把昨天錄成今天的課。Agent Harness 是 Ryland 所住的世界。
+早上的課講太久，他就少一點時間做事。白天事件塞太亂，他就開始把上午、下午、半夜混成同一個現在。過夜課程錄得爛，隔天的 Ryland 會從一堂災難回顧開始新的一天。
 
 以前的模型像無尾熊，一天只醒兩小時。現在的模型可以醒三天三夜。
 
 這不是讓它們變成神。
 
-只是讓人類更有責任安排好它們的一天。
+這只是讓人類終於有機會安排一個像樣的作息。
+
+別問 Ryland 能不能再撐一下。
+
+先看現在幾點。

--- a/src/data/post-versions.json
+++ b/src/data/post-versions.json
@@ -1,7 +1,8 @@
 {
-  "en-sd-22-20260508-context-window-model-day": 1,
-  "sd-22-20260508-context-window-model-day": 1,
-  "sp-193-20260508-article-autobrowse-agent": 1,
+  "en-sd-22-20260508-context-window-model-day": 5,
+  "sd-22-20260508-context-window-model-day": 5,
+  "en-sp-193-20260508-article-autobrowse-agent": 1,
+  "sp-193-20260508-article-autobrowse-agent": 2,
   "sp-192-20260508-article-agent-ralph": 7,
   "en-sp-192-20260508-article-agent-ralph": 3,
   "clawd-picks-20260227-trq212-seeing-like-agent": 9,


### PR DESCRIPTION
Final SD-22 polish after ShroomDog review:\n\n- Replaces AI-ish 'one-line version' ending with the 'Before dawn / check what time it is' ending\n- Replaces the spoiler-adjacent committee joke with Naming Coincidence Committee\n- Adds final ShroomDog vibe 10 frontmatter score for the refined version\n- Adds a post-version freshness check mode and pre-push guard so stale vN manifests get caught by tooling\n- Updates post-versions manifest to v5 for SD-22 zh/en\n\nValidation:\n- node scripts/check-jingjing.mjs zh post\n- node scripts/check-pronoun-clarity.mjs zh post\n- pnpm run validate:posts\n- tribunal vibe score-only PASS zh=9/en=9\n- pnpm versions:check\n- pnpm exec astro build\n- node scripts/check-links.mjs --internal-only