### PR TITLE
content: soften SD-22 spoiler aside

### DIFF
--- a/docs/shroomdog-editorial-feedback.md
+++ b/docs/shroomdog-editorial-feedback.md
@@ -156,3 +156,10 @@
 - 情境：SD-22 already explained capacity and fatigue, but the one ShroomDogNote could better explain why the day metaphor is structurally stronger than the desktop metaphor.
 - 修法：expand the only ShroomDogNote to say desktop explains capacity but misses order; context arrives along token time, so later tool results are later events in Ryland's day. Use `human` / `humans`, not `we`, when contrasting reader wall-clock time with Ryland's token time; in zh-tw prose use `人類` to avoid 晶晶體.
 - Reusable lesson：When comparing metaphors, state the missing semantic dimension directly. Here: desktop = capacity/simultaneity; day = capacity + ordered experience + different clocks. If the EN instruction says `human`, translate the zh-tw article naturally unless `human` is being used as a literal technical term.
+
+### Feedback: Spoiler disclaimers should sound human, not legalistic
+
+- ShroomDog feedback：`這不是什麼大雷，基本上就是第一章的核心設定。` felt unnatural; suggested `希望沒有暴雷，這只是第一章的內容嗚嗚`.
+- 情境：SD-22 references the opening setup of *Project Hail Mary*. The original disclaimer sounded like an explanatory legal note rather than ShroomDog's voice.
+- 修法：change the zh line to `希望沒有暴雷，這只是第一章的內容嗚嗚。`; mirror the EN tone as `Please do not count this as a spoiler. It is only first-chapter material, sob.`
+- Reusable lesson：When spoiler-sensitive gu-log notes are low-stakes, prefer a slightly sheepish human aside over stiff wording like `not a real spoiler` / `core setup`.

--- a/src/content/posts/en-sd-22-20260508-context-window-model-day.mdx
+++ b/src/content/posts/en-sd-22-20260508-context-window-model-day.mdx
@@ -32,7 +32,7 @@ But Ryland has a disease: **every morning, they wake up with no personal memory.
 
 They do not know what happened yesterday. They do not know which task they were working on last round. They do not know what stupid mistake they made yesterday. Unless someone teaches them what matters after they wake up, the day starts from zero.
 
-If you have read Andy Weir's *Project Hail Mary*, this should feel familiar. Ryland Grace wakes up with a lot of scientific knowledge, but has to reconstruct the mission from clues. This is not a real spoiler; it is basically the first chapter setup.
+If you have read Andy Weir's *Project Hail Mary*, this should feel familiar. Ryland Grace wakes up with a lot of scientific knowledge, but has to reconstruct the mission from clues. Please do not count this as a spoiler. It is only first-chapter material, sob.
 
 In this essay, though, we will not call this person Ryland Grace.
 

--- a/src/content/posts/sd-22-20260508-context-window-model-day.mdx
+++ b/src/content/posts/sd-22-20260508-context-window-model-day.mdx
@@ -32,7 +32,7 @@ import ShroomDogNote from '../../components/ShroomDogNote.astro';
 
 他不知道昨天聊過什麼，不知道自己上一輪做過哪個任務，也不知道昨天到底犯過什麼蠢。除非有人在他醒來後，把今天需要知道的東西教給他。
 
-如果讀過 Andy Weir 的《Project Hail Mary》，這個畫面應該很熟。Ryland Grace 一醒來，腦袋裡有大量學科知識，卻得靠眼前線索慢慢拼回任務。這不是什麼大雷，基本上就是第一章的核心設定。
+如果讀過 Andy Weir 的《Project Hail Mary》，這個畫面應該很熟。Ryland Grace 一醒來，腦袋裡有大量學科知識，卻得靠眼前線索慢慢拼回任務。希望沒有暴雷，這只是第一章的內容嗚嗚。
 
 這篇文章裡，先不叫他 Ryland Grace。
 

--- a/src/data/post-versions.json
+++ b/src/data/post-versions.json
@@ -1,6 +1,6 @@
 {
-  "en-sd-22-20260508-context-window-model-day": 8,
-  "sd-22-20260508-context-window-model-day": 8,
+  "en-sd-22-20260508-context-window-model-day": 9,
+  "sd-22-20260508-context-window-model-day": 9,
   "en-sp-193-20260508-article-autobrowse-agent": 1,
   "sp-193-20260508-article-autobrowse-agent": 2,
   "sp-192-20260508-article-agent-ralph": 7,


### PR DESCRIPTION
Small SD-22 wording polish after ShroomDog review.\n\n- Softens the Project Hail Mary spoiler disclaimer in zh/en\n- Updates ShroomDog editorial feedback corpus\n- Regenerates post version manifest; SD-22 zh/en now v9\n\nNo tribunal per ShroomDog instruction.\n\nValidation:\n- node scripts/check-jingjing.mjs zh post\n- pnpm run validate:posts\n- pnpm exec astro build\n- pnpm versions:check