### PR TITLE
Harden tribunal quota edge cases

### DIFF
--- a/scripts/tests/test-tribunal-openai-quota-controller.sh
+++ b/scripts/tests/test-tribunal-openai-quota-controller.sh
@@ -64,6 +64,16 @@ out=$(run_case "$with_inflight" 2 3)
 [ "$out" = "10|3|none|pacing" ] || fail "in-flight workers should not affect burn-rate gating; got: $out"
 pass "in-flight workers do not feed back into burn-rate quota gating"
 
+below_floor='[{"provider":"openai","status":"ok","session_remaining_pct":100,"session_reset_min":300,"weekly_remaining_pct":9,"weekly_reset_hr":72}]'
+out=$(run_case "$below_floor")
+[ "$out" = "259200|0|seven_day|floor_stop" ] || fail "weekly quota below reserve floor should sleep until reset; got: $out"
+pass "quota below reserve floor stops until reset"
+
+missing_reset='[{"provider":"openai","status":"ok","session_remaining_pct":100,"weekly_remaining_pct":100,"weekly_reset_hr":168}]'
+out=$(run_case "$missing_reset")
+[ "$out" = "600|1|none|fallback" ] || fail "missing reset metadata should fail safe into fallback; got: $out"
+pass "missing OpenAI reset metadata fails safe into fallback sleep"
+
 claude_fixture='[{"provider":"claude","status":"ok","five_hr_remaining_pct":100,"five_hr_reset":"5.0 小時","weekly_remaining_pct":100,"weekly_reset":"7.0 天"}]'
 out=$(run_case "$claude_fixture")
 [ "$out" = "10|1|none|pacing" ] || fail "legacy Claude fixture parser regressed; got: $out"

--- a/scripts/tribunal-quota-loop.sh
+++ b/scripts/tribunal-quota-loop.sh
@@ -369,10 +369,18 @@ try:
     # long bucket as weekly_remaining_pct/weekly_reset_hr.
     for p in data:
         if p.get('provider') == 'openai' and p.get('status') == 'ok':
-            five_pct = p.get('session_remaining_pct', 0)
-            five_reset_sec = int(float(p.get('session_reset_min', 0)) * 60)
-            seven_pct = p.get('weekly_remaining_pct', 0)
-            seven_reset_sec = int(float(p.get('weekly_reset_hr', 0)) * 3600)
+            required = ['session_remaining_pct', 'session_reset_min', 'weekly_remaining_pct', 'weekly_reset_hr']
+            if any(k not in p or p.get(k) is None for k in required):
+                continue
+            five_pct = p['session_remaining_pct']
+            five_reset_sec = int(float(p['session_reset_min']) * 60)
+            seven_pct = p['weekly_remaining_pct']
+            seven_reset_sec = int(float(p['weekly_reset_hr']) * 3600)
+            # Missing/invalid reset metadata is not safe for burn-rate math.
+            # Return failure so the main loop enters fallback sleep instead of
+            # accidentally treating unknown reset as immediate reset.
+            if five_reset_sec <= 0 or seven_reset_sec <= 0:
+                continue
             print(f'{five_pct}|{five_reset_sec}|{seven_pct}|{seven_reset_sec}|0|0|0')
             sys.exit(0)
 


### PR DESCRIPTION
## Summary
- Fail safe when OpenAI reset metadata is missing or invalid
- Add regression coverage for reserve-floor stop and missing reset fallback

## Tests
- bash scripts/tests/test-tribunal-openai-quota-controller.sh
- bash scripts/tests/test-tribunal-safety-contract.sh
- bash -n scripts/tribunal-quota-loop.sh
- git diff --check