### PR TITLE
Use Noto Sans TC for SP-194 artifact headings

### DIFF
--- a/src/pages/artifacts/sp-194-html-loop.astro
+++ b/src/pages/artifacts/sp-194-html-loop.astro
@@ -282,7 +282,7 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
 </BaseLayout>
 
 <style is:inline>
-  @import url('https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,600;9..144,750&family=Noto+Sans+TC:wght@400;500;700;800&display=swap');
+  @import url('https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@400;500;700;800&display=swap');
 
   .artifact-page {
     --cream: #fff4dc;
@@ -392,7 +392,7 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
   .easter-card h2,
   .example-section h2,
   .panel-heading h2 {
-    font-family: 'Fraunces', 'Noto Sans TC', serif;
+    font-family: 'Noto Sans TC', sans-serif;
     color: var(--ink);
     letter-spacing: -0.04em;
   }


### PR DESCRIPTION
Switches the SP-194 artifact headings from mixed Fraunces + Noto Sans TC to Noto Sans TC all the way, so English and zh-tw glyphs feel visually coherent.\n\nValidation:\n- npm run build\n- pnpm exec astro check\n- pnpm run lint\n- pnpm run bundle:check\n- node scripts/check-contrast.mjs\n- Playwright mobile check: title computed font-family is Noto Sans TC.