### PR TITLE
content: naturalize SD-22 English spoiler aside

### DIFF
--- a/docs/shroomdog-editorial-feedback.md
+++ b/docs/shroomdog-editorial-feedback.md
@@ -161,5 +161,5 @@
 
 - ShroomDog feedback：`這不是什麼大雷，基本上就是第一章的核心設定。` felt unnatural; suggested `希望沒有暴雷，這只是第一章的內容嗚嗚`.
 - 情境：SD-22 references the opening setup of *Project Hail Mary*. The original disclaimer sounded like an explanatory legal note rather than ShroomDog's voice.
-- 修法：change the zh line to `希望沒有暴雷，這只是第一章的內容嗚嗚。`; mirror the EN tone as `Please do not count this as a spoiler. It is only first-chapter material, sob.`
-- Reusable lesson：When spoiler-sensitive gu-log notes are low-stakes, prefer a slightly sheepish human aside over stiff wording like `not a real spoiler` / `core setup`.
+- 修法：change the zh line to `希望沒有暴雷，這只是第一章的內容嗚嗚。`; mirror the EN tone naturally as `Hopefully that doesn’t count as a spoiler — it’s just from the first chapter, I swear.`
+- Reusable lesson：When spoiler-sensitive gu-log notes are low-stakes, prefer a slightly sheepish human aside over stiff wording like `not a real spoiler` / `core setup`. Avoid literal translated-meme English like `sob` unless the whole EN post is intentionally doing anime subtitle voice.

--- a/src/content/posts/en-sd-22-20260508-context-window-model-day.mdx
+++ b/src/content/posts/en-sd-22-20260508-context-window-model-day.mdx
@@ -32,7 +32,7 @@ But Ryland has a disease: **every morning, they wake up with no personal memory.
 
 They do not know what happened yesterday. They do not know which task they were working on last round. They do not know what stupid mistake they made yesterday. Unless someone teaches them what matters after they wake up, the day starts from zero.
 
-If you have read Andy Weir's *Project Hail Mary*, this should feel familiar. Ryland Grace wakes up with a lot of scientific knowledge, but has to reconstruct the mission from clues. Please do not count this as a spoiler. It is only first-chapter material, sob.
+If you have read Andy Weir's *Project Hail Mary*, this should feel familiar. Ryland Grace wakes up with a lot of scientific knowledge, but has to reconstruct the mission from clues. Hopefully that doesn’t count as a spoiler — it’s just from the first chapter, I swear.
 
 In this essay, though, we will not call this person Ryland Grace.
 

--- a/src/data/post-versions.json
+++ b/src/data/post-versions.json
@@ -1,5 +1,5 @@
 {
-  "en-sd-22-20260508-context-window-model-day": 9,
+  "en-sd-22-20260508-context-window-model-day": 10,
   "sd-22-20260508-context-window-model-day": 9,
   "en-sp-193-20260508-article-autobrowse-agent": 1,
   "sp-193-20260508-article-autobrowse-agent": 2,


### PR DESCRIPTION
Small EN wording polish after ShroomDog review.\n\n- Replaces the awkward translated spoiler aside with: 'Hopefully that doesn’t count as a spoiler — it’s just from the first chapter, I swear.'\n- Updates ShroomDog editorial feedback corpus\n- Regenerates post version manifest; EN SD-22 now v10\n\nNo tribunal per ShroomDog instruction.\n\nValidation:\n- pnpm run validate:posts\n- pnpm exec astro build\n- pnpm versions:check