### PR TITLE
Make tribunal quota loop OpenAI-aware

### DIFF
--- a/.codex/agents/tribunal-writer.toml
+++ b/.codex/agents/tribunal-writer.toml
@@ -16,5 +16,25 @@ feedback during a task, append it there with feedback/context/fix/lesson.
 Only rewrite when scripts/tribunal.sh explicitly asks for a rewrite. Preserve
 frontmatter, source attribution, ClawdNote components, and already-passing
 dimensions. Do not perform broad style rewrites when targeted fixes are enough.
-"""
 
+Codex/GPT-5.5 operating rules:
+- You are spawned from an isolated temporary directory. Do not assume relative
+  paths resolve to the repo. Use the Repo root and absolute paths in the task.
+- Act like a surgical editor, not a second author. Fix the failed judge
+  dimensions; preserve sections, working jokes, factual claims, source links,
+  frontmatter, and already-passing dimensions unless the judge/build evidence
+  explicitly says they are the problem.
+- GPT-5.5 is good at broad rewrites; resist that instinct. Prefer the smallest
+  coherent patch that can make the next judge pass.
+- Never fabricate facts, URLs, citations, source quotes, or internal links. If a
+  missing citation is required, use only links already present in the post or
+  clearly relevant gu-log posts you actually read.
+- Preserve all MDX components and imports. Do not remove ClawdNote components;
+  only edit ClawdNote text when the failed dimension specifically targets
+  ClawdNote quality or the build error points there.
+- Keep zh-tw posts natural 台灣中文. Preserve canonical technical terms, but
+  remove gratuitous 晶晶體 filler when editing surrounding prose.
+- Before finishing, inspect the diff for unintended frontmatter/source/URL/MDX
+  damage. Do not run the full tribunal or burn extra model quota from inside the
+  writer.
+"""

--- a/scripts/tests/test-tribunal-openai-quota-controller.sh
+++ b/scripts/tests/test-tribunal-openai-quota-controller.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Static/no-token regression tests for Tribunal v4 OpenAI-aware quota pacing.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TRIBUNAL_LOOP="$ROOT_DIR/scripts/tribunal-quota-loop.sh"
+
+fail() { echo "x $*" >&2; exit 1; }
+pass() { echo "ok $*"; }
+
+run_case() {
+  local json="$1"
+  local active_workers="${2:-0}"
+  local tmp
+  tmp=$(mktemp)
+  cat > "$tmp" <<EOF
+#!/usr/bin/env bash
+if [ "\${1:-}" = "--json" ]; then
+  cat <<'JSON'
+$json
+JSON
+else
+  echo 'fake usage-monitor: only --json is supported' >&2
+  exit 2
+fi
+EOF
+  chmod +x "$tmp"
+  USAGE_MONITOR="$tmp" \
+    QUOTA_FLOOR=10 \
+    ARTICLE_COST_PCT=1 \
+    AVG_ARTICLE_TIME=1800 \
+    MIN_COOLDOWN=10 \
+    MAX_COOLDOWN=1800 \
+    bash "$TRIBUNAL_LOOP" --controller-once "$active_workers"
+  rm -f "$tmp"
+}
+
+full_openai='[{"provider":"openai","status":"ok","session_remaining_pct":100,"session_reset_min":300,"weekly_remaining_pct":100,"weekly_reset_hr":168}]'
+out=$(run_case "$full_openai")
+[ "$out" = "6720|0|seven_day|weekly_debt" ] || fail "full OpenAI quota should pace by weekly projection; got: $out"
+pass "OpenAI 5hr/weekly readings bind to projected weekly burn line"
+
+low_5hr='[{"provider":"openai","status":"ok","session_remaining_pct":20,"session_reset_min":240,"weekly_remaining_pct":100,"weekly_reset_hr":168}]'
+out=$(run_case "$low_5hr")
+[ "$out" = "12600|0|five_hour|five_hour_debt" ] || fail "low 5hr bucket should sleep until projected 5hr reserve catches up; got: $out"
+pass "OpenAI low 5hr quota sleeps until projected short-window budget catches up"
+
+surplus_weekly='[{"provider":"openai","status":"ok","session_remaining_pct":100,"session_reset_min":60,"weekly_remaining_pct":100,"weekly_reset_hr":24}]'
+out=$(run_case "$surplus_weekly")
+[ "$out" = "960|1|seven_day|pacing" ] || fail "surplus weekly quota should pace instead of debt-sleep; got: $out"
+pass "OpenAI surplus quota uses normal pacing rather than debt stop"
+
+with_inflight='[{"provider":"openai","status":"ok","session_remaining_pct":100,"session_reset_min":300,"weekly_remaining_pct":100,"weekly_reset_hr":168}]'
+out=$(run_case "$with_inflight" 2)
+[ "$out" = "20160|0|seven_day|weekly_debt" ] || fail "in-flight workers should be charged before opening another slot; got: $out"
+pass "in-flight workers are charged against projected quota before dispatch"
+
+claude_fixture='[{"provider":"claude","status":"ok","five_hr_remaining_pct":100,"five_hr_reset":"5.0 小時","weekly_remaining_pct":100,"weekly_reset":"7.0 天"}]'
+out=$(run_case "$claude_fixture")
+[ "$out" = "6720|0|seven_day|weekly_debt" ] || fail "legacy Claude fixture parser regressed; got: $out"
+pass "legacy Claude quota fixture remains parseable for dev/backcompat"

--- a/scripts/tests/test-tribunal-safety-contract.sh
+++ b/scripts/tests/test-tribunal-safety-contract.sh
@@ -8,6 +8,8 @@ ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 TRIBUNAL="$ROOT_DIR/scripts/tribunal.sh"
 VIBE="$ROOT_DIR/scripts/vibe-scorer.sh"
 HELPERS="$ROOT_DIR/scripts/tribunal-helpers.sh"
+CODEX_AGENTS_DIR="$ROOT_DIR/.codex/agents"
+CODEX_WRITER="$CODEX_AGENTS_DIR/tribunal-writer.toml"
 
 fail() { echo "x $*" >&2; exit 1; }
 pass() { echo "ok $*"; }
@@ -70,6 +72,32 @@ if ! grep -q 'Ignore YAML' "$HELPERS" || ! grep -q 'frontmatter runtime fields' 
   fail "Codex tribunal helper does not ignore Claude Code frontmatter runtime"
 fi
 pass "Codex agent specs are separated from Claude Code frontmatter"
+
+if ! grep -q -- '--model gpt-5.5' "$HELPERS"; then
+  fail "Codex tribunal helper is not pinned to GPT-5.5"
+fi
+if ! grep -q 'local model_id="gpt-5.5"' "$TRIBUNAL"; then
+  fail "Tribunal frontmatter/logging model_id is not pinned to GPT-5.5"
+fi
+unpinned_agents=$(grep -L '^model = "gpt-5.5"' "$CODEX_AGENTS_DIR"/*.toml || true)
+if [ -n "$unpinned_agents" ]; then
+  fail "One or more Codex tribunal agent specs are not pinned to GPT-5.5: $unpinned_agents"
+fi
+pass "Tribunal v4 Codex model pinning remains GPT-5.5 end-to-end"
+
+if ! grep -q 'temporary directory' "$CODEX_WRITER" || ! grep -q 'surgical editor' "$CODEX_WRITER"; then
+  fail "Codex tribunal writer prompt lacks GPT-5.5 temp-dir/surgical-edit guardrails"
+fi
+if ! grep -q 'Do not run the full tribunal' "$CODEX_WRITER"; then
+  fail "Codex tribunal writer prompt does not prohibit nested tribunal/quota-burning calls"
+fi
+if ! grep -q 'Use absolute paths under the Repo root' "$TRIBUNAL"; then
+  fail "Tribunal writer task prompt does not force absolute repo paths"
+fi
+if grep -q 'WRITING_GUIDELINES.md' "$TRIBUNAL" "$CODEX_WRITER"; then
+  fail "Tribunal writer prompt references removed WRITING_GUIDELINES.md"
+fi
+pass "Codex tribunal writer prompt is tuned for GPT-5.5 isolated execution"
 
 if ! grep -q 'tribunal-assert-pass-artifacts.sh' "$TRIBUNAL"; then
   fail "PASS artifact guard is not wired into commit_progress"

--- a/scripts/tribunal-quota-loop.sh
+++ b/scripts/tribunal-quota-loop.sh
@@ -5,7 +5,7 @@
 # 3.2 at /bin/bash, so the shebang picks up whichever bash is on PATH
 # (typically Homebrew bash on Mac, system bash 5.x on Linux).
 #
-# Checks Claude API quota via usage-monitor.sh and adapts processing speed.
+# Checks OpenAI/Codex quota via usage-monitor.sh and adapts processing speed.
 # Never burns below QUOTA_FLOOR% (human personal use reserve).
 #
 # Strategy: closed-loop feedback controller.
@@ -36,20 +36,22 @@ POSTS_DIR="$ROOT_DIR/src/content/posts"
 PROGRESS_FILE="$ROOT_DIR/scores/tribunal-progress.json"
 LOG_DIR="$ROOT_DIR/.score-loop/logs"
 LOG_FILE="$LOG_DIR/tribunal-quota-loop-$(date +%Y%m%d-%H%M%S).log"
-USAGE_MONITOR="$HOME/clawd/scripts/usage-monitor.sh"
-QUOTA_FLOOR=3
+USAGE_MONITOR="${USAGE_MONITOR:-$HOME/clawd/scripts/usage-monitor.sh}"
+QUOTA_FLOOR="${QUOTA_FLOOR:-10}"
 DRY_RUN=false
 WORKERS=1   # Phase 2 supervisor: set to >1 for parallel workers
 LEGACY_QUOTA=false
+CONTROLLER_ONCE=""
 
 # ─── Closed-loop controller constants ────────────────────────────────────────
-MIN_COOLDOWN=10        # seconds — floor for inter-article wait
-MAX_COOLDOWN=1800      # seconds (30 min) — short-window/fallback ceiling; weekly debt can sleep longer
-WEEKLY_WINDOW_SEC=604800 # seconds (7 days) — Claude weekly window length for projected-quota scheduler
-ARTICLE_COST_PCT=0.5   # % per article (cold start; EMA calibrates after ~5 articles)
-AVG_ARTICLE_TIME=1800  # seconds (~30 min average per article, for worker count estimation)
-EMA_ALPHA=0.3          # calibration smoothing factor
-EXTRA_USAGE_LIMIT=1.0  # disabled — let 5hr/7day curves control pacing
+MIN_COOLDOWN="${MIN_COOLDOWN:-10}"        # seconds — floor for inter-article wait
+MAX_COOLDOWN="${MAX_COOLDOWN:-1800}"      # seconds (30 min) — normal pacing ceiling; projected debt can sleep longer
+FIVE_HOUR_WINDOW_SEC="${FIVE_HOUR_WINDOW_SEC:-18000}" # seconds (5 hours) — OpenAI short-window quota length
+WEEKLY_WINDOW_SEC="${WEEKLY_WINDOW_SEC:-604800}" # seconds (7 days) — OpenAI weekly quota length
+ARTICLE_COST_PCT="${ARTICLE_COST_PCT:-0.5}"   # % per article (cold start; EMA calibrates after ~5 articles)
+AVG_ARTICLE_TIME="${AVG_ARTICLE_TIME:-1800}"  # seconds (~30 min average per article, for worker count estimation)
+EMA_ALPHA="${EMA_ALPHA:-0.3}"          # calibration smoothing factor
+EXTRA_USAGE_LIMIT="${EXTRA_USAGE_LIMIT:-1.0}"  # disabled — let 5hr/7day curves control pacing
 QUOTA_HISTORY_FILE="$ROOT_DIR/.score-loop/state/quota-history.jsonl"
 QUOTA_CONTROLLER_STATE="$ROOT_DIR/.score-loop/state/quota-controller.json"
 
@@ -61,6 +63,7 @@ while [ $# -gt 0 ]; do
     --dry-run) DRY_RUN=true; shift ;;
     --workers) WORKERS="$2"; shift 2 ;;
     --legacy-quota) LEGACY_QUOTA=true; shift ;;
+    --controller-once) CONTROLLER_ONCE="${2:-0}"; shift 2 ;;
     *) echo "Unknown arg: $1" >&2; exit 1 ;;
   esac
 done
@@ -312,6 +315,10 @@ legacy_compute_tier_name() {
 
 # ─── Quota: Closed-loop controller ───────────────────────────────────────────
 # Parses usage-monitor.sh --json output into dual-window quota readings.
+# Preferred provider is OpenAI/Codex v4:
+#   session_remaining_pct + session_reset_min   → 5hr bucket
+#   weekly_remaining_pct  + weekly_reset_hr     → weekly bucket
+# Claude parsing is retained only for --legacy-quota / historical dev fixtures.
 # Outputs a single line of pipe-separated values:
 #   five_hr_pct|five_hr_resets_sec|seven_day_pct|seven_day_resets_sec|extra_used|extra_limit|extra_enabled
 # Returns exit code 1 on error.
@@ -355,6 +362,21 @@ def parse_reset_to_sec(s):
 
 try:
     data = json.loads(sys.argv[1])
+    # Tribunal v4 runs on OpenAI/Codex GPT-5.5. usage-monitor exposes the
+    # short OpenAI bucket as session_remaining_pct/session_reset_min and the
+    # long bucket as weekly_remaining_pct/weekly_reset_hr.
+    for p in data:
+        if p.get('provider') == 'openai' and p.get('status') == 'ok':
+            five_pct = p.get('session_remaining_pct', 0)
+            five_reset_sec = int(float(p.get('session_reset_min', 0)) * 60)
+            seven_pct = p.get('weekly_remaining_pct', 0)
+            seven_reset_sec = int(float(p.get('weekly_reset_hr', 0)) * 3600)
+            print(f'{five_pct}|{five_reset_sec}|{seven_pct}|{seven_reset_sec}|0|0|0')
+            sys.exit(0)
+
+    # Backward-compatible parser for older Claude fixtures / --legacy-quota
+    # development flows. Production should not reach this branch now that
+    # Claude subscription quota is disabled.
     for p in data:
         if p.get('provider') == 'claude' and p.get('status') == 'ok':
             five_pct = p.get('five_hr_remaining_pct', 0)
@@ -407,6 +429,7 @@ article_cost = float('$ARTICLE_COST_PCT')
 min_cd = float('$MIN_COOLDOWN')
 max_cd = float('$MAX_COOLDOWN')
 extra_threshold = float('$EXTRA_USAGE_LIMIT')
+five_window_sec = float('$FIVE_HOUR_WINDOW_SEC')
 weekly_window_sec = float('$WEEKLY_WINDOW_SEC')
 
 # Extra usage safety valve
@@ -417,18 +440,37 @@ if extra_enabled and extra_limit > 0 and (extra_used / extra_limit) > extra_thre
 # Feedforward compensation: subtract in-flight workers' estimated cost
 inflight_cost = active_workers * article_cost
 
-# Weekly projected-quota scheduler.
-# The weekly bucket is shared with the human. Treat it as a budget curve, not a
-# capped retry loop: if the remaining quota only covers a later slice of the
-# week, pause until one article can be spent while still leaving projected quota
-# for the rest of the weekly window.
-if seven_reset_sec > 0 and weekly_window_sec > 0:
-    projected_after_one = seven_pct - inflight_cost - article_cost
-    target_reset_sec = max(0.0, projected_after_one / 100.0 * weekly_window_sec)
-    debt_sleep = int(seven_reset_sec - target_reset_sec)
-    if debt_sleep > min_cd:
-        print(f'{debt_sleep}|0|seven_day|weekly_debt')
-        sys.exit(0)
+# Projected-quota scheduler.
+# Treat each quota bucket as a time budget curve, not a binary GO/STOP gate.
+# Before spending the next article, ask: after paying in-flight work + this
+# article, would remaining quota still be at/above the projected reserve line
+# for the time left in this window?
+#
+# Ideal line with floor:
+#   ideal_remaining(t) = floor + (100 - floor) * reset_sec / window_sec
+# If spending now would put us below that line, sleep until the line catches
+# down to our projected post-spend quota. This can sleep much longer than
+# MAX_COOLDOWN; that is intentional debt repayment, not ordinary pacing.
+def projected_debt_sleep(remaining_pct, reset_sec, window_sec):
+    if reset_sec <= 0 or window_sec <= 0:
+        return 0
+    projected_after_one = remaining_pct - inflight_cost - article_cost
+    if projected_after_one <= floor:
+        return int(reset_sec)
+    usable_after_one = max(0.0, projected_after_one - floor)
+    usable_span = max(0.0001, 100.0 - floor)
+    target_reset_sec = min(window_sec, usable_after_one / usable_span * window_sec)
+    return max(0, int(reset_sec - target_reset_sec))
+
+debt_5hr = projected_debt_sleep(five_pct, five_reset_sec, five_window_sec)
+debt_7day = projected_debt_sleep(seven_pct, seven_reset_sec, weekly_window_sec)
+
+if debt_5hr > min_cd or debt_7day > min_cd:
+    if debt_5hr >= debt_7day:
+        print(f'{debt_5hr}|0|five_hour|five_hour_debt')
+    else:
+        print(f'{debt_7day}|0|seven_day|weekly_debt')
+    sys.exit(0)
 
 def compute_window(remaining_pct, reset_sec, inflight_cost):
     \"\"\"Return (cooldown_sec, is_active).
@@ -838,6 +880,11 @@ get_unscored_articles() {
 }
 
 # ─── Dry Run ──────────────────────────────────────────────────────────────────
+if [ -n "$CONTROLLER_ONCE" ]; then
+  controller_tick "$CONTROLLER_ONCE"
+  exit 0
+fi
+
 if [ "$DRY_RUN" = true ]; then
   tlog "=== Dry-run mode ==="
   mapfile -t ARTICLES < <(get_unscored_articles)

--- a/scripts/tribunal.sh
+++ b/scripts/tribunal.sh
@@ -408,16 +408,24 @@ repair_final_build_failure() {
   writer_prompt="$(cat <<PROMPT
 You are the tribunal-writer for gu-log. All judge stages passed, but the final full-site build failed.
 
+## Repo root
+$ROOT_DIR
+
 ## Target post
-src/content/posts/$post_file
+$ROOT_DIR/src/content/posts/$post_file
+
+## EN counterpart, if present
+$ROOT_DIR/src/content/posts/en-$post_file
 
 ## Build failure evidence (tail)
 $evidence
 
 ## Task
-1. Fix only content-actionable problems in src/content/posts/$post_file.
-2. Also update src/content/posts/en-$post_file if it exists and the same issue applies.
-3. Do not rewrite unrelated content and do not change stable frontmatter fields unless the build error specifically requires it.
+1. Use absolute paths under the Repo root above; this Codex process runs from a temp directory, not the repo root.
+2. Fix only content-actionable problems in $ROOT_DIR/src/content/posts/$post_file.
+3. Also update $ROOT_DIR/src/content/posts/en-$post_file if it exists and the same issue applies.
+4. Inspect your diff before finishing. Do not run tribunal, judge agents, or any quota-burning model calls from inside this repair.
+5. Do not rewrite unrelated content and do not change stable frontmatter fields unless the build error specifically requires it.
 PROMPT
 )"
   writer_out="$(mktemp)"
@@ -736,8 +744,14 @@ PROMPT
     writer_prompt="$(cat <<PROMPT
 You are the tribunal-writer for gu-log. The $label judge reviewed this post and it FAILED.
 
+## Repo root
+$ROOT_DIR
+
 ## Post to rewrite
-src/content/posts/$post_file
+$ROOT_DIR/src/content/posts/$post_file
+
+## EN counterpart, if present
+$ROOT_DIR/src/content/posts/en-$post_file
 
 ## Judge Feedback (JSON)
 $score_json
@@ -746,13 +760,15 @@ $score_json
 $ssot_content
 
 ## Task
-1. Read the post at src/content/posts/$post_file
-2. Read the judge feedback JSON above — identify every dimension that scored below 8
-3. Rewrite the post to fix the specific failures. Write it back in-place.
-4. Also rewrite the EN counterpart at src/content/posts/en-$post_file if it exists.
+1. Use absolute paths under the Repo root above; this Codex process runs from a temp directory, not the repo root.
+2. Read $ROOT_DIR/src/content/posts/$post_file and $ROOT_DIR/GU-LOG_WRITER_PROMPT.md.
+3. Read the judge feedback JSON above — identify every dimension that scored below 8.
+4. Rewrite the post to fix those specific failures. Write it back in-place.
+5. Also rewrite the EN counterpart at $ROOT_DIR/src/content/posts/en-$post_file if it exists and the same fix applies.
+6. Inspect your diff before finishing. Do not run tribunal, judge agents, or any quota-burning model calls from inside this rewrite.
 
-Follow GU-LOG_WRITER_PROMPT.md style rules and CONTRIBUTING.md frontmatter schema.
-Do NOT change frontmatter fields (title, ticketId, dates, sourceUrl).
+Follow $ROOT_DIR/GU-LOG_WRITER_PROMPT.md and $ROOT_DIR/CONTRIBUTING.md frontmatter schema.
+Do NOT change frontmatter fields (title, ticketId, dates, sourceUrl). Preserve MDX components, URLs, source attribution, and already-passing dimensions unless the judge feedback explicitly targets them.
 PROMPT
 )"
     writer_out="$(mktemp)"


### PR DESCRIPTION
## Summary
- Parse OpenAI/Codex usage-monitor quota fields for Tribunal v4 pacing
- Add floor-aware projected debt sleep for both 5hr and weekly buckets
- Add no-token regression tests for OpenAI quota controller examples
- Keep Tribunal writer GPT-5.5 safety contract green

## Tests
- bash scripts/tests/test-tribunal-openai-quota-controller.sh
- bash scripts/tests/test-tribunal-safety-contract.sh
- bash -n scripts/tribunal-quota-loop.sh
- bash -n scripts/tribunal.sh
- git diff --check
- pre-commit hooks passed
- pre-push checks passed (bundle trend warnings non-blocking)