### PR TITLE
Restore before-after order in SP-194 artifact

### DIFF
--- a/src/pages/artifacts/sp-194-html-loop.astro
+++ b/src/pages/artifacts/sp-194-html-loop.astro
@@ -950,10 +950,6 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
       font-size: 0.84rem;
     }
 
-    .surface-card {
-      order: -1;
-    }
-
     .markdown-wall,
     .surface-card,
     .packet-card,


### PR DESCRIPTION
Restores the mobile display order so the SP-194 artifact shows Before / 文字牆 before After / 控制面板.\n\nValidation:\n- npm run build\n- pnpm exec astro check\n- pnpm run lint\n- pnpm run bundle:check\n- node scripts/check-contrast.mjs\n- Playwright mobile order check: markdown-wall appears before surface-card.