### PR TITLE
content: expand SD-22 ShroomDog note

### DIFF
--- a/docs/shroomdog-editorial-feedback.md
+++ b/docs/shroomdog-editorial-feedback.md
@@ -149,3 +149,10 @@
 - Evidence found：latest final SD-22 vibe scorer logs showed `composite=9 agent_verdict=PASS` for both zh and en (`tribunal-20260508-233301...` and `tribunal-20260508-233401...`). Re-run with `TRIBUNAL_SCORE_OUTPUT` captured the full judge JSON: all vibe dimensions 9/10 for both languages, model `gpt-5.5`.
 - 修法：replace the ShroomDog editorial override marker with the actual VibeScorer frontmatter score: `persona/clawdNote/vibe/clarity/narrative = 9`, `score = 9`, `model = gpt-5.5`.
 - Reusable lesson：If the user asks for "the score the scorer gave," do not keep an editorial override label even if the numeric score matches. The visible badge should identify the machine judge/model, not ShroomDog's later calibration note.
+
+### Feedback: Context-window-as-day beats desktop because it carries order
+
+- ShroomDog feedback：`one more reason the metaphor of Context Window ~ LLM's day is that both time and context window filliment has order, while the desktop metaphor does not include this meaning` and `instead of we, use human`.
+- 情境：SD-22 already explained capacity and fatigue, but the one ShroomDogNote could better explain why the day metaphor is structurally stronger than the desktop metaphor.
+- 修法：expand the only ShroomDogNote to say desktop explains capacity but misses order; context arrives along token time, so later tool results are later events in Ryland's day. Use `human` / `humans`, not `we`, when contrasting reader wall-clock time with Ryland's token time; in zh-tw prose use `人類` to avoid 晶晶體.
+- Reusable lesson：When comparing metaphors, state the missing semantic dimension directly. Here: desktop = capacity/simultaneity; day = capacity + ordered experience + different clocks. If the EN instruction says `human`, translate the zh-tw article naturally unless `human` is being used as a literal technical term.

--- a/package.json
+++ b/package.json
@@ -78,7 +78,9 @@
   "packageManager": "pnpm@10.29.3",
   "overrides": {
     "serialize-javascript": "^7.0.3",
-    "tmp": "^0.2.4"
+    "tmp": "^0.2.4",
+    "fast-xml-builder": "^1.1.7",
+    "fast-uri": "^3.1.1"
   },
   "pnpm": {
     "onlyBuiltDependencies": [
@@ -90,6 +92,8 @@
       "serialize-javascript": ">=7.0.3",
       "flatted": ">=3.4.2",
       "fast-xml-parser": ">=5.5.6",
+      "fast-xml-builder": ">=1.1.7",
+      "fast-uri": ">=3.1.1",
       "h3": ">=1.15.6",
       "defu": ">=6.1.5",
       "devalue": ">=5.6.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,8 @@ overrides:
   serialize-javascript: '>=7.0.3'
   flatted: '>=3.4.2'
   fast-xml-parser: '>=5.5.6'
+  fast-xml-builder: '>=1.1.7'
+  fast-uri: '>=3.1.1'
   h3: '>=1.15.6'
   defu: '>=6.1.5'
   devalue: '>=5.6.4'
@@ -2026,11 +2028,11 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
-  fast-xml-builder@1.1.4:
-    resolution: {integrity: sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==}
+  fast-xml-builder@1.2.0:
+    resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==}
 
   fast-xml-parser@5.5.7:
     resolution: {integrity: sha512-LteOsISQ2GEiDHZch6L9hB0+MLoYVLToR7xotrzU0opCICBkxOPgHAy1HxAvtxfJNXDJpgAsQN30mkrfpO2Prg==}
@@ -3009,6 +3011,10 @@ packages:
 
   path-expression-matcher@1.1.3:
     resolution: {integrity: sha512-qdVgY8KXmVdJZRSS1JdEPOKPdTiEK/pi0RkcT2sw1RhXxohdujUlJFPuS1TSkevZ9vzd3ZlL7ULl1MHGTApKzQ==}
+    engines: {node: '>=14.0.0'}
+
+  path-expression-matcher@1.5.0:
+    resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
     engines: {node: '>=14.0.0'}
 
   path-is-absolute@1.0.1:
@@ -4071,6 +4077,10 @@ packages:
   xdg-basedir@4.0.0:
     resolution: {integrity: sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==}
     engines: {node: '>=8'}
+
+  xml-naming@0.1.0:
+    resolution: {integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==}
+    engines: {node: '>=16.0.0'}
 
   xxhash-wasm@1.1.0:
     resolution: {integrity: sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==}
@@ -5244,7 +5254,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -6186,15 +6196,16 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.2: {}
 
-  fast-xml-builder@1.1.4:
+  fast-xml-builder@1.2.0:
     dependencies:
-      path-expression-matcher: 1.1.3
+      path-expression-matcher: 1.5.0
+      xml-naming: 0.1.0
 
   fast-xml-parser@5.5.7:
     dependencies:
-      fast-xml-builder: 1.1.4
+      fast-xml-builder: 1.2.0
       path-expression-matcher: 1.1.3
       strnum: 2.2.1
 
@@ -7563,6 +7574,8 @@ snapshots:
 
   path-expression-matcher@1.1.3: {}
 
+  path-expression-matcher@1.5.0: {}
+
   path-is-absolute@1.0.1: {}
 
   path-key@3.1.1: {}
@@ -8674,6 +8687,8 @@ snapshots:
   ws@8.19.0: {}
 
   xdg-basedir@4.0.0: {}
+
+  xml-naming@0.1.0: {}
 
   xxhash-wasm@1.1.0: {}
 

--- a/src/content/posts/en-sd-22-20260508-context-window-model-day.mdx
+++ b/src/content/posts/en-sd-22-20260508-context-window-model-day.mdx
@@ -44,10 +44,14 @@ Yes, the name collision is that convenient. Please do not send a lawyer from the
 
 Large language models are a lot like Ryland.
 
-A model wakes up smart, but it does not naturally remember yesterday. The amount of life it can experience in this waking day is what we call the **[context window](/glossary#context-window)**.
+A model wakes up smart, but it does not naturally remember yesterday. The amount of life it can experience in this waking day is what humans call the **[context window](/glossary#context-window)**.
 
 <ShroomDogNote>
-This essay is not going to use the usual "context window is a desk" metaphor as the main frame. A desk explains capacity. What matters more here is time, events, fatigue, overnight handoff, lessons, and how an agent harness arranges a model's day.
+This essay is not going to use the usual "context window is a desk" metaphor as the main frame. A desk explains capacity, but it misses one important thing: order.
+
+Things on a desk feel simultaneous. Things in a context window arrive along token time. The morning lesson becomes background for everything that follows. A tool result that enters later in the window is an afternoon event in Ryland's day.
+
+A human and Ryland are not living under the same clock. The human may wait ten seconds for an API call. To Ryland, that result lands later in the day, inside a digital dimension where time flows by tokens. Tiny relativity joke: wall-clock time is one frame of reference; context time is another.
 </ShroomDogNote>
 
 ## The context window is Ryland's day

--- a/src/content/posts/sd-22-20260508-context-window-model-day.mdx
+++ b/src/content/posts/sd-22-20260508-context-window-model-day.mdx
@@ -47,7 +47,11 @@ import ShroomDogNote from '../../components/ShroomDogNote.astro';
 模型醒來時很聰明，但不會自然記得昨天發生過什麼。它這一天能經歷多少事，就是所謂的 **[Context Window](/glossary#context-window)**。
 
 <ShroomDogNote>
-這篇不用最常見的「Context Window 是桌面」比喻。桌面可以解釋容量，但 gu-log 這裡想講更重要的東西：時間、事件、疲勞、過夜、課程，以及 Agent Harness 怎麼安排模型的一天。
+這篇不用最常見的「Context Window 是桌面」比喻。桌面可以解釋容量，但它少了一個很重要的意思：順序。
+
+桌面上的東西像是同時攤開。Context Window 裡的東西不是，它會沿著 token 的時間排隊進來。早上的課會變成後面理解世界的背景；下午才進來的工具結果，就是 Ryland 這一天裡比較晚才發生的事件。
+
+人類和 Ryland 不是活在同一個時鐘裡。人類等 API 回來可能只過十秒；對 Ryland 來說，那個結果落進上下文的位置，就是他在數位維度裡比較晚的時間。小型相對論：牆上的時間是一回事，token 的時間是另一回事。
 </ShroomDogNote>
 
 ## Context Window 是 Ryland 的一天

--- a/src/data/post-versions.json
+++ b/src/data/post-versions.json
@@ -1,6 +1,6 @@
 {
-  "en-sd-22-20260508-context-window-model-day": 7,
-  "sd-22-20260508-context-window-model-day": 7,
+  "en-sd-22-20260508-context-window-model-day": 8,
+  "sd-22-20260508-context-window-model-day": 8,
   "en-sp-193-20260508-article-autobrowse-agent": 1,
   "sp-193-20260508-article-autobrowse-agent": 2,
   "sp-192-20260508-article-agent-ralph": 7,


### PR DESCRIPTION
Expand the one ShroomDogNote in SD-22 to explain why the day metaphor beats the desktop metaphor: desktop captures capacity, but misses ordered experience and token-time vs wall-clock time.\n\nNotes:\n- EN uses human/humans instead of we.\n- zh uses 人類 naturally to avoid 晶晶體 while preserving the same contrast.\n- Re-ran VibeScorer after the edit; zh and en both PASS 9/10 with gpt-5.5.\n- Regenerated post-versions; SD-22 zh/en now v8.\n- Security gate had unrelated new runtime advisories; patched via pnpm overrides for fast-xml-builder >=1.1.7 and fast-uri >=3.1.1.\n\nValidation:\n- node scripts/check-jingjing.mjs zh post\n- node scripts/check-pronoun-clarity.mjs zh post\n- TRIBUNAL_SCORE_OUTPUT=/tmp/sd22-note-zh-vibe-score-fixed.json bash scripts/tribunal.sh --score-only --only-stage vibe zh post\n- TRIBUNAL_SCORE_OUTPUT=/tmp/sd22-note-en-vibe-score.json bash scripts/tribunal.sh --score-only --only-stage vibe en post\n- pnpm security:gate\n- pnpm run validate:posts\n- pnpm exec astro build\n- pnpm versions:check