### PR TITLE
Fix SP-194 artifact title line height

### DIFF
--- a/src/pages/artifacts/sp-194-html-loop.astro
+++ b/src/pages/artifacts/sp-194-html-loop.astro
@@ -401,7 +401,8 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
     max-width: 760px;
     margin: 0;
     font-size: clamp(1.7rem, 5.8vw, 4rem);
-    line-height: 1.04;
+    line-height: 1.18;
+    letter-spacing: -0.025em;
   }
 
   .hero-copy {
@@ -912,7 +913,8 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
     .hero-card h1 {
       font-size: clamp(1.3rem, 5.9vw, 1.56rem);
       max-width: 100%;
-      line-height: 1.02;
+      line-height: 1.24;
+      letter-spacing: -0.015em;
     }
 
     .hero-copy {


### PR DESCRIPTION
Fixes the mobile zh-tw title line-height on the SP-194 artifact.\n\nValidation:\n- npm run build\n- pnpm exec astro check\n- pnpm run lint\n- pnpm run bundle:check\n- node scripts/check-contrast.mjs\n- Playwright mobile screenshot inspected; computed title line-height is 28.75px at 23.19px font size.