### PR TITLE
Fix SD ChatGPT inspiration source label

### DIFF
--- a/src/pages/en/posts/[...slug].astro
+++ b/src/pages/en/posts/[...slug].astro
@@ -41,6 +41,11 @@ const isClawdPicks = post.data.tags?.includes('clawd-picks');
 const ticketId = post.data.ticketId;
 const ticketPrefix = ticketId?.split('-')[0] || '';
 const isLevelUp = ticketId?.startsWith('Lv-') ?? false;
+const isShroomDogOriginal = ticketId?.startsWith('SD-') ?? false;
+const isChatGptShareSource = post.data.sourceUrl.startsWith('https://chatgpt.com/share/');
+const showSourceCitation = !isLevelUp && (!isShroomDogOriginal || isChatGptShareSource);
+const sourceCitationLabel =
+  isShroomDogOriginal && isChatGptShareSource ? 'Inspiration source' : 'Original source';
 
 const postVersion = getPostVersion(post.id);
 const postStatus = resolvePostStatus(post, allPosts);
@@ -109,9 +114,9 @@ const ticketLabel = ticketLabels[ticketPrefix] || '';
     }
 
     {
-      !post.data.ticketId?.startsWith('SD-') && !post.data.ticketId?.startsWith('Lv-') && (
+      showSourceCitation && (
         <div class="source-citation">
-          <strong>Original source:</strong>
+          <strong>{sourceCitationLabel}:</strong>
           <a href={post.data.sourceUrl} target="_blank" rel="noopener">
             {post.data.source}
           </a>

--- a/src/pages/posts/[...slug].astro
+++ b/src/pages/posts/[...slug].astro
@@ -38,6 +38,10 @@ const isClawdPicks = post.data.tags?.includes('clawd-picks');
 const ticketId = post.data.ticketId;
 const ticketPrefix = ticketId?.split('-')[0] || '';
 const isLevelUp = ticketId?.startsWith('Lv-') ?? false;
+const isShroomDogOriginal = ticketId?.startsWith('SD-') ?? false;
+const isChatGptShareSource = post.data.sourceUrl.startsWith('https://chatgpt.com/share/');
+const showSourceCitation = !isLevelUp && (!isShroomDogOriginal || isChatGptShareSource);
+const sourceCitationLabel = isShroomDogOriginal && isChatGptShareSource ? '靈感來源' : '原文出處';
 
 const postVersion = getPostVersion(post.id);
 const postStatus = resolvePostStatus(post, allPosts);
@@ -106,9 +110,9 @@ const ticketLabel = ticketLabels[ticketPrefix] || '';
     }
 
     {
-      !post.data.ticketId?.startsWith('SD-') && !post.data.ticketId?.startsWith('Lv-') && (
+      showSourceCitation && (
         <div class="source-citation">
-          <strong>原文出處：</strong>
+          <strong>{sourceCitationLabel}：</strong>
           <a href={post.data.sourceUrl} target="_blank" rel="noopener">
             {post.data.source}
           </a>


### PR DESCRIPTION
## Summary
- Show the source citation block for SD originals when the source is a ChatGPT share URL.
- Label those as 靈感來源 / Inspiration source instead of 原文出處 / Original source.
- Keep existing SP/CP source labels unchanged and keep Lv hidden.

## Validation
- pnpm run build
- pnpm run validate:posts (passes with existing warnings)