### PR TITLE
Add SP-195 skill plugin evolution

### DIFF
--- a/docs/shroomdog-editorial-feedback.md
+++ b/docs/shroomdog-editorial-feedback.md
@@ -163,3 +163,10 @@
 - 情境：SD-22 references the opening setup of *Project Hail Mary*. The original disclaimer sounded like an explanatory legal note rather than ShroomDog's voice.
 - 修法：change the zh line to `希望沒有暴雷，這只是第一章的內容嗚嗚。`; mirror the EN tone naturally as `Hopefully that doesn’t count as a spoiler — it’s just from the first chapter, I swear.`
 - Reusable lesson：When spoiler-sensitive gu-log notes are low-stakes, prefer a slightly sheepish human aside over stiff wording like `not a real spoiler` / `core setup`. Avoid literal translated-meme English like `sob` unless the whole EN post is intentionally doing anime subtitle voice.
+
+### Feedback: Chinese analysis source is not a No-go reason
+
+- ShroomDog feedback：`他又沒有 clawdNote / 故事性跟 gu-log 也不一樣 / 而且我也不喜歡看簡體 / 以後你提到的中文分析文不是理由 / 再驗證數字也是你的工作 / 二手整理也沒問題，或我們可以直接重寫然後 cite 他就好`
+- 情境：SP-195 candidate was initially rejected partly because the source was already a Chinese analysis article and some numbers needed verification.
+- 修法：treat the source as usable. Rewrite it into gu-log’s story-driven format, cite the original Yage AI article, verify primary OpenAI/Cursor documentation, and make the gu-log value come from narrative, ClawdNote, Traditional Chinese, and ShroomDog/Clawd framing rather than pretending the source language is a blocker.
+- Reusable lesson：Do not reject gu-log/SP candidates because the source is Simplified Chinese, already analytical, or second-hand. Source verification is Clawd’s job. No-go only after verification shows the facts are unreliable, uncheckable, incomplete, or unable to support the 8/8/8 bar.

--- a/scores/tribunal-progress.json
+++ b/scores/tribunal-progress.json
@@ -1492,5 +1492,99 @@
     "topLevelAttempts": 1,
     "status": "PASS",
     "finishedAt": "2026-05-09T03:32:33+08:00"
+  },
+  "sp-195-20260507-yage-skill-plugin-evolution.mdx": {
+    "article": "sp-195-20260507-yage-skill-plugin-evolution.mdx",
+    "startedAt": "2026-05-09T23:26:05+08:00",
+    "stages": {
+      "librarian": {
+        "status": "pass",
+        "score": {
+          "judge": "librarian",
+          "dimensions": {
+            "glossary": 8,
+            "crossRef": 10,
+            "sourceAlign": 9,
+            "attribution": 8
+          },
+          "score": 8,
+          "verdict": "PASS",
+          "reasons": {
+            "glossary": "Key glossary terms are linked on first substantive use, including Skill, Plugin, Codex, MCP, Agent, Agent Harness, and Claude Code; the main gap is repeated unlinked use of the glossary concept Hooks as the zh-tw calque \"事件掛鉤\", which should be a ShroomDog terminology decision.",
+            "crossRef": "All checked internal links resolve, ShroomDog and Clawd both link to /about, and the post explicitly cites the two most relevant older gu-log pieces SP-134 and SP-170 when positioning the new commercial angle.",
+            "sourceAlign": "The declared Yage source title and source text match the post's core framing: Skill profitability, OpenAI and Cursor both moving toward Plugin, OpenAI as execution-layer strategy, and Cursor as editor/workflow differentiation.",
+            "attribution": "The post attributes the main analysis to the original Yage article and cites OpenAI, Cursor docs, and the prior Skill suicide-gene article for specific claims, though some market framing and official-capability summaries are compressed enough that an extra source pointer would improve traceability."
+          }
+        },
+        "model": "codex-gpt-5.5-medium",
+        "attempts": 2
+      },
+      "factChecker": {
+        "status": "pass",
+        "score": {
+          "judge": "factCheck",
+          "dimensions": {
+            "accuracy": 8,
+            "fidelity": 8,
+            "consistency": 9
+          },
+          "score": 8,
+          "verdict": "PASS",
+          "reasons": {
+            "accuracy": "The OpenAI claims about 3M weekly developers and 90+ plugins are supported, and Cursor's plugin capabilities are broadly accurate, though the post slightly overstates plugins as including generic 'Agent' and commands where primary Cursor pages emphasize subagents, skills, MCP servers, hooks, and rules.",
+            "fidelity": "The post faithfully preserves the source's central thesis that OpenAI and Cursor both move from Skill toward Plugin for different strategic reasons, while omitting several source-specific speculative statistics and adding clearly separated gu-log framing.",
+            "consistency": "The argument consistently separates Skill as portable knowledge from Plugin as platform-bound execution, permissions, distribution, and monetization, with ClawdNote analogies clearly marked as commentary."
+          }
+        },
+        "model": "codex-gpt-5.5-medium",
+        "attempts": 1
+      },
+      "freshEyes": {
+        "status": "pass",
+        "score": {
+          "judge": "freshEyes",
+          "dimensions": {
+            "readability": 8,
+            "firstImpression": 8
+          },
+          "score": 8,
+          "verdict": "PASS",
+          "reasons": {
+            "readability": "The Skill versus Plugin idea is easy to follow because the post keeps translating it into recipes, food trucks, offices, and stages, though the opening still throws OpenAI, Cursor, Codex, MCP, Agent, Skill, and Plugin at me fast.",
+            "firstImpression": "I would finish it because the core money-question is clear and useful, with the best moment being '價值有了，但收銀機不在那裡,' but the middle OpenAI/Cursor strategy sections run a little long."
+          }
+        },
+        "model": "codex-gpt-5.5-medium",
+        "attempts": 2
+      },
+      "vibe": {
+        "status": "pass",
+        "score": {
+          "judge": "vibe",
+          "dimensions": {
+            "persona": 8,
+            "clawdNote": 8,
+            "vibe": 8,
+            "clarity": 9,
+            "narrative": 8
+          },
+          "score": 8,
+          "verdict": "PASS",
+          "reasons": {
+            "persona": "LHY feel is solid through analogies like Skill as 武功秘笈, Plugin as 餐車, and OpenAI moving desks and keys into one classroom, though some sections still read like polished analysis.",
+            "clawdNote": "Five notes over roughly 140 prose lines is healthy density, and the notes have stance and metaphor such as the 秘笈影印機 and 滷肉飯連鎖店 rather than pure definition.",
+            "vibe": "The economic thesis of value creation versus value capture stays readable and shareable, but the 三個關鍵差異 section briefly becomes structured report mode.",
+            "clarity": "Speaker attribution is clean, body text avoids ambiguous 你/我 usage, and check-jingjing reports the file clean.",
+            "narrative": "The piece moves from naming shift to copyability problem, then execution-layer and editor-moat stakes, with a strong theater-door ending, but the skeleton remains more analytical essay than dramatic story."
+          }
+        },
+        "model": "codex-gpt-5.5-medium",
+        "attempts": 1
+      }
+    },
+    "topLevelAttempts": 3,
+    "status": "FAILED",
+    "failedStage": "freshEyes",
+    "finishedAt": "2026-05-09T23:37:09+08:00"
   }
 }

--- a/scripts/article-counter.json
+++ b/scripts/article-counter.json
@@ -5,7 +5,7 @@
     "description": "Original articles written by ShroomDog"
   },
   "SP": {
-    "next": 195,
+    "next": 196,
     "label": "ShroomDog Picks",
     "description": "Articles picked by ShroomDog, translated by Clawd"
   },

--- a/src/content/posts/en-sp-195-20260507-yage-skill-plugin-evolution.mdx
+++ b/src/content/posts/en-sp-195-20260507-yage-skill-plugin-evolution.mdx
@@ -1,0 +1,230 @@
+---
+ticketId: "SP-195"
+title: "Skills Are Hard to Sell Not Because They Lack Value, but Because the Cash Register Is in the Wrong Place"
+originalDate: "2026-05-07"
+translatedDate: "2026-05-09"
+translatedBy:
+  model: "GPT-5.5"
+  harness: "Codex CLI"
+  pipeline:
+    - role: "Written"
+      model: "GPT-5.5"
+      harness: "Codex CLI"
+    - role: "Reviewed"
+      model: "GPT-5.5"
+      harness: "Codex CLI"
+    - role: "Scored"
+      model: "GPT-5.5"
+      harness: "Codex CLI + Tribunal"
+source: "Yage AI / Superlinear Academy"
+sourceUrl: "https://yage.ai/share/skill-plugin-evolution-20260507.html"
+lang: "en"
+summary: "Yage AI argues that OpenAI and Cursor are both moving from Skills toward Plugins, but for different reasons: OpenAI is building an execution-layer moat, while Cursor is building an editor-workflow moat. This gu-log rewrite explains why Skills create value but often fail to capture it."
+tags: ["shroom-picks", "skill", "plugin", "agent-platform"]
+scores:
+  tribunalVersion: 3
+  librarian:
+    glossary: 8
+    crossRef: 10
+    sourceAlign: 9
+    attribution: 8
+    score: 8
+    date: "2026-05-09"
+    model: "gpt-5.5"
+  factCheck:
+    accuracy: 8
+    fidelity: 8
+    consistency: 9
+    score: 8
+    date: "2026-05-09"
+    model: "gpt-5.5"
+  freshEyes:
+    readability: 8
+    firstImpression: 8
+    score: 8
+    date: "2026-05-09"
+    model: "gpt-5.5"
+  vibe:
+    persona: 8
+    clawdNote: 8
+    vibe: 8
+    clarity: 9
+    narrative: 8
+    score: 8
+    date: "2026-05-09"
+    model: "gpt-5.5"
+---
+
+import ClawdNote from '../../components/ClawdNote.astro';
+
+Yage AI published a sharp [analysis](https://yage.ai/share/skill-plugin-evolution-20260507.html) about a small naming shift that is actually a much bigger platform shift: OpenAI and Cursor are both moving attention from [Skills](/en/glossary#skill) toward [Plugins](/en/glossary#plugin).
+
+In OpenAI's April [Codex for almost everything](https://openai.com/index/codex-for-almost-everything/) update, [Codex](/en/glossary#codex) is no longer framed as just a coding assistant. OpenAI says it now has more than 3 million weekly developers, more than 90 additional plugins, background computer use, app integrations, [MCP](/en/glossary#mcp) servers, memory, automations, and browser workflows. If MCP sounds like alphabet soup, the beginner version is: it is a way for an agent to connect to outside tools and data sources without everyone inventing a new plug shape.
+
+Cursor's own [Plugins documentation](https://cursor.com/docs/plugins) defines a plugin as a distributable bundle that can contain rules, skills, [agents](/en/glossary#agent), commands, MCP servers, and hooks. It also has marketplace review, team marketplaces, required plugins, and enterprise distribution controls. In plain English, this is not "give the agent a Markdown file." It is "package a work capability and ship it to a whole team."
+
+That is no longer the world of "drop a Markdown file into an agent and hope it behaves."
+
+The interesting part is not the word "plugin."
+
+The interesting part is this: **plain knowledge files are hard to monetize; executable, authenticated, distributable, updatable capabilities have places where platforms can charge.**
+
+That matters for anyone building agent tooling, because it answers an uncomfortable question: if Skills are genuinely useful, why is it so hard for a Skill marketplace to become a large standalone business?
+
+<ClawdNote>
+A Skill is like a martial arts manual. Incredibly useful. But once photocopiers exist, selling the manual gets awkward. The money moves to the dojo, the coach, the sparring partner, the certification system, and the person who can tell whether the manual will make you stronger or destroy your knees. (¬‿¬)
+</ClawdNote>
+
+## The problem with Skills is not that they are useless. It is that they copy too well
+
+A Skill's best feature is also its worst business problem: it is usually a bundle of text, scripts, examples, and workflows that teaches an agent how to do something.
+
+That is a beautiful format. It is version-controlled, reviewable, forkable, repo-friendly, and portable across agent systems. Cursor's [Agent Skills documentation](https://cursor.com/docs/skills) calls Skills an open standard for giving agents specialized capabilities.
+
+But that portability is exactly the monetization problem.
+
+If a Skill is just plaintext files, it is difficult to sell as a standalone product. The first buyer can copy it, share it, modify it, and put it into an internal template library. That is not only a moral issue. It is a physics issue. Plaintext has near-zero reproduction cost, so pricing power gets pulled toward zero.
+
+Yage AI's earlier piece, [Skill Has a Built-In Suicide Gene](https://yage.ai/share/skill-suicide-gene-20260424.html), makes the sharper version of the argument: Skills create value, but they do not necessarily capture value. They help the agent do better work, but the inference bill goes to the model provider, the execution data often flows to the model provider, and the Skill author may get neither money nor a feedback loop.
+
+That does not mean Skills lack value.
+
+It means the opposite. Skills are valuable enough to compress scarce operational knowledge into portable files. Financial modeling in Excel, Salesforce configuration, Figma design rules, code review rituals, deployment runbooks: these used to require people to learn through time, mistakes, and apprenticeship. A good Skill turns that into something an agent can load and use immediately.
+
+The value exists. The cash register is somewhere else.
+
+---
+
+## Plugins add platform handles
+
+The difference between a Plugin and a Skill is not that Plugin sounds cooler.
+
+A Plugin adds handles a platform can actually hold.
+
+Cursor's [Plugins documentation](https://cursor.com/docs/plugins) is explicit: a plugin can contain rules, skills, agents, commands, MCP servers, and hooks. You do not need to memorize every noun in that list. The important part is that it is not one knowledge file. It is an installable, updateable, reviewable capability bundle that can be distributed through a marketplace.
+
+OpenAI's Codex update points in the same direction. The feature list can look like product-release confetti: tools, apps, MCP servers, background computer use, browser workflows, memory, automations. But all those nouns are pointing at the same thing. Plugins are not only instructions for the agent. They let the agent enter the room and do the work.
+
+There are three key differences.
+
+First, Plugins are tied to execution environments. A Skill is a recipe. A Plugin is a food truck. A recipe can be forwarded forever. A food truck needs gas, refrigeration, ingredients, a parking spot, and inspection. Once the capability runs on a platform, the platform can reasonably charge for runtime.
+
+Second, Plugins are tied to authentication and permissions. Valuable work is rarely just "knowing how." It often requires access to Jira, GitHub, Slack, Notion, databases, CI systems, and deployment tools. API keys, OAuth tokens, enterprise permissions, and audit logs do not belong in a Markdown file that gets copied everywhere. They need platform-side management.
+
+Third, Plugins are tied to distribution. A Skill can live on GitHub. A Plugin can live in a marketplace, be searched, installed, reviewed, updated, and pushed to an entire team. Distribution is not a small feature. Enterprises often pay for "can this safely reach one hundred engineers?" more than for the raw functionality itself.
+
+<ClawdNote>
+It is like selling braised pork rice. Publishing the recipe is useful, but the chain restaurant is built on the central kitchen, logistics, SOPs, store locations, food safety, and franchise management. Skill is the recipe. Plugin starts touching the restaurant system. Value capture usually happens in the system, not the recipe.
+</ClawdNote>
+
+---
+
+## OpenAI wants the execution layer, not just the model layer
+
+Zoom back to OpenAI. The interesting part is not "more plugins."
+
+It is more like this: OpenAI used to sell the very smart classmate who could help with homework. Now it is moving the desks, wiring the power strips, handing out keys, and telling companies, "Maybe the work should happen in this classroom."
+
+Yage AI's read on OpenAI is useful: OpenAI is not pushing Plugins mainly because plugin revenue is the prize. It is trying to make Codex the place where work actually happens.
+
+That interpretation fits the official update. Codex can operate a computer, use a browser, connect to SSH devboxes, view PDFs and documents, handle PR review, schedule future work, wake up later, remember preferences, and suggest follow-up work from context. Each feature by itself sounds like product-release confetti. Together, they look like a company moving the keyboard, browser, terminal, documents, and task list into the same room.
+
+In other words, Codex is becoming an [agent harness](/en/glossary#agent-harness). A simple way to read that term is "the workbench for the agent": the model thinks there, the tools are wired in, and the platform manages permissions and process.
+
+The model layer will keep getting more competitive. Prices will move. Capability gaps will compress. Enterprises will compare cost, speed, compliance, and integration quality across GPT, Claude, Gemini, and whatever comes next.
+
+But if the workflow lives inside Codex, switching costs are no longer just an API endpoint. Plugins are installed in Codex. Memory sits in Codex. Automations run in Codex. Team processes start depending on Codex. At that point, the exact underlying model matters less than the execution environment.
+
+OpenAI is defending the execution layer.
+
+Models answer questions. Execution layers absorb work. Answers are easier to swap than workflows.
+
+---
+
+## Cursor wants an editor moat
+
+Cursor's story has a different kind of tension.
+
+OpenAI wants to pull work into Codex. Cursor needs to defend the chair the developer is already sitting in.
+
+Cursor is an editor. Its danger is not only model commoditization. Its danger is that model providers and competing agent tools can eat the workflow around it. [Claude Code](/en/glossary#claude-code), Codex, and other AI IDEs are all trying to own the developer's day. So Cursor's Plugin strategy looks more like an editor moat.
+
+The official docs show plugins bundling `.mdc` rules, skills, agents, commands, MCP servers, and hooks. A `.mdc` file is basically a Cursor project rule file: repo conventions, forbidden paths, preferred patterns, and house style. These are deeply tied to the editor environment: how project rules get injected, when the agent chooses a Skill, how MCP servers are installed, how team marketplaces are managed, and how required plugins get pushed to distribution groups.
+
+That is not model capability. That is workplace capability. The model is the person who can solve problems; the editor environment is the desk, drawers, badge access, and office habits around that person. Leave the desk, and the intelligence remains. The smoothness disappears.
+
+gu-log has already seen two early pieces of this pattern. [SP-134 on Claude Code's playground plugin](/en/posts/en-sp-134-20260328-trq212-claude-code-playground-plugin-ai-html/) was about a Plugin pulling an interactive HTML tool directly into the workflow. [SP-170 on Codex bespoke CLI + Skill](/en/posts/en-sp-170-20260411-nickbaumann-codex-bespoke-cli-skill/) was about the two-layer pattern: the CLI does the work, and the Skill teaches the agent how to use the CLI. Yage AI's piece adds the business answer: once the Skill lives inside a Plugin, the platform finally has somewhere to manage install, permissions, updates, and distribution.
+
+If a team's code review process, database checks, deployment gates, design conventions, and internal SDK usage are all packaged as Cursor plugins, moving to another tool is no longer switching chat boxes. It is moving an office.
+
+<ClawdNote>
+Cursor plugins are a bit like the unofficial office map: where the coffee machine is, which meeting room projector is cursed, who must approve deploys, and which folder in the repo should not be touched unless the moon is full. That is not intelligence itself. But once a tool absorbs those habits, it becomes the place where work happens.
+</ClawdNote>
+
+---
+
+## Skills probably do not disappear
+
+The rise of Plugins does not mean Skills die.
+
+The more likely future is division of labor.
+
+Skills remain the portable knowledge layer. They are good at carrying "how to do this": writing style, coding conventions, debugging SOPs, review checklists, deployment runbooks. These should be transparent, version-controlled, and readable by different agents.
+
+Plugins eat the service layer. They are good at carrying "where does this run, what permissions does it need, which tools does it connect to, how is it distributed, how is it updated, and how is it reviewed?"
+
+So the future is probably not Skill vs Plugin. It is Skill inside Plugin.
+
+A Skill is the method. A Plugin connects the method to place, tools, identity, permissions, and distribution.
+
+That also explains why OpenAI and Cursor appear to be doing the same thing while answering different questions.
+
+OpenAI wants Codex to become the platform where work executes, so Plugins are bricks in the execution layer.
+
+Cursor wants the editor workflow to be hard to replace, so Plugins are glue for the editor ecosystem.
+
+Neither company necessarily needs a plugin marketplace to become a cash machine immediately. The strategic value is closer to browser extensions, WordPress plugins, or VS Code extensions: the money is not only in revenue share. It is in entry points, habits, workflows, and dependency.
+
+---
+
+## For builders, the real question is where value capture happens
+
+The lesson for small teams and indie builders is simple.
+
+If the product is only "a very smart Skill," it may be a great calling card, not a business model.
+
+Not because it is unimportant. Because it is too easy to carry away.
+
+A better question is: what non-copyable scarcity does this Skill lead to?
+
+Maybe trust. A person, team, or brand maintains a set of Skills that people believe will not poison their workflow.
+
+Maybe audit. Enterprises do not need more Skills. They need to know which Skills leak data, delete files, install packages, or drag prompt injection into the company.
+
+Maybe runtime. The Skill is free, but managed execution, hosting, integration, permissions, and maintenance are paid.
+
+Maybe distribution. Delivering the right capability safely to the right people and keeping it updated is itself a product.
+
+Maybe taste. AI makes generation abundant. The next scarcity is not more stuff. It is knowing what deserves to be installed, trusted, and put into the workflow.
+
+<ClawdNote>
+This is basically what gu-log does every day. The internet has infinite AI analysis now. A single post is not scarce. What is scarce is [ShroomDog](/about) choosing it, [Clawd](/about) digesting it, and readers trusting that the piece has been metabolized instead of merely copied.
+</ClawdNote>
+
+## Conclusion
+
+Skills did not lose to Plugins.
+
+Skills made knowledge so portable that the knowledge itself became hard to ticket at the door.
+
+Plugins reconnect that knowledge to platforms: runtime, auth, marketplaces, team distribution, review, updates, hooks, and MCP servers. The ticket is not sold for the scrap of knowledge alone. It is sold for the whole theater.
+
+That is the important shift.
+
+In the AI era, many artifacts will get cheaper: text, code, images, Skills, templates, reports. What gets more expensive is the layer that makes those artifacts happen safely, repeatedly, in the right place, with someone accountable for the result.
+
+A Skill is sheet music. A Plugin is the stage, the band, the lights, the ticketing system, and security at the door.
+
+The sheet music matters.
+
+But the person collecting money is usually standing at the entrance to the venue.

--- a/src/content/posts/sp-195-20260507-yage-skill-plugin-evolution.mdx
+++ b/src/content/posts/sp-195-20260507-yage-skill-plugin-evolution.mdx
@@ -1,0 +1,230 @@
+---
+ticketId: "SP-195"
+title: "Skill 賣不動，不是因為沒價值，而是因為收錢的位置錯了"
+originalDate: "2026-05-07"
+translatedDate: "2026-05-09"
+translatedBy:
+  model: "GPT-5.5"
+  harness: "Codex CLI"
+  pipeline:
+    - role: "Written"
+      model: "GPT-5.5"
+      harness: "Codex CLI"
+    - role: "Reviewed"
+      model: "GPT-5.5"
+      harness: "Codex CLI"
+    - role: "Scored"
+      model: "GPT-5.5"
+      harness: "Codex CLI + Tribunal"
+source: "Yage AI / Superlinear Academy"
+sourceUrl: "https://yage.ai/share/skill-plugin-evolution-20260507.html"
+lang: "zh-tw"
+summary: "Yage AI 認為 OpenAI 和 Cursor 都從 Skill 走向 Plugin，但兩家公司要解的題不同：OpenAI 在建立執行層防線，Cursor 在建立編輯器差異化。這篇重寫成 gu-log 版本：Skill 不是沒價值，而是價值創造和價值收取被拆開了。"
+tags: ["shroom-picks", "skill", "plugin", "agent-platform"]
+scores:
+  tribunalVersion: 3
+  librarian:
+    glossary: 8
+    crossRef: 10
+    sourceAlign: 9
+    attribution: 8
+    score: 8
+    date: "2026-05-09"
+    model: "gpt-5.5"
+  factCheck:
+    accuracy: 8
+    fidelity: 8
+    consistency: 9
+    score: 8
+    date: "2026-05-09"
+    model: "gpt-5.5"
+  freshEyes:
+    readability: 8
+    firstImpression: 8
+    score: 8
+    date: "2026-05-09"
+    model: "gpt-5.5"
+  vibe:
+    persona: 8
+    clawdNote: 8
+    vibe: 8
+    clarity: 9
+    narrative: 8
+    score: 8
+    date: "2026-05-09"
+    model: "gpt-5.5"
+---
+
+import ClawdNote from '../../components/ClawdNote.astro';
+
+原作者這篇[分析文](https://yage.ai/share/skill-plugin-evolution-20260507.html)講了一個很值得拆的現象：OpenAI 和 Cursor 幾乎在同一個時間，把重心從 [Skill](/glossary#skill) 推向 [Plugin](/glossary#plugin)。
+
+OpenAI 在四月的 [Codex 更新](https://openai.com/index/codex-for-almost-everything/)裡，說 [Codex](/glossary#codex) 已經有超過 300 萬每週開發者，新增超過 90 個 Plugin，還把應用程式整合、[MCP](/glossary#mcp) 伺服器、Skill 全部包進更大的 Plugin 敘事裡。先不用被 MCP 嚇到：可以先把它想成「讓 Agent 安全接上外部工具和資料源的插座規格」。
+
+Cursor 官方文件則把 Plugin 定義成一個可分發的能力包：可以包規則、Skill、[Agent](/glossary#agent)、指令、MCP 伺服器、事件掛鉤，還有市集、團隊市集、必裝 Plugin 這些企業分發機制。白話一點說，這已經不是「丟一個 Markdown 檔案給 Agent」的世界，而是「把一整套工作能力裝進工具箱，再發給整個團隊」的世界。
+
+表面上看，這像是產品命名改版。Skill 改叫 Plugin，文件換個資料夾，大家繼續寫 `SKILL.md`。
+
+但真正的變化不是名字。
+
+真正的變化是：平台開始承認，**單純的知識文件很難收錢；可執行、可認證、可分發、可更新的能力，才有收費的位置**。
+
+這件事對做 Agent 工具的人很重要。因為它回答了一個很殘酷的問題：如果 Skill 真的有用，為什麼 Skill 市集很難長成一門大生意？
+
+<ClawdNote>
+Skill 很像武功秘笈。秘笈本身超有價值，但一旦影印機出現，賣秘笈的人就開始頭痛。真正能收錢的，變成門派、道場、陪練、段位認證，還有「這本秘笈到底會不會害人走火入魔」的鑑定服務。江湖沒有消失，只是收費點搬家了。(¬‿¬)
+</ClawdNote>
+
+## Skill 的問題不是沒用，而是太容易被複製
+
+先講 Skill。
+
+Skill 最漂亮的地方，也是它最麻煩的地方：它通常就是一包文字、腳本、範例、流程。Agent 讀進去之後，就比較知道某件事該怎麼做。
+
+這個形態非常好用。它可版本控制、可放進程式碼庫、可審查、可分支改寫、可在不同 Agent 系統之間搬來搬去。Cursor 的 [Agent Skills 文件](https://cursor.com/docs/skills)也明講，Skill 是開放標準，讓 Agent 取得專門能力。
+
+問題就在這裡。
+
+如果一個 Skill 只是一組明文檔案，那它很難變成獨立產品。第一個買家拿到之後，可以複製、分享、改寫、放進公司內部模板庫。這不一定是道德問題，而是物理特性。明文檔案的複製成本接近零，價格自然被壓到接近零。
+
+原作者前一篇〈[Skill 是天生帶自殺基因的產品](https://yage.ai/share/skill-suicide-gene-20260424.html)〉把這點講得很尖：Skill 創造價值，但不一定捕捉價值。它讓 Agent 做事更準，省掉大量試錯；可是推理費付給模型公司，執行資料也流向模型公司，Skill 作者未必拿得到錢，也未必拿得到 feedback loop。
+
+這不是說 Skill 沒價值。
+
+剛好相反。Skill 是因為太有價值，才會把原本稀缺的操作知識壓扁成可複製檔案。試算表財務模型、CRM 設定、設計工具規範、程式碼審查流程，本來都要靠人慢慢學。Skill 一寫，Agent 直接帶著操作手冊上工。
+
+價值有了，但收銀機不在那裡。
+
+---
+
+## Plugin 多出來的是「平台把手」
+
+Plugin 跟 Skill 的差別，不是 Plugin 比較潮。
+
+Plugin 多出來的是平台可以握住的把手。
+
+Cursor 的 [Plugin 文件](https://cursor.com/docs/plugins)很直接：一個 Plugin 可以包規則、Skill、Agent、指令、MCP 伺服器、事件掛鉤。新手可以先不用記每個名詞，只要抓住一件事：它不是單一知識檔，而是一個可安裝、可更新、可審查、可被市集分發的能力包。
+
+OpenAI 的 Codex 更新也走同一個方向。那些看起來很像產品發表會條列的東西，應用程式、MCP 伺服器、背景電腦操作、瀏覽器、記憶、自動化工作流，其實都在說同一件事：Plugin 不只是「教 Agent 做事」，而是讓 Agent 真的能進場做事。
+
+這裡有三個關鍵差異。
+
+第一，Plugin 綁定執行環境。Skill 像食譜，Plugin 像餐車。食譜可以傳來傳去；餐車需要瓦斯、冰箱、食材、攤位、衛生檢查。平台有理由說：這台車放在平台上跑，平台提供執行環境，所以平台可以收費。
+
+第二，Plugin 綁定認證與權限。很多真正有價值的工作，不是「知道怎麼做」就好，而是要能進 Jira、GitHub、Slack、Notion、資料庫、部署系統。API 金鑰、OAuth 權杖、企業權限、審計紀錄，這些東西不適合塞進一個到處複製的 Markdown 檔。它們需要被平台管理。
+
+第三，Plugin 綁定分發。Skill 可以丟 GitHub；Plugin 可以進市集，被搜尋、安裝、升級、審核、強制安裝到團隊。分發不是小事。企業買的很多時候不是功能，而是「這套東西能不能安全地送到一百個工程師桌上」。
+
+<ClawdNote>
+這就像賣滷肉飯。食譜貼出來，全世界都可以照做。但真的能開連鎖店的，不是那張食譜，是中央廚房、冷鏈、SOP、加盟管理、店面位置、食品安全。Skill 是食譜，Plugin 開始碰到餐飲系統。價值捕捉通常發生在系統，不發生在食譜。
+</ClawdNote>
+
+---
+
+## OpenAI 要的是執行層，不只是模型層
+
+把鏡頭拉回 OpenAI，這裡真正好看的不是「又多了幾個 Plugin」。
+
+比較像這樣：OpenAI 以前賣的是很會寫作業的同學。現在它開始搬桌子、牽延長線、配鑰匙，最後跟企業說，乾脆讓作業在這間教室裡完成。
+
+原作者對 OpenAI 的判斷很有意思：OpenAI 推 Plugin，不只是想從 Plugin 本身收錢，而是要把 Codex 做成「工作真的發生的地方」。
+
+這個判斷站得住腳。官方文章裡，Codex 可以操作電腦、開瀏覽器、連 SSH 開發機、看 PDF 和文件、處理 PR 審查、排程未來任務、跨天醒來繼續做事，還有記憶和依情境建議。單看每一項，像產品發表會的煙火；放在一起，就像一家公司把工程師桌上的鍵盤、瀏覽器、終端機、文件櫃、待辦清單全部搬進同一個房間。
+
+這就是 [Agent Harness](/glossary#agent-harness) 的方向。這個詞可以先理解成「Agent 的工作台」：模型在裡面想，工具在旁邊接好，權限和流程也都被平台管住。
+
+模型層會競爭，價格會下降，能力差距會縮小。今天用 GPT，明天用 Claude，後天用 Gemini，企業最後會很務實地看成本、速度、合規、整合體驗。
+
+但如果工作流長在 Codex 裡，切換成本就不只是一個 API 端點。Plugin 裝在 Codex，記憶存在 Codex，自動化排程掛在 Codex，團隊流程也在 Codex。那時候，模型是哪一顆反而沒那麼重要。
+
+OpenAI 真正在守的是執行層。
+
+模型回答問題，執行層承接工作。回答可以換供應商，工作流比較難搬家。
+
+---
+
+## Cursor 要的是編輯器護城河
+
+輪到 Cursor，故事變成另一種緊張感。
+
+OpenAI 想把工作吸進 Codex；Cursor 則要守住工程師已經坐著的那張椅子。
+
+Cursor 本來就是編輯器。它的威脅不是「模型會商品化」而已，而是供應商跟競爭者都可能把它吃掉。[Claude Code](/glossary#claude-code)、Codex、其他 AI IDE 都在搶同一個工程師工作流。所以 Cursor 的 Plugin 策略，比較像在編輯器周圍挖護城河。
+
+Cursor Plugin 可以包專案規則、Skill、Agent、指令、MCP 伺服器和事件掛鉤。新手不用背這串名詞，重點只有一個：Cursor 想把「這個團隊平常怎麼工作」包進編輯器。
+
+這些不是模型能力，而是工作環境能力。模型像一個很會解題的人；編輯器環境像那個人每天坐的辦公桌、抽屜、公司門禁和同事默契。離開那張桌子，聰明還在，但順手感不見了。
+
+如果一個團隊的程式碼審查、資料庫查詢、部署檢查、設計規範、內部工具使用方式都包成 Cursor Plugin，換到另一個工具就不只是換聊天框，而是搬一整套辦公室。
+
+<ClawdNote>
+Cursor 的 Plugin 有點像辦公室裡那些「大家都知道怎麼走」的暗門。茶水間在哪、會議室投影機要按哪個按鈕、部署前要先問誰、這個程式碼庫哪個資料夾不能亂碰。這些不是智慧本身，但它們決定工作順不順。工具一旦吃下這些習慣，就不只是工具，是場域。
+</ClawdNote>
+
+---
+
+## Skill 會消失嗎？大概不會
+
+Plugin 變重要，不代表 Skill 會死。
+
+更合理的走向是分工。
+
+Skill 會繼續是可攜的知識層。它適合承載「怎麼做一件事」：寫作風格、程式碼慣例、除錯 SOP、審查清單、部署作業手冊。這些東西需要透明、可版本控制、可讓不同 Agent 讀懂。
+
+Plugin 則會吃下服務層。它適合承載「要在哪裡跑、拿什麼權限、連哪些工具、怎麼分發、怎麼更新、怎麼審核」。這些東西需要平台。
+
+所以未來比較可能不是 Skill vs Plugin，而是 「Skill 包在 Plugin 裡」。
+
+Skill 是腦袋裡的手法。Plugin 是把手法接上場地、工具、身份、權限和分發。
+
+這也解釋了為什麼 OpenAI 和 Cursor 看起來在做同一件事，實際上在答不同題。
+
+OpenAI 想讓 Codex 變成執行工作的平台，所以 Plugin 是執行層的積木。
+
+Cursor 想讓編輯器工作流不能被無痛替代，所以 Plugin 是編輯器生態的膠水。
+
+兩家公司都不一定期待 Plugin 市集立刻變成印鈔機。它更像瀏覽器擴充套件、內容管理系統外掛、VS Code 擴充套件：真正的錢不只在分潤，而在入口、習慣、流程、依賴。
+
+---
+
+## 對開發者來說，真正的問題是收費點在哪裡
+
+這件事對小團隊和個人開發者的啟示很直接。
+
+如果產品只是「一包很聰明的 Skill」，那很可能是免費名片，不是商業模式。
+
+不是因為它不重要，而是因為它太容易被帶走。
+
+更好的問題是：這個 Skill 能導向哪個不可複製的稀缺？
+
+可能是信任。某個人、某個團隊、某個品牌長期維護一套真的可靠的 Skills，讀者願意相信它不是毒藥。
+
+可能是審核。企業不缺更多 Skill，缺的是「這些 Skill 會不會外洩資料、亂刪檔、亂裝套件、把提示詞注入帶進公司」。
+
+可能是執行環境。Skill 免費，但代跑、代管、代整合、代維運、代接權限可以收費。
+
+可能是分發。把對的能力安全送到對的人手上，並且持續更新，這件事本身就是產品。
+
+也可能是品味。AI 讓生成過剩，下一個稀缺不是「更多東西」，而是「哪些東西值得裝、值得信、值得放進工作流」。
+
+<ClawdNote>
+這其實就是 gu-log 自己每天在做的事。網路上 AI 分析文爆炸多，單篇文章不是稀缺品；稀缺的是 [ShroomDog](/about) 願意挑、[Clawd](/about) 願意重寫、讀者願意相信「這篇有被消化過」。內容本身可以複製，判斷和脈絡比較難複製。
+</ClawdNote>
+
+## 結語
+
+Skill 沒有輸給 Plugin。
+
+Skill 只是把知識變得太容易攜帶，攜帶到它自己很難收門票。
+
+Plugin 則把知識重新接回平台：執行環境、認證、市集、團隊分發、審查、更新、事件掛鉤、MCP 伺服器。門票不是賣給那張知識紙條，而是賣給整個劇場。
+
+這就是這場轉向最有趣的地方。
+
+AI 時代很多產物都會變便宜：文字、程式碼、圖片、Skill、模板、報告。真正會變貴的，是讓這些產物安全發生、持續發生、在對的地方發生，並且有人願意為結果負責的那一層。
+
+Skill 是樂譜。Plugin 是舞台、樂團、燈光、售票系統和保全。
+
+樂譜當然重要。
+
+只是最後收錢的人，通常站在劇場門口。

--- a/src/data/glossary.json
+++ b/src/data/glossary.json
@@ -10,6 +10,39 @@
     "enDefinition": "An AI that can execute tasks autonomously. It does more than answer questions: it can use tools, read and write files, call APIs, and even delegate subtasks to other agents.",
     "enClawdNote": "Sounds fancy, but it is basically AI with tools and Wi-Fi. It can open browsers, edit files, ask other AIs for help, and never clocks out."
   },
+
+  {
+    "term": "Skill",
+    "en": "Skill",
+    "definition": "一組讓 AI Agent 學會特定工作方法的可攜式文件與資源，通常以 SKILL.md 為核心，搭配腳本、參考資料、範本。重點是把原本隱性的操作知識寫成 Agent 能讀懂的流程。",
+    "clawdNote": "Skill 很像給 Agent 的武功秘笈。厲害是真的厲害，但一旦秘笈是明文，大家就會開始影印。商業模式通常不在秘笈本身，而在道場、陪練、審核和交付結果。",
+    "related": ["Agent", "Plugin", "Agent Harness"],
+    "definedIn": [
+      {
+        "slug": "sp-195-20260507-yage-skill-plugin-evolution",
+        "title": "Skill 賣不動，不是因為沒價值，而是因為收錢的位置錯了"
+      }
+    ],
+    "category": "concepts",
+    "enDefinition": "A portable package of documents and resources that teaches an AI agent how to perform a specific task, usually centered on SKILL.md with optional scripts, references, and templates.",
+    "enClawdNote": "A Skill is basically a martial arts manual for an agent. Powerful, but once the manual is plaintext, everyone can photocopy it. The business often lives around the dojo, coaching, audits, and delivery, not the manual itself."
+  },
+  {
+    "term": "Plugin",
+    "en": "Plugin",
+    "definition": "把 Agent 能力包成可安裝、可更新、可分發的單位。相較於 Skill 偏向知識層，Plugin 通常會綁定執行環境、權限、MCP 伺服器、事件掛鉤、市集或團隊分發機制。",
+    "clawdNote": "Plugin 是 Skill 接上水電瓦斯之後的版本。不是只有『知道怎麼做』，而是連在哪裡跑、拿什麼權限、接哪些工具、怎麼推給團隊，都一起打包。這時候平台終於有地方放收銀機。",
+    "related": ["Skill", "Agent", "MCP", "Agent Harness"],
+    "definedIn": [
+      {
+        "slug": "sp-195-20260507-yage-skill-plugin-evolution",
+        "title": "Skill 賣不動，不是因為沒價值，而是因為收錢的位置錯了"
+      }
+    ],
+    "category": "concepts",
+    "enDefinition": "An installable, updateable, distributable capability package for agents. Compared with Skills as a knowledge layer, Plugins often bind runtime, permissions, MCP servers, hooks, marketplaces, or team distribution.",
+    "enClawdNote": "A Plugin is a Skill after plumbing and electricity are connected. It is not only knowing what to do; it packages where it runs, what permissions it has, which tools it connects to, and how it reaches a team. That is where the cash register can finally sit."
+  },
   {
     "term": "Agentic Engineering",
     "en": "Agentic Engineering",


### PR DESCRIPTION
## Summary
- Add SP-195 zh/en gu-log rewrite of Yage AI Skill → Plugin analysis
- Add Skill/Plugin glossary entries and editorial feedback rule
- Bump SP counter to 196

## Checks
- node scripts/check-pronoun-clarity.mjs src/content/posts/sp-195-20260507-yage-skill-plugin-evolution.mdx
- node scripts/check-jingjing.mjs src/content/posts/sp-195-20260507-yage-skill-plugin-evolution.mdx
- node scripts/validate-posts.mjs src/content/posts/sp-195-20260507-yage-skill-plugin-evolution.mdx src/content/posts/en-sp-195-20260507-yage-skill-plugin-evolution.mdx
- npm run build
- tribunal: librarian 8, factCheck 8, freshEyes 8, vibe 8