### PR TITLE
Fix source citation word wrapping

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -343,7 +343,9 @@ blockquote.codex-note br {
 }
 
 .source-citation a {
-  word-break: break-all;
+  word-break: normal;
+  overflow-wrap: break-word;
+  hyphens: none;
 }
 
 /* Article meta */


### PR DESCRIPTION
## Summary
- Stop source citation links from using break-all wrapping.
- Preserve whole English words while still allowing very long strings to wrap when needed.

## Validation
- pnpm run build
- pnpm run validate:posts