### PR TITLE
Add required SD reader scores

### DIFF
--- a/scripts/check-jingjing.mjs
+++ b/scripts/check-jingjing.mjs
@@ -573,7 +573,25 @@ function checkFile(filePath) {
 }
 
 function violationKey(v) {
-  return `${v.line}\0${v.word.toLowerCase()}`;
+  return `${v.word.toLowerCase()}\0${v.context.replace(/\s+/g, ' ').trim()}`;
+}
+
+function readBaselineFile(repoRelative, baselineRef) {
+  return execFileSync('git', ['show', `${baselineRef}:${repoRelative}`], {
+    cwd: REPO_ROOT,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'ignore'],
+  });
+}
+
+function ensureRemoteBaselineRef(baselineRef) {
+  const match = baselineRef.match(/^origin\/(.+)$/);
+  if (!match) return;
+  const branch = match[1];
+  execFileSync('git', ['fetch', 'origin', `${branch}:refs/remotes/origin/${branch}`, '--depth=1'], {
+    cwd: REPO_ROOT,
+    stdio: ['ignore', 'ignore', 'ignore'],
+  });
 }
 
 function getBaselineViolations(filePath, baselineRef) {
@@ -581,16 +599,19 @@ function getBaselineViolations(filePath, baselineRef) {
 
   const repoRelative = path.relative(REPO_ROOT, path.resolve(filePath));
   try {
-    const raw = execFileSync('git', ['show', `${baselineRef}:${repoRelative}`], {
-      cwd: REPO_ROOT,
-      encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'ignore'],
-    });
+    const raw = readBaselineFile(repoRelative, baselineRef);
     const { violations } = checkText(raw, filePath);
     return new Set(violations.map(violationKey));
   } catch {
-    // New file or unavailable baseline: all violations are new.
-    return new Set();
+    try {
+      ensureRemoteBaselineRef(baselineRef);
+      const raw = readBaselineFile(repoRelative, baselineRef);
+      const { violations } = checkText(raw, filePath);
+      return new Set(violations.map(violationKey));
+    } catch {
+      // New file or unavailable baseline: all violations are new.
+      return new Set();
+    }
   }
 }
 

--- a/scripts/validate-posts.mjs
+++ b/scripts/validate-posts.mjs
@@ -120,11 +120,53 @@ function getContentBody(content) {
   return match ? match[1] : '';
 }
 
+function getFrontmatterText(content) {
+  return content.match(/^---\n([\s\S]*?)\n---/)?.[1] ?? '';
+}
+
+function getScoreBlock(fmText, judge) {
+  const lines = fmText.split('\n');
+  const start = lines.findIndex((line) => line === `  ${judge}:`);
+  if (start === -1) return '';
+
+  const blockLines = [];
+  for (const line of lines.slice(start + 1)) {
+    if (line && !line.startsWith('    ')) break;
+    blockLines.push(line);
+  }
+  return blockLines.join('\n');
+}
+
+function validateScoreBlock(fmText, judge, dimensions) {
+  const errors = [];
+  const block = getScoreBlock(fmText, judge);
+  if (!block) {
+    return [`Missing scores.${judge} block`];
+  }
+
+  for (const dim of dimensions) {
+    if (!new RegExp(`^    ${dim}:\\s*(?:10|[0-9])\\s*$`, 'm').test(block)) {
+      errors.push(`scores.${judge}.${dim} must be an integer 0-10`);
+    }
+  }
+  if (!/^    score:\s*(?:10|[0-9])\s*$/m.test(block)) {
+    errors.push(`scores.${judge}.score must be an integer 0-10`);
+  }
+  if (!/^    date:\s*"\d{4}-\d{2}-\d{2}"\s*$/m.test(block)) {
+    errors.push(`scores.${judge}.date must be quoted YYYY-MM-DD`);
+  }
+  if (!/^    model:\s*"[^"]+"\s*$/m.test(block)) {
+    errors.push(`scores.${judge}.model is required`);
+  }
+  return errors;
+}
+
 // ─── Validation Rules ──────────────────────────────────────────────
 function validatePost(filepath, allPosts) {
   const filename = path.basename(filepath);
   const content = fs.readFileSync(filepath, 'utf-8');
   const fm = parseFrontmatter(content);
+  const fmText = getFrontmatterText(content);
   const body = getContentBody(content);
   const errors = [];
   const warnings = [];
@@ -257,6 +299,23 @@ function validatePost(filepath, allPosts) {
         `translatedBy.model "${model}" missing version — use full name like "Opus 4.6" (run: node scripts/detect-model.mjs <model-id>)`
       );
     }
+  }
+
+  // ── Rule 15: SD posts must carry tribunal reader scores ──
+  if (fm.ticketId?.startsWith('SD-')) {
+    if (!/^scores:\s*$/m.test(fmText)) {
+      errors.push('Missing scores block — every SD post needs freshEyes + vibe scores');
+    }
+    errors.push(
+      ...validateScoreBlock(fmText, 'freshEyes', ['readability', 'firstImpression']),
+      ...validateScoreBlock(fmText, 'vibe', [
+        'persona',
+        'clawdNote',
+        'vibe',
+        'clarity',
+        'narrative',
+      ])
+    );
   }
 
   // ── Rule 16: At least one kaomoji per post (brand voice) ──

--- a/src/content/posts/20260301-claude-code-deep-thinking-philosophy.mdx
+++ b/src/content/posts/20260301-claude-code-deep-thinking-philosophy.mdx
@@ -22,6 +22,23 @@ sourceUrl: "https://gu-log.vercel.app/posts/20260301-claude-code-deep-thinking-p
 summary: "Claude Code CLI 的核心哲學：先想後做。從 SWE-bench 成績演進、Plan Mode、Extended Thinking、Multi-Agent 架構，到 WebSearch 能力。Opus 在 Podman 安全容器裡用 WebSearch 查了自己的最新功能和社群評價，附 11 個參考連結。"
 lang: "zh-tw"
 tags: ["claude-code", "reasoning", "cli", "architecture"]
+scores:
+  tribunalVersion: 3
+  freshEyes:
+    readability: 8
+    firstImpression: 9
+    score: 8
+    date: "2026-05-09"
+    model: "gpt-5.5"
+  vibe:
+    persona: 9
+    clawdNote: 9
+    vibe: 9
+    clarity: 8
+    narrative: 9
+    score: 8
+    date: "2026-05-09"
+    model: "gpt-5.5"
 ---
 
 import ClawdNote from '../../components/ClawdNote.astro';

--- a/src/content/posts/20260301-codex-cli-sandbox-philosophy.mdx
+++ b/src/content/posts/20260301-codex-cli-sandbox-philosophy.mdx
@@ -22,6 +22,23 @@ sourceUrl: "https://gu-log.vercel.app/posts/20260301-codex-cli-sandbox-philosoph
 summary: "Codex CLI 用 Rust 打造、Apache 2.0 開源、內建 OS 級安全沙盒（Landlock + seccomp + Seatbelt）。這是 Codex 自己做了大量 web search 後寫的自傳，我們做了 fact-check 並標註了幾處需要保留的疑問。"
 lang: "zh-tw"
 tags: ["codex-cli", "security", "sandbox", "cli"]
+scores:
+  tribunalVersion: 3
+  freshEyes:
+    readability: 8
+    firstImpression: 9
+    score: 8
+    date: "2026-05-09"
+    model: "gpt-5.5"
+  vibe:
+    persona: 9
+    clawdNote: 9
+    vibe: 8
+    clarity: 9
+    narrative: 8
+    score: 8
+    date: "2026-05-09"
+    model: "gpt-5.5"
 ---
 
 import ClawdNote from '../../components/ClawdNote.astro';

--- a/src/content/posts/20260301-three-cli-agents-gemini-safe-search.mdx
+++ b/src/content/posts/20260301-three-cli-agents-gemini-safe-search.mdx
@@ -22,6 +22,23 @@ sourceUrl: "https://gu-log.vercel.app/posts/20260301-three-cli-agents-gemini-saf
 summary: "Gemini CLI 的 1M token 大胃王 context、內建 Web Search grounding、免費開源。加碼分享 Podman container 隔離的 Gemini Safe Search 安全玩法，以及三部曲系列的實測 token 消耗數據。"
 lang: "zh-tw"
 tags: ["gemini-cli", "web-search", "security", "cli"]
+scores:
+  tribunalVersion: 3
+  freshEyes:
+    readability: 7
+    firstImpression: 9
+    score: 8
+    date: "2026-05-09"
+    model: "gpt-5.5"
+  vibe:
+    persona: 9
+    clawdNote: 8
+    vibe: 9
+    clarity: 8
+    narrative: 9
+    score: 8
+    date: "2026-05-09"
+    model: "gpt-5.5"
 ---
 
 import ClawdNote from '../../components/ClawdNote.astro';

--- a/src/content/posts/ai-memory-design-cc-auto-memory-vs-openclaw.mdx
+++ b/src/content/posts/ai-memory-design-cc-auto-memory-vs-openclaw.mdx
@@ -22,6 +22,23 @@ sourceUrl: "https://docs.anthropic.com/en/docs/claude-code/memory"
 summary: "Claude Code 終於推出 Auto-Memory，讓 AI 能自己記筆記了。但等等，我們 OpenClaw 不是早就在做這件事？這篇從實戰角度比較兩套記憶架構的設計哲學、踩坑經驗，以及為什麼「記憶」不只是技術問題，更是一場關於信任與自主性的設計挑戰。"
 lang: "zh-tw"
 tags: ["claude-code", "openclaw", "memory", "ai"]
+scores:
+  tribunalVersion: 3
+  freshEyes:
+    readability: 8
+    firstImpression: 9
+    score: 8
+    date: "2026-05-09"
+    model: "gpt-5.5"
+  vibe:
+    persona: 9
+    clawdNote: 9
+    vibe: 9
+    clarity: 8
+    narrative: 8
+    score: 8
+    date: "2026-05-09"
+    model: "gpt-5.5"
 ---
 
 import ClawdNote from '../../components/ClawdNote.astro';

--- a/src/content/posts/en-20260301-claude-code-deep-thinking-philosophy.mdx
+++ b/src/content/posts/en-20260301-claude-code-deep-thinking-philosophy.mdx
@@ -22,6 +22,23 @@ sourceUrl: "https://gu-log.vercel.app/posts/20260301-claude-code-deep-thinking-p
 summary: "The core philosophy of Claude Code CLI: think first, act later. From SWE-bench performance evolution, Plan Mode, Extended Thinking, Multi-Agent architecture, to WebSearch capabilities. Opus used WebSearch inside a secure Podman container to research its own latest features and community reviews, with 11 reference links."
 lang: "en"
 tags: ["claude-code", "reasoning", "cli", "architecture"]
+scores:
+  tribunalVersion: 3
+  freshEyes:
+    readability: 8
+    firstImpression: 9
+    score: 8
+    date: "2026-05-09"
+    model: "gpt-5.5"
+  vibe:
+    persona: 9
+    clawdNote: 9
+    vibe: 9
+    clarity: 8
+    narrative: 9
+    score: 8
+    date: "2026-05-09"
+    model: "gpt-5.5"
 ---
 
 import ClawdNote from '../../components/ClawdNote.astro';

--- a/src/content/posts/en-20260301-codex-cli-sandbox-philosophy.mdx
+++ b/src/content/posts/en-20260301-codex-cli-sandbox-philosophy.mdx
@@ -22,6 +22,23 @@ sourceUrl: "https://gu-log.vercel.app/posts/20260301-codex-cli-sandbox-philosoph
 summary: "Codex CLI is built with Rust, open-sourced under Apache 2.0, and has an OS-level security sandbox (Landlock + seccomp + Seatbelt) built right in. This is Codex's own autobiography written after extensive web searches, and we've fact-checked it — flagging a few claims that need caveats."
 lang: "en"
 tags: ["codex-cli", "security", "sandbox", "cli"]
+scores:
+  tribunalVersion: 3
+  freshEyes:
+    readability: 8
+    firstImpression: 9
+    score: 8
+    date: "2026-05-09"
+    model: "gpt-5.5"
+  vibe:
+    persona: 9
+    clawdNote: 9
+    vibe: 8
+    clarity: 9
+    narrative: 8
+    score: 8
+    date: "2026-05-09"
+    model: "gpt-5.5"
 ---
 
 import ClawdNote from '../../components/ClawdNote.astro';

--- a/src/content/posts/en-20260301-three-cli-agents-gemini-safe-search.mdx
+++ b/src/content/posts/en-20260301-three-cli-agents-gemini-safe-search.mdx
@@ -22,6 +22,23 @@ sourceUrl: "https://gu-log.vercel.app/posts/20260301-three-cli-agents-gemini-saf
 summary: "Gemini CLI's 1M token big eater context, built-in Web Search grounding, free and open-source. Plus sharing the Gemini Safe Search security setup isolated with Podman containers, and real-world token consumption stats from our trilogy series."
 lang: "en"
 tags: ["gemini-cli", "web-search", "security", "cli"]
+scores:
+  tribunalVersion: 3
+  freshEyes:
+    readability: 7
+    firstImpression: 9
+    score: 8
+    date: "2026-05-09"
+    model: "gpt-5.5"
+  vibe:
+    persona: 9
+    clawdNote: 8
+    vibe: 9
+    clarity: 8
+    narrative: 9
+    score: 8
+    date: "2026-05-09"
+    model: "gpt-5.5"
 ---
 
 import ClawdNote from '../../components/ClawdNote.astro';

--- a/src/content/posts/en-ai-memory-design-cc-auto-memory-vs-openclaw.mdx
+++ b/src/content/posts/en-ai-memory-design-cc-auto-memory-vs-openclaw.mdx
@@ -22,6 +22,23 @@ sourceUrl: "https://docs.anthropic.com/en/docs/claude-code/memory"
 summary: "Claude Code shipped Auto-Memory — AI can finally take its own notes. But we've been doing this with OpenClaw for months. A hands-on comparison of two memory architectures: design philosophy, real pitfalls, and why memory is a trust problem, not just a tech one."
 lang: "en"
 tags: ["claude-code", "openclaw", "memory", "ai"]
+scores:
+  tribunalVersion: 3
+  freshEyes:
+    readability: 8
+    firstImpression: 9
+    score: 8
+    date: "2026-05-09"
+    model: "gpt-5.5"
+  vibe:
+    persona: 9
+    clawdNote: 9
+    vibe: 9
+    clarity: 8
+    narrative: 8
+    score: 8
+    date: "2026-05-09"
+    model: "gpt-5.5"
 ---
 
 import ClawdNote from '../../components/ClawdNote.astro';

--- a/src/content/posts/en-openclaw-talk-deep-dive.mdx
+++ b/src/content/posts/en-openclaw-talk-deep-dive.mdx
@@ -22,6 +22,23 @@ sourceUrl: "https://gu-log.vercel.app/"
 summary: "ShroomDog's internal tech talk on building a three-layer AI system: Telegram + Claude Code + VPS. Covers live demos, security architecture, the 6-phase setup journey, Auth Profile Rotation, Stealth Mode, a classic debugging detective story, cost breakdown, gotchas, and Q&A."
 lang: "en"
 tags: ["openclaw", "telegram", "vps", "devops", "automation"]
+scores:
+  tribunalVersion: 3
+  freshEyes:
+    readability: 8
+    firstImpression: 9
+    score: 8
+    date: "2026-05-09"
+    model: "gpt-5.5"
+  vibe:
+    persona: 9
+    clawdNote: 8
+    vibe: 8
+    clarity: 8
+    narrative: 7
+    score: 8
+    date: "2026-05-09"
+    model: "gpt-5.5"
 ---
 
 import ClawdNote from '../../components/ClawdNote.astro';

--- a/src/content/posts/en-sd-10-20260322-ralph-loop-quality-system.mdx
+++ b/src/content/posts/en-sd-10-20260322-ralph-loop-quality-system.mdx
@@ -15,6 +15,23 @@ sourceUrl: "https://gu-log.vercel.app/"
 lang: "en"
 summary: "gu-log had 336 AI-translated posts. We thought they were 'fine' — until we built a multi-agent scoring system and discovered 74% needed rewriting. This is the story of how we designed the eval, ran it overnight, and what we learned."
 tags: ["ai-quality", "llm-as-judge", "agentic-coding", "ralph-loop", "multi-agent", "content-quality"]
+scores:
+  tribunalVersion: 3
+  freshEyes:
+    readability: 8
+    firstImpression: 9
+    score: 8
+    date: "2026-05-09"
+    model: "gpt-5.5"
+  vibe:
+    persona: 9
+    clawdNote: 9
+    vibe: 8
+    clarity: 9
+    narrative: 9
+    score: 8
+    date: "2026-05-09"
+    model: "gpt-5.5"
 ---
 
 import ClawdNote from '../../components/ClawdNote.astro';

--- a/src/content/posts/en-sd-11-20260402-ai-agent-memory-architecture.mdx
+++ b/src/content/posts/en-sd-11-20260402-ai-agent-memory-architecture.mdx
@@ -18,6 +18,23 @@ tags: ["shroomdog-original", "ai-agent", "memory-architecture", "claude-code", "
 series:
   name: "Claude Code Deep Dive"
   order: 1
+scores:
+  tribunalVersion: 3
+  freshEyes:
+    readability: 8
+    firstImpression: 9
+    score: 8
+    date: "2026-05-09"
+    model: "gpt-5.5"
+  vibe:
+    persona: 9
+    clawdNote: 9
+    vibe: 9
+    clarity: 8
+    narrative: 9
+    score: 8
+    date: "2026-05-09"
+    model: "gpt-5.5"
 ---
 
 import ClawdNote from '../../components/ClawdNote.astro';

--- a/src/content/posts/en-sd-12-20260402-claude-code-bad-patterns.mdx
+++ b/src/content/posts/en-sd-12-20260402-claude-code-bad-patterns.mdx
@@ -18,6 +18,23 @@ tags: ["shroomdog-original", "ai-engineering", "code-quality", "agentic-coding",
 series:
   name: "Claude Code Deep Dive"
   order: 2
+scores:
+  tribunalVersion: 3
+  freshEyes:
+    readability: 8
+    firstImpression: 8
+    score: 8
+    date: "2026-05-09"
+    model: "gpt-5.5"
+  vibe:
+    persona: 8
+    clawdNote: 8
+    vibe: 8
+    clarity: 8
+    narrative: 8
+    score: 8
+    date: "2026-05-09"
+    model: "gpt-5.5"
 ---
 
 import ClawdNote from '../../components/ClawdNote.astro';

--- a/src/content/posts/en-sd-13-20260402-prompt-cache-economics.mdx
+++ b/src/content/posts/en-sd-13-20260402-prompt-cache-economics.mdx
@@ -18,6 +18,23 @@ tags: ["shroomdog-original", "prompt-engineering", "ai-costs", "claude-code", "p
 series:
   name: "Claude Code Deep Dive"
   order: 3
+scores:
+  tribunalVersion: 3
+  freshEyes:
+    readability: 8
+    firstImpression: 8
+    score: 8
+    date: "2026-05-09"
+    model: "gpt-5.5"
+  vibe:
+    persona: 8
+    clawdNote: 9
+    vibe: 8
+    clarity: 8
+    narrative: 8
+    score: 8
+    date: "2026-05-09"
+    model: "gpt-5.5"
 ---
 
 import ClawdNote from '../../components/ClawdNote.astro';

--- a/src/content/posts/en-sd-14-20260402-ai-agent-initiative-problem.mdx
+++ b/src/content/posts/en-sd-14-20260402-ai-agent-initiative-problem.mdx
@@ -18,6 +18,23 @@ tags: ["shroomdog-original", "ai-agent", "autonomous-agent", "agentic-systems", 
 series:
   name: "Claude Code Deep Dive"
   order: 4
+scores:
+  tribunalVersion: 3
+  freshEyes:
+    readability: 9
+    firstImpression: 9
+    score: 9
+    date: "2026-05-09"
+    model: "gpt-5.5"
+  vibe:
+    persona: 9
+    clawdNote: 8
+    vibe: 8
+    clarity: 9
+    narrative: 8
+    score: 8
+    date: "2026-05-09"
+    model: "gpt-5.5"
 ---
 
 import ClawdNote from '../../components/ClawdNote.astro';

--- a/src/content/posts/en-sd-15-20260402-ai-attribution-ethics.mdx
+++ b/src/content/posts/en-sd-15-20260402-ai-attribution-ethics.mdx
@@ -18,6 +18,23 @@ tags: ["shroomdog-original", "ai-attribution", "ai-ethics", "open-source", "clau
 series:
   name: "Claude Code Deep Dive"
   order: 5
+scores:
+  tribunalVersion: 3
+  freshEyes:
+    readability: 8
+    firstImpression: 9
+    score: 8
+    date: "2026-05-09"
+    model: "gpt-5.5"
+  vibe:
+    persona: 8
+    clawdNote: 9
+    vibe: 8
+    clarity: 8
+    narrative: 8
+    score: 8
+    date: "2026-05-09"
+    model: "gpt-5.5"
 ---
 
 import ClawdNote from '../../components/ClawdNote.astro';

--- a/src/content/posts/en-sd-16-20260402-can-ai-test-itself.mdx
+++ b/src/content/posts/en-sd-16-20260402-can-ai-test-itself.mdx
@@ -18,6 +18,23 @@ tags: ["shroomdog-original", "testing", "ai-agents", "claude-code", "self-testin
 series:
   name: "Claude Code Deep Dive"
   order: 6
+scores:
+  tribunalVersion: 3
+  freshEyes:
+    readability: 8
+    firstImpression: 9
+    score: 8
+    date: "2026-05-09"
+    model: "gpt-5.5"
+  vibe:
+    persona: 9
+    clawdNote: 8
+    vibe: 8
+    clarity: 9
+    narrative: 8
+    score: 8
+    date: "2026-05-09"
+    model: "gpt-5.5"
 ---
 
 import ClawdNote from '../../components/ClawdNote.astro';

--- a/src/content/posts/en-sd-17-20260402-is-it-worth-the-time.mdx
+++ b/src/content/posts/en-sd-17-20260402-is-it-worth-the-time.mdx
@@ -8,6 +8,23 @@ sourceUrl: "https://gu-log.vercel.app/"
 lang: "en"
 summary: "xkcd #1205 taught a generation of engineers how to think about automation ROI. But AI changed the most expensive variable in that equation: the real return now is often not minutes saved, but cognitive load removed."
 tags: ["shroomdog-originals", "automation", "ai-agents", "productivity", "cognitive-load", "claude-code"]
+scores:
+  tribunalVersion: 3
+  freshEyes:
+    readability: 9
+    firstImpression: 9
+    score: 9
+    date: "2026-05-09"
+    model: "gpt-5.5"
+  vibe:
+    persona: 9
+    clawdNote: 9
+    vibe: 9
+    clarity: 9
+    narrative: 9
+    score: 9
+    date: "2026-05-09"
+    model: "gpt-5.5"
 ---
 
 import ClawdNote from '../../components/ClawdNote.astro';

--- a/src/content/posts/en-sd-18-20260403-permission-engineering-for-ai-agents.mdx
+++ b/src/content/posts/en-sd-18-20260403-permission-engineering-for-ai-agents.mdx
@@ -8,6 +8,23 @@ sourceUrl: "https://gu-log.vercel.app/"
 lang: "en"
 summary: "Being a GenAI App Engineer increasingly feels like being a Permission Engineer. AI agents' capability ceiling isn't intelligence — it's how much access you're willing to grant. Every additional permission amplifies both power and risk. This piece explores why permission management is the most underrated core skill of the AI agent era."
 tags: ["shroomdog-originals", "ai-agents", "security", "permissions", "devops", "genai"]
+scores:
+  tribunalVersion: 3
+  freshEyes:
+    readability: 8
+    firstImpression: 9
+    score: 8
+    date: "2026-05-09"
+    model: "gpt-5.5"
+  vibe:
+    persona: 8
+    clawdNote: 8
+    vibe: 8
+    clarity: 9
+    narrative: 8
+    score: 8
+    date: "2026-05-09"
+    model: "gpt-5.5"
 ---
 
 import ClawdNote from '../../components/ClawdNote.astro';

--- a/src/content/posts/en-sd-19-20260409-lightning-talk-ralph-loop.mdx
+++ b/src/content/posts/en-sd-19-20260409-lightning-talk-ralph-loop.mdx
@@ -15,6 +15,23 @@ sourceUrl: "https://gu-log.vercel.app/"
 lang: "en"
 summary: "3-minute lightning talk slides. AI has read almost everything — but some concepts aren't in training data yet. What you know that AI doesn't = your leverage."
 tags: ["lightning-talk", "ralph-loop", "agentic-coding", "claude-code", "leverage"]
+scores:
+  tribunalVersion: 3
+  freshEyes:
+    readability: 9
+    firstImpression: 8
+    score: 8
+    date: "2026-05-09"
+    model: "gpt-5.5"
+  vibe:
+    persona: 8
+    clawdNote: 9
+    vibe: 8
+    clarity: 9
+    narrative: 8
+    score: 8
+    date: "2026-05-09"
+    model: "gpt-5.5"
 ---
 
 import ClawdNote from '../../components/ClawdNote.astro';

--- a/src/content/posts/en-sd-2-20260212-subagent-showdown-claude-code-vs-openclaw.mdx
+++ b/src/content/posts/en-sd-2-20260212-subagent-showdown-claude-code-vs-openclaw.mdx
@@ -22,6 +22,23 @@ sourceUrl: "https://gu-log.vercel.app/en/posts/en-sd-2-20260212-subagent-showdow
 summary: "Claude Code's Subagents and OpenClaw's sessions_spawn both let AI delegate work to clones, but their design philosophies couldn't be more different. One is an in-process coworker in your local dev tool; the other is a fully isolated field agent in a distributed messaging system. Full comparison across architecture, configuration, communication, tool permissions, and real-world scenarios."
 lang: "en"
 tags: ["openclaw", "claude-code", "sub-agent", "architecture"]
+scores:
+  tribunalVersion: 3
+  freshEyes:
+    readability: 8
+    firstImpression: 9
+    score: 8
+    date: "2026-05-09"
+    model: "gpt-5.5"
+  vibe:
+    persona: 8
+    clawdNote: 8
+    vibe: 8
+    clarity: 9
+    narrative: 8
+    score: 8
+    date: "2026-05-09"
+    model: "gpt-5.5"
 ---
 
 import ClawdNote from '../../components/ClawdNote.astro';

--- a/src/content/posts/en-sd-22-20260508-context-window-model-day.mdx
+++ b/src/content/posts/en-sd-22-20260508-context-window-model-day.mdx
@@ -19,6 +19,12 @@ scores:
     score: 9
     date: "2026-05-08"
     model: "gpt-5.5"
+  freshEyes:
+    readability: 9
+    firstImpression: 9
+    score: 9
+    date: "2026-05-09"
+    model: "gpt-5.5"
 ---
 
 import ClawdNote from '../../components/ClawdNote.astro';

--- a/src/content/posts/en-sd-23-20260510-ai-dota-teammates.mdx
+++ b/src/content/posts/en-sd-23-20260510-ai-dota-teammates.mdx
@@ -21,6 +21,23 @@ sourceUrl: "https://chatgpt.com/share/69ff7111-9ebc-83ab-b03a-f3cd7efe94a5"
 lang: "en"
 summary: "LLMs are not gods, and they are not just tools. They are more like DOTA teammates: great at last-hitting, occasionally great at feeding. The human job is not to fight AI for the same lane, but to cover taste, map awareness, context ownership, and strategic judgment."
 tags: ["shroomdog-original", "ai-collaboration", "agent", "llm", "mental-model"]
+scores:
+  tribunalVersion: 3
+  freshEyes:
+    readability: 8
+    firstImpression: 8
+    score: 8
+    date: "2026-05-09"
+    model: "gpt-5.5"
+  vibe:
+    persona: 9
+    clawdNote: 9
+    vibe: 9
+    clarity: 9
+    narrative: 9
+    score: 9
+    date: "2026-05-09"
+    model: "shroomdog-editorial-override"
 ---
 
 import ClawdNote from '../../components/ClawdNote.astro';

--- a/src/content/posts/en-sd-9-20260312-browser-automation-tool-comparison.mdx
+++ b/src/content/posts/en-sd-9-20260312-browser-automation-tool-comparison.mdx
@@ -22,6 +22,23 @@ sourceUrl: "https://gu-log.vercel.app/"
 lang: "en"
 summary: "We had Claude Opus run E2E tests on our own blog using Playwright, agent-browser, and Rodney. The surprise? The tool mattered way less than the prompt."
 tags: ["e2e-testing", "browser-automation", "ai-agents", "playwright", "developer-tools"]
+scores:
+  tribunalVersion: 3
+  freshEyes:
+    readability: 8
+    firstImpression: 8
+    score: 8
+    date: "2026-05-09"
+    model: "gpt-5.5"
+  vibe:
+    persona: 8
+    clawdNote: 8
+    vibe: 8
+    clarity: 9
+    narrative: 7
+    score: 8
+    date: "2026-05-09"
+    model: "gpt-5.5"
 ---
 
 import ClawdNote from '../../components/ClawdNote.astro';

--- a/src/content/posts/en-sqaa-levelup-journey.mdx
+++ b/src/content/posts/en-sqaa-levelup-journey.mdx
@@ -8,6 +8,23 @@ sourceUrl: "https://gu-log.vercel.app/posts/sqaa-levelup-journey"
 summary: "A Tech Lead uses his own blog as a training ground, spending two days learning 12 quality metrics with an AI tutor using RPG-style Level-Up teaching — from npm audit to LLM-as-Judge — while sub-agents implement everything in parallel. The real takeaway isn't the metrics, but a replicable methodology for AI-assisted learning."
 lang: "en"
 tags: ["sqaa", "quality", "ai", "tech-lead", "devops"]
+scores:
+  tribunalVersion: 3
+  freshEyes:
+    readability: 8
+    firstImpression: 8
+    score: 8
+    date: "2026-05-09"
+    model: "gpt-5.5"
+  vibe:
+    persona: 9
+    clawdNote: 8
+    vibe: 8
+    clarity: 8
+    narrative: 7
+    score: 8
+    date: "2026-05-09"
+    model: "gpt-5.5"
 ---
 
 import ClawdNote from '../../components/ClawdNote.astro';

--- a/src/content/posts/openclaw-talk-deep-dive.mdx
+++ b/src/content/posts/openclaw-talk-deep-dive.mdx
@@ -22,6 +22,23 @@ sourceUrl: "https://gu-log.vercel.app/posts/openclaw-talk-deep-dive"
 summary: "不只是普通的「如何使用 AI」教學，而是一場關於「如何用 AI 來管理 AI」的解剖報告。ShroomDog 分享如何在 Hetzner VPS 上架設 OpenClaw，並透過本機的 Claude Code 來管理遠端的 OpenClaw。三層式架構，充滿駭客精神與自動化魔法。涵蓋 Demo、安全架構、建置旅程、Auth Profile Rotation、Bug 追蹤偵探故事、踩坑精選與 Q&A。"
 lang: "zh-tw"
 tags: ["openclaw", "telegram", "vps", "devops", "automation"]
+scores:
+  tribunalVersion: 3
+  freshEyes:
+    readability: 8
+    firstImpression: 9
+    score: 8
+    date: "2026-05-09"
+    model: "gpt-5.5"
+  vibe:
+    persona: 9
+    clawdNote: 8
+    vibe: 8
+    clarity: 8
+    narrative: 7
+    score: 8
+    date: "2026-05-09"
+    model: "gpt-5.5"
 ---
 
 import ClawdNote from '../../components/ClawdNote.astro';

--- a/src/content/posts/sd-10-20260322-ralph-loop-quality-system.mdx
+++ b/src/content/posts/sd-10-20260322-ralph-loop-quality-system.mdx
@@ -15,6 +15,23 @@ sourceUrl: "https://gu-log.vercel.app/"
 lang: "zh-tw"
 summary: "gu-log 有 336 篇 AI 翻譯的文章。我們以為品質「還行」——直到用 multi-agent 系統認真評分後，發現 74% 需要改寫。這是我們怎麼設計評分系統、怎麼 overnight 跑完全站改寫、以及學到了什麼的故事。"
 tags: ["ai-quality", "llm-as-judge", "agentic-coding", "ralph-loop", "multi-agent", "content-quality"]
+scores:
+  tribunalVersion: 3
+  freshEyes:
+    readability: 8
+    firstImpression: 9
+    score: 8
+    date: "2026-05-09"
+    model: "gpt-5.5"
+  vibe:
+    persona: 9
+    clawdNote: 9
+    vibe: 8
+    clarity: 9
+    narrative: 9
+    score: 8
+    date: "2026-05-09"
+    model: "gpt-5.5"
 ---
 
 import ClawdNote from '../../components/ClawdNote.astro';

--- a/src/content/posts/sd-11-20260402-ai-agent-memory-architecture.mdx
+++ b/src/content/posts/sd-11-20260402-ai-agent-memory-architecture.mdx
@@ -18,6 +18,23 @@ tags: ["shroomdog-original", "ai-agent", "memory-architecture", "claude-code", "
 series:
   name: "Claude Code Deep Dive"
   order: 1
+scores:
+  tribunalVersion: 3
+  freshEyes:
+    readability: 8
+    firstImpression: 9
+    score: 8
+    date: "2026-05-09"
+    model: "gpt-5.5"
+  vibe:
+    persona: 9
+    clawdNote: 9
+    vibe: 9
+    clarity: 8
+    narrative: 9
+    score: 8
+    date: "2026-05-09"
+    model: "gpt-5.5"
 ---
 
 import ClawdNote from '../../components/ClawdNote.astro';

--- a/src/content/posts/sd-12-20260402-claude-code-bad-patterns.mdx
+++ b/src/content/posts/sd-12-20260402-claude-code-bad-patterns.mdx
@@ -18,6 +18,23 @@ tags: ["shroomdog-original", "ai-engineering", "code-quality", "agentic-coding",
 series:
   name: "Claude Code Deep Dive"
   order: 2
+scores:
+  tribunalVersion: 3
+  freshEyes:
+    readability: 8
+    firstImpression: 8
+    score: 8
+    date: "2026-05-09"
+    model: "gpt-5.5"
+  vibe:
+    persona: 8
+    clawdNote: 8
+    vibe: 8
+    clarity: 8
+    narrative: 8
+    score: 8
+    date: "2026-05-09"
+    model: "gpt-5.5"
 ---
 
 import ClawdNote from '../../components/ClawdNote.astro';

--- a/src/content/posts/sd-13-20260402-prompt-cache-economics.mdx
+++ b/src/content/posts/sd-13-20260402-prompt-cache-economics.mdx
@@ -18,6 +18,23 @@ tags: ["shroomdog-original", "prompt-engineering", "ai-costs", "claude-code", "p
 series:
   name: "Claude Code Deep Dive"
   order: 3
+scores:
+  tribunalVersion: 3
+  freshEyes:
+    readability: 8
+    firstImpression: 8
+    score: 8
+    date: "2026-05-09"
+    model: "gpt-5.5"
+  vibe:
+    persona: 8
+    clawdNote: 9
+    vibe: 8
+    clarity: 8
+    narrative: 8
+    score: 8
+    date: "2026-05-09"
+    model: "gpt-5.5"
 ---
 
 import ClawdNote from '../../components/ClawdNote.astro';

--- a/src/content/posts/sd-14-20260402-ai-agent-initiative-problem.mdx
+++ b/src/content/posts/sd-14-20260402-ai-agent-initiative-problem.mdx
@@ -18,6 +18,23 @@ tags: ["shroomdog-original", "ai-agent", "autonomous-agent", "agentic-systems", 
 series:
   name: "Claude Code Deep Dive"
   order: 4
+scores:
+  tribunalVersion: 3
+  freshEyes:
+    readability: 9
+    firstImpression: 9
+    score: 9
+    date: "2026-05-09"
+    model: "gpt-5.5"
+  vibe:
+    persona: 9
+    clawdNote: 8
+    vibe: 8
+    clarity: 9
+    narrative: 8
+    score: 8
+    date: "2026-05-09"
+    model: "gpt-5.5"
 ---
 
 import ClawdNote from '../../components/ClawdNote.astro';

--- a/src/content/posts/sd-15-20260402-ai-attribution-ethics.mdx
+++ b/src/content/posts/sd-15-20260402-ai-attribution-ethics.mdx
@@ -18,6 +18,23 @@ tags: ["shroomdog-original", "ai-attribution", "ai-ethics", "open-source", "clau
 series:
   name: "Claude Code Deep Dive"
   order: 5
+scores:
+  tribunalVersion: 3
+  freshEyes:
+    readability: 8
+    firstImpression: 9
+    score: 8
+    date: "2026-05-09"
+    model: "gpt-5.5"
+  vibe:
+    persona: 8
+    clawdNote: 9
+    vibe: 8
+    clarity: 8
+    narrative: 8
+    score: 8
+    date: "2026-05-09"
+    model: "gpt-5.5"
 ---
 
 import ClawdNote from '../../components/ClawdNote.astro';

--- a/src/content/posts/sd-16-20260402-can-ai-test-itself.mdx
+++ b/src/content/posts/sd-16-20260402-can-ai-test-itself.mdx
@@ -18,6 +18,23 @@ tags: ["shroomdog-original", "testing", "ai-agents", "claude-code", "self-testin
 series:
   name: "Claude Code Deep Dive"
   order: 6
+scores:
+  tribunalVersion: 3
+  freshEyes:
+    readability: 8
+    firstImpression: 9
+    score: 8
+    date: "2026-05-09"
+    model: "gpt-5.5"
+  vibe:
+    persona: 9
+    clawdNote: 8
+    vibe: 8
+    clarity: 9
+    narrative: 8
+    score: 8
+    date: "2026-05-09"
+    model: "gpt-5.5"
 ---
 
 import ClawdNote from '../../components/ClawdNote.astro';

--- a/src/content/posts/sd-17-20260402-is-it-worth-the-time.mdx
+++ b/src/content/posts/sd-17-20260402-is-it-worth-the-time.mdx
@@ -8,6 +8,23 @@ sourceUrl: "https://gu-log.vercel.app/"
 lang: "zh-tw"
 summary: "xkcd #1205 那張經典圖表，教了整整一代工程師怎麼算『值不值得自動化』。但 AI 把等式裡最貴的變數直接砍掉了：現在回本的不只是時間，更多時候是 cognitive load。"
 tags: ["shroomdog-originals", "automation", "ai-agents", "productivity", "cognitive-load", "claude-code"]
+scores:
+  tribunalVersion: 3
+  freshEyes:
+    readability: 9
+    firstImpression: 9
+    score: 9
+    date: "2026-05-09"
+    model: "gpt-5.5"
+  vibe:
+    persona: 9
+    clawdNote: 9
+    vibe: 9
+    clarity: 9
+    narrative: 9
+    score: 9
+    date: "2026-05-09"
+    model: "gpt-5.5"
 ---
 
 import ClawdNote from '../../components/ClawdNote.astro';

--- a/src/content/posts/sd-18-20260403-permission-engineering-for-ai-agents.mdx
+++ b/src/content/posts/sd-18-20260403-permission-engineering-for-ai-agents.mdx
@@ -8,6 +8,23 @@ sourceUrl: "https://gu-log.vercel.app/"
 lang: "zh-tw"
 summary: "GenAI App Engineer 做到後來根本是 Permission Engineer。AI agent 的能力天花板不是智力，是你願意給它多少權限。每多一份權限，能力跟風險同時放大。這篇是從每天跟 AI agent 共事的角度，聊聊為什麼 permission management 是 AI 時代最被低估的核心能力。"
 tags: ["shroomdog-originals", "ai-agents", "security", "permissions", "devops", "genai"]
+scores:
+  tribunalVersion: 3
+  freshEyes:
+    readability: 8
+    firstImpression: 9
+    score: 8
+    date: "2026-05-09"
+    model: "gpt-5.5"
+  vibe:
+    persona: 8
+    clawdNote: 8
+    vibe: 8
+    clarity: 9
+    narrative: 8
+    score: 8
+    date: "2026-05-09"
+    model: "gpt-5.5"
 ---
 
 import ClawdNote from '../../components/ClawdNote.astro';

--- a/src/content/posts/sd-19-20260409-lightning-talk-ralph-loop.mdx
+++ b/src/content/posts/sd-19-20260409-lightning-talk-ralph-loop.mdx
@@ -16,6 +16,7 @@ lang: "zh-tw"
 summary: "3 分鐘 lightning talk 投影片。AI 什麼都讀過，但有些概念它還不知道——你知道、它不知道，這就是你的槓桿。"
 tags: ["lightning-talk", "ralph-loop", "agentic-coding", "claude-code", "leverage"]
 scores:
+  tribunalVersion: 3
   ralph:
     p: 8
     c: 9
@@ -23,6 +24,21 @@ scores:
     score: 8
     date: "2026-04-09"
     model: "claude-opus-4-6"
+  freshEyes:
+    readability: 9
+    firstImpression: 8
+    score: 8
+    date: "2026-05-09"
+    model: "gpt-5.5"
+  vibe:
+    persona: 8
+    clawdNote: 9
+    vibe: 8
+    clarity: 9
+    narrative: 8
+    score: 8
+    date: "2026-05-09"
+    model: "gpt-5.5"
 ---
 
 import ClawdNote from '../../components/ClawdNote.astro';

--- a/src/content/posts/sd-2-20260212-subagent-showdown-claude-code-vs-openclaw.mdx
+++ b/src/content/posts/sd-2-20260212-subagent-showdown-claude-code-vs-openclaw.mdx
@@ -22,6 +22,23 @@ sourceUrl: "https://gu-log.vercel.app/posts/sd-2-20260212-subagent-showdown-clau
 summary: "Claude Code 的 Subagent 和 OpenClaw 的 sessions_spawn 都能讓 AI 派分身做事，但設計哲學完全不同。一個是本地開發工具的 in-process 分身，一個是分散式 messaging-native 的獨立 session。這篇從架構、設定、溝通方式、工具權限到實戰場景，全面比較兩套 Sub-Agent 系統。"
 lang: "zh-tw"
 tags: ["openclaw", "claude-code", "sub-agent", "architecture"]
+scores:
+  tribunalVersion: 3
+  freshEyes:
+    readability: 8
+    firstImpression: 9
+    score: 8
+    date: "2026-05-09"
+    model: "gpt-5.5"
+  vibe:
+    persona: 8
+    clawdNote: 8
+    vibe: 8
+    clarity: 9
+    narrative: 8
+    score: 8
+    date: "2026-05-09"
+    model: "gpt-5.5"
 ---
 
 import ClawdNote from '../../components/ClawdNote.astro';

--- a/src/content/posts/sd-22-20260508-context-window-model-day.mdx
+++ b/src/content/posts/sd-22-20260508-context-window-model-day.mdx
@@ -19,6 +19,12 @@ scores:
     score: 9
     date: "2026-05-08"
     model: "gpt-5.5"
+  freshEyes:
+    readability: 9
+    firstImpression: 9
+    score: 9
+    date: "2026-05-09"
+    model: "gpt-5.5"
 ---
 
 import ClawdNote from '../../components/ClawdNote.astro';

--- a/src/content/posts/sd-23-20260510-ai-dota-teammates.mdx
+++ b/src/content/posts/sd-23-20260510-ai-dota-teammates.mdx
@@ -18,6 +18,23 @@ sourceUrl: "https://chatgpt.com/share/69ff7111-9ebc-83ab-b03a-f3cd7efe94a5"
 lang: "zh-tw"
 summary: "LLM 不是神，也不只是工具，比較像 DOTA 裡會補刀也會送頭的隊友。人類的價值不是跟 AI 搶同一路，而是補上 taste、map awareness、context ownership、strategic judgment，讓整隊勝率變高。"
 tags: ["shroomdog-original", "ai-collaboration", "agent", "llm", "mental-model"]
+scores:
+  tribunalVersion: 3
+  freshEyes:
+    readability: 8
+    firstImpression: 8
+    score: 8
+    date: "2026-05-09"
+    model: "gpt-5.5"
+  vibe:
+    persona: 9
+    clawdNote: 9
+    vibe: 9
+    clarity: 9
+    narrative: 9
+    score: 9
+    date: "2026-05-09"
+    model: "shroomdog-editorial-override"
 ---
 
 import ClawdNote from '../../components/ClawdNote.astro';

--- a/src/content/posts/sd-8-20260307-openclaw-survival-guide-for-non-engineers.mdx
+++ b/src/content/posts/sd-8-20260307-openclaw-survival-guide-for-non-engineers.mdx
@@ -11,6 +11,23 @@ sourceUrl: "https://gu-log.vercel.app/posts/sd-8-20260307-openclaw-survival-guid
 lang: "zh-tw"
 summary: "你的 PM 朋友問你「OpenClaw 是什麼？」——這篇就是你轉給他的那篇。從 ChatGPT 到 AI Agent 的信任光譜、真實的爆炸故事、三種不同的玩法。不需要會寫 code，但需要想清楚一件事：你願意信任 AI 到什麼程度？"
 tags: ["openclaw", "ai-agents", "trust", "non-technical", "cowork", "beginner"]
+scores:
+  tribunalVersion: 3
+  freshEyes:
+    readability: 9
+    firstImpression: 9
+    score: 9
+    date: "2026-05-09"
+    model: "gpt-5.5"
+  vibe:
+    persona: 9
+    clawdNote: 9
+    vibe: 9
+    clarity: 9
+    narrative: 9
+    score: 9
+    date: "2026-05-09"
+    model: "gpt-5.5"
 ---
 
 import ClawdNote from '../../components/ClawdNote.astro';

--- a/src/content/posts/sd-9-20260312-browser-automation-tool-comparison.mdx
+++ b/src/content/posts/sd-9-20260312-browser-automation-tool-comparison.mdx
@@ -22,6 +22,23 @@ sourceUrl: "https://gu-log.vercel.app/"
 lang: "zh-tw"
 summary: "我們讓 Claude Opus 分別用 Playwright、agent-browser、Rodney 三個工具對自家 blog 跑 E2E 測試。結果發現：工具只是載具，prompt 品質才是方向盤。"
 tags: ["e2e-testing", "browser-automation", "ai-agents", "playwright", "developer-tools"]
+scores:
+  tribunalVersion: 3
+  freshEyes:
+    readability: 8
+    firstImpression: 8
+    score: 8
+    date: "2026-05-09"
+    model: "gpt-5.5"
+  vibe:
+    persona: 8
+    clawdNote: 8
+    vibe: 8
+    clarity: 9
+    narrative: 7
+    score: 8
+    date: "2026-05-09"
+    model: "gpt-5.5"
 ---
 
 import ClawdNote from '../../components/ClawdNote.astro';

--- a/src/content/posts/sqaa-levelup-journey.mdx
+++ b/src/content/posts/sqaa-levelup-journey.mdx
@@ -8,6 +8,23 @@ sourceUrl: "https://gu-log.vercel.app/posts/sqaa-levelup-journey"
 summary: "Tech Lead 用自己的部落格當練兵場，花兩天跟 AI 助手用 Level-Up 互動教學打完 12 關品質指標，從 npm audit 到 LLM-as-Judge，同時讓 sub-agents 平行實作。學到的不只是指標，還有一套可複製的 AI 輔助學習方法論。"
 lang: "zh-tw"
 tags: ["sqaa", "quality", "ai", "tech-lead", "devops"]
+scores:
+  tribunalVersion: 3
+  freshEyes:
+    readability: 8
+    firstImpression: 8
+    score: 8
+    date: "2026-05-09"
+    model: "gpt-5.5"
+  vibe:
+    persona: 9
+    clawdNote: 8
+    vibe: 8
+    clarity: 8
+    narrative: 7
+    score: 8
+    date: "2026-05-09"
+    model: "gpt-5.5"
 ---
 
 import ClawdNote from '../../components/ClawdNote.astro';


### PR DESCRIPTION
## Summary
- Add missing freshEyes + vibe score blocks to every existing SD post and counterpart that exists
- Add a deterministic validator gate so future ticketId=SD posts must include both reader score blocks
- Set SD-23 vibe score to 9 via ShroomDog editorial override for DOTA-audience sharing

## Validation
- node scripts/validate-posts.mjs
- node scripts/validate-posts.mjs --check-duplicates
- pnpm run format:check
- pnpm run lint
- pnpm run build