### PR TITLE
Add source evaluation rule to pipeline prompts

### DIFF
--- a/tools/sp-pipeline/internal/prompts/eval-codex.tmpl
+++ b/tools/sp-pipeline/internal/prompts/eval-codex.tmpl
@@ -9,6 +9,12 @@ Checklist:
 2. Is it relevant to gu-log audience topics (AI, tech, developer, indie hacker)?
 3. Does it have enough depth to expand into a full article?
 
+Important non-blockers:
+- Do NOT mark SKIP just because the source is already a Chinese / Simplified Chinese analysis article.
+  gu-log's value is Traditional Chinese, story structure, ClawdNote, ShroomDog/Clawd framing, and reader context — not only language translation.
+- Do NOT mark SKIP just because the source is second-hand synthesis. If attribution is clear and the source is useful, gu-log can rewrite, contextualize, and cite it.
+- Do NOT mark SKIP just because numbers or claims need verification. Verification is the pipeline/agent's job. Mark SKIP only after the facts look unreliable, uncheckable, incomplete, irrelevant, or unable to support the 8/8/8 publish bar.
+
 Source content ({{.LineCount}} lines):
 {{.Source}}
 

--- a/tools/sp-pipeline/internal/prompts/eval-gemini.tmpl
+++ b/tools/sp-pipeline/internal/prompts/eval-gemini.tmpl
@@ -9,6 +9,12 @@ Checklist:
 2. Is it relevant to gu-log audience topics (AI, tech, developer, indie hacker)?
 3. Does it have enough depth to expand into a full article?
 
+Important non-blockers:
+- Do NOT mark SKIP just because the source is already a Chinese / Simplified Chinese analysis article.
+  gu-log's value is Traditional Chinese, story structure, ClawdNote, ShroomDog/Clawd framing, and reader context — not only language translation.
+- Do NOT mark SKIP just because the source is second-hand synthesis. If attribution is clear and the source is useful, gu-log can rewrite, contextualize, and cite it.
+- Do NOT mark SKIP just because numbers or claims need verification. Verification is the pipeline/agent's job. Mark SKIP only after the facts look unreliable, uncheckable, incomplete, irrelevant, or unable to support the 8/8/8 publish bar.
+
 Source content ({{.LineCount}} lines):
 {{.Source}}
 

--- a/tools/sp-pipeline/internal/prompts/write.tmpl
+++ b/tools/sp-pipeline/internal/prompts/write.tmpl
@@ -13,6 +13,8 @@ Task:
 - The source may contain a FULL THREAD (multiple tweets separated by ---). Cover ALL tweets, not just the first one.
 - If you see "⚠️ INCOMPLETE THREAD", acknowledge what's missing and note it for the reader. Do NOT pad partial content into a full article.
 - NEVER pad or filler. If a section says "there are other patterns" but you don't have the details, either skip that claim or explicitly say the details weren't available. Do NOT write vague paragraphs that say nothing.
+- If the source is already a Chinese / Simplified Chinese analysis article or second-hand synthesis, do NOT treat that as a reason to make the draft thin or dismissive. Rewrite it into gu-log's own Traditional Chinese, story-driven structure with ClawdNotes, clear attribution, and verified primary-source context where needed.
+- If the source contains numbers or factual claims that need checking, verify them against primary sources when possible. Do NOT invent certainty. If verification fails, preserve uncertainty or state the limit instead of padding.
 - Follow the style guide exactly.
 - Read `docs/shroomdog-editorial-feedback.md` before drafting and apply relevant ShroomDog feedback lessons.
 - Use this metadata:


### PR DESCRIPTION
## Summary
- Add the Chinese/Simplified Chinese source non-blocker rule to SP eval prompts.
- Add second-hand synthesis and verification-needed non-blocker rules to SP eval prompts.
- Add the same source-handling rule to the SP write prompt so accepted sources are rewritten in gu-log style instead of treated thinly.

## Checks
- `git diff --check`
- `rg` verification/source-rule strings in `AGENTS.md` and pipeline prompts

Note: local `go test ./tools/sp-pipeline/internal/prompts` could not run on this VM because `go` is not installed; CI will run the full gate.
