### PR TITLE
content: adjust SD-22 final vibe score

### DIFF
--- a/docs/shroomdog-editorial-feedback.md
+++ b/docs/shroomdog-editorial-feedback.md
@@ -136,9 +136,9 @@
 - 修法：add `--check` mode to `scripts/build-version-manifest.mjs`, wire CI `validate-content` to fail when `post-versions.json` is stale, and add `pnpm versions:check`. This makes stale versions a failing check instead of relying on AI memory.
 - Reusable lesson：If a visible value is derived from git history, CI must enforce freshness. Do not rely on agents remembering to hand-edit or regenerate derived manifests.
 
-### Feedback: Final refined SD article can receive ShroomDog vibe 10
+### Feedback: Reserve vibe 10 for truly ceiling-level pieces
 
-- ShroomDog feedback：`Maybe we can give it a vibe 10 (for the final, refined version that i said yes)`
-- 情境：SD-22 went through several ShroomDog-directed refinements and became a stronger original mental model than the initial draft.
-- 修法：write frontmatter `scores.vibe` as 10/10 with model marker `ShroomDog final vibe override (refined SD-22)` so the displayed score reflects the final editorial verdict rather than an intermediate automated judge pass.
-- Reusable lesson：Automated tribunal scores are useful gates, but ShroomDog can override final vibe for original essays after editorial convergence. Mark the model/source clearly so it is not confused with a pure automated judge score.
+- ShroomDog feedback：`Maybe we can give it a vibe 10 (for the final, refined version that i said yes)` → later adjusted to `還是回到9好了，感覺差10還是差了一點，總是能再更好一點`
+- 情境：SD-22 went through several ShroomDog-directed refinements and became a stronger original mental model than the initial draft, but 10/10 felt too absolute after reflection.
+- 修法：write frontmatter `scores.vibe` as 9/10 with model marker `ShroomDog final vibe adjustment (refined SD-22)` so the displayed score reflects the final editorial verdict while preserving room above it.
+- Reusable lesson：Automated tribunal scores are useful gates, but ShroomDog can override final vibe for original essays after editorial convergence. Keep 10/10 rare; if the piece still feels like it can obviously get better, 9 is the more honest score.

--- a/src/content/posts/en-sd-22-20260508-context-window-model-day.mdx
+++ b/src/content/posts/en-sd-22-20260508-context-window-model-day.mdx
@@ -11,14 +11,14 @@ tags: ["shroomdog-original", "context-window", "llm", "agent", "memory", "contex
 scores:
   tribunalVersion: 3
   vibe:
-    persona: 10
-    clawdNote: 10
-    vibe: 10
-    clarity: 10
-    narrative: 10
-    score: 10
+    persona: 9
+    clawdNote: 9
+    vibe: 9
+    clarity: 9
+    narrative: 9
+    score: 9
     date: "2026-05-08"
-    model: "ShroomDog final vibe override (refined SD-22)"
+    model: "ShroomDog final vibe adjustment (refined SD-22)"
 ---
 
 import ClawdNote from '../../components/ClawdNote.astro';

--- a/src/content/posts/sd-22-20260508-context-window-model-day.mdx
+++ b/src/content/posts/sd-22-20260508-context-window-model-day.mdx
@@ -11,14 +11,14 @@ tags: ["shroomdog-original", "context-window", "llm", "agent", "memory", "contex
 scores:
   tribunalVersion: 3
   vibe:
-    persona: 10
-    clawdNote: 10
-    vibe: 10
-    clarity: 10
-    narrative: 10
-    score: 10
+    persona: 9
+    clawdNote: 9
+    vibe: 9
+    clarity: 9
+    narrative: 9
+    score: 9
     date: "2026-05-08"
-    model: "ShroomDog final vibe override (refined SD-22)"
+    model: "ShroomDog final vibe adjustment (refined SD-22)"
 ---
 
 import ClawdNote from '../../components/ClawdNote.astro';

--- a/src/data/post-versions.json
+++ b/src/data/post-versions.json
@@ -1,6 +1,6 @@
 {
-  "en-sd-22-20260508-context-window-model-day": 5,
-  "sd-22-20260508-context-window-model-day": 5,
+  "en-sd-22-20260508-context-window-model-day": 6,
+  "sd-22-20260508-context-window-model-day": 6,
   "en-sp-193-20260508-article-autobrowse-agent": 1,
   "sp-193-20260508-article-autobrowse-agent": 2,
   "sp-192-20260508-article-agent-ralph": 7,


### PR DESCRIPTION
Adjust SD-22 final visible vibe score from 10/10 back to 9/10 after ShroomDog review.\n\nAlso regenerates post-versions so this score-adjustment commit bumps the article version to v6.\n\nValidation:\n- pnpm versions:check\n- pnpm run validate:posts\n- pnpm exec astro build