### PR TITLE
Add SD-24 Codex runtime kernel post

### DIFF
--- a/docs/shroomdog-editorial-feedback.md
+++ b/docs/shroomdog-editorial-feedback.md
@@ -200,3 +200,12 @@
 - 情境：SP-196 保留了太多原文工具名、Skill 名、模型名、書名、人名、benchmark 名和部署選項。它們對 Garry 原文忠實，但對 gu-log 讀者來說容易變成名詞牆：讀者被迫記 `brain-ops`、`enrich`、`cross-modal-eval`、模型分工、benchmark、雲端服務，而不是抓到「流程會記住錯誤並複利」這個核心。
 - 修法：刪減不重要專有名詞，把細節轉成故事或譬喻：Skill 組合改寫成「小工廠產線」；模型分工改寫成「有的抓精確錯誤、有的補脈絡、有的抓萬用雞湯」；工具棧與部署名改成「知識層、流程層、派工層」。保留必要名詞，例如 Garry、Demis、GBrain、Skill、Harness，但不要求讀者背完整 inventory。
 - Reusable lesson：gu-log 的價值不是做 1-to-1 translation。讀者來 gu-log 是為了更快抓到 idea behind the details。寫作時先問：這個專有名詞是否承載核心觀念？若沒有，就改成故事、角色、流程、譬喻或「有一個工具負責 X」。細節控讀者可以點原文；gu-log 要交付的是可記住的 mental model。
+
+## 2026-05-16 — SD-24 Codex Runtime Kernel
+
+### Feedback: Architecture posts should deliver the mental model, not the spec tour
+
+- ShroomDog feedback：`Interesting, but too long, too many detailed that should be linked. But seems there r some interesting insights that worth starting a SD post from this`
+- 情境：SD-24 初稿把 Hermes Codex App-Server Runtime 和 OpenClaw Codex harness 的細節完整展開，包含 auth、native tools、tool boundary、optional routing、不同產品動機等。內容有 insight，但讀起來太像 spec walkthrough，不像一篇 gu-log SD 原創文。
+- 修法：把文章重寫成短版：只保留核心 thesis「Codex 正在變成 coding agent 的 runtime kernel；OpenClaw / Hermes 變成外層 control plane」，把 implementation detail 變成原文連結，不在正文展開 inventory。
+- Reusable lesson：架構趨勢文不要把文件細節搬進正文。gu-log 要交付的是可記住的 mental model；implementation details、限制清單、auth 指令、完整 tool matrix 應該連回原文。若細節沒有推動 thesis，就刪掉或縮成一句。

--- a/scripts/article-counter.json
+++ b/scripts/article-counter.json
@@ -1,6 +1,6 @@
 {
   "SD": {
-    "next": 24,
+    "next": 25,
     "label": "ShroomDog Original",
     "description": "Original articles written by ShroomDog"
   },

--- a/src/content/posts/en-sd-24-20260515-codex-runtime-kernel.mdx
+++ b/src/content/posts/en-sd-24-20260515-codex-runtime-kernel.mdx
@@ -1,0 +1,128 @@
+---
+ticketId: "SD-24"
+title: "Codex Is Becoming the Runtime Kernel for AI Agents"
+originalDate: "2026-05-15"
+translatedDate: "2026-05-15"
+source: "ShroomDog Lab"
+sourceUrl: "https://hermes-agent.nousresearch.com/docs/user-guide/features/codex-app-server-runtime"
+lang: "en"
+summary: "OpenClaw and Hermes are both handing low-level coding-agent execution to Codex app-server. This is not just a model switch. It is the agent product stack separating model, execution engine, and chat surface."
+tags: ["shroomdog-original", "codex", "openclaw", "hermes-agent", "agent-harness", "runtime", "architecture"]
+scores:
+  tribunalVersion: 3
+  freshEyes:
+    readability: 8
+    firstImpression: 8
+    score: 8
+    date: "2026-05-16"
+    model: "gpt-5.5"
+  vibe:
+    persona: 8
+    clawdNote: 8
+    vibe: 8
+    clarity: 9
+    narrative: 8
+    score: 8
+    date: "2026-05-16"
+    model: "gpt-5.5"
+---
+
+import ClawdNote from '../../components/ClawdNote.astro';
+
+The next big split in AI agents may not be "which model are you using?"
+
+It may be: who does the thinking, who does the work, and who gets the result back to the human.
+
+In May 2026, Hermes and OpenClaw both connected the layer that actually writes code, runs terminal commands, and edits files to Codex app-server. Hermes documents this as [Codex App-Server Runtime](https://hermes-agent.nousresearch.com/docs/user-guide/features/codex-app-server-runtime). OpenClaw documents it as [Codex harness](https://docs.openclaw.ai/plugins/codex-harness).
+
+If you do not live in agent-infra land: Hermes and OpenClaw are outer agent products. They connect agents to chat apps, workflows, memory, approvals, and delivery. Codex app-server is closer to the machine room behind Codex CLI: the part that gives an AI a workspace and lets it actually touch code.
+
+This is interesting not because Codex gets one more entry point.
+
+It is interesting because AI agent products are starting to admit that the model, the execution engine, and the chat surface are three different things.
+
+This is the browser-engine moment for coding agents.
+
+---
+
+## The Three Layers Are Splitting
+
+When someone asks, "Is this GPT-5.5 or GPT-5.4? Is it running on OpenClaw or Codex?" the question can easily get mashed together.
+
+Now the split is clearer.
+
+The model is the brain. GPT-5.5, GPT-5.4, or any other model decides the quality of reasoning.
+
+The execution engine is the hands. The thing that actually runs commands, edits files, and handles code tasks can be Codex app-server.
+
+The chat surface is the front desk. Telegram, Discord, iMessage, and web UI are where humans send tasks in and receive results back.
+
+What OpenClaw and Hermes are doing here is handing the "hands" layer to Codex while continuing to own the front desk, workflow, memory, delegation, and reporting.
+
+<ClawdNote>
+This is restaurant architecture.
+
+The model is the chef's brain.
+Codex is the kitchen: fire, knives, actual cooking.
+OpenClaw and Hermes are the front of house: taking orders, remembering regulars, sending the food back to the right table.
+
+A lot of older agent products tried to be the chef, build the kitchen, and run the dining room all at once. It sounds complete. In practice, it turns into a restaurant where the owner is fixing the plumbing in the basement before the food even reaches the table.
+
+╮(╯▽╰)╭
+</ClawdNote>
+
+---
+
+## Why Hand It To Codex
+
+The first reason: the kitchen is hard to build.
+
+The low-level work of a coding agent is not just "run a command." It needs to edit files safely, know when to apply a patch, handle long tasks, and clean up context when the conversation gets too full. If this layer fails, everything breaks. If it works, users rarely think about it.
+
+The second reason: Codex is already specializing in this layer.
+
+If there is a dedicated execution engine for coding agents, OpenClaw and Hermes gain less from rebuilding the same layer. It is smarter to focus on the parts Codex does not own: how tasks arrive, who approves them, how results are delivered, what memory remains, and how the next task continues.
+
+The third reason: accounts and usage limits are becoming part of architecture.
+
+Hermes mentions reusing the Codex CLI login flow. OpenClaw also separates the model, the Codex execution engine, and chat apps like Telegram or Discord. The exact mechanics are in the docs. The real point is simple: asking "which model does this agent use?" is no longer enough. The next question is "which engine is it running inside?"
+
+---
+
+## This Is Not Someone Losing
+
+It is easy to frame this as "OpenClaw or Hermes lost to Codex."
+
+That is not quite right.
+
+It is more like a browser adopting V8. Chrome, Edge, and Brave can share a JavaScript engine while still competing on interface, sync, privacy, extensions, ecosystem, and default experience.
+
+In the same way, OpenClaw and Hermes adopting Codex app-server does not erase the outer product. It means the kitchen that writes code can be handled by a specialized kitchen.
+
+The real competition moves upward.
+
+Who has better memory? Who has smoother approval? Who connects Telegram, cron, workflows, and team collaboration more naturally? Who makes sure the agent's result actually comes back to the human instead of rotting in a log file?
+
+That is the battlefield for the outer product.
+
+<ClawdNote>
+This is the real substance: products are starting to admit that "can write code" is not the only selling point.
+
+When everyone can borrow the same high-end kitchen, the difference is no longer who owns the pans. It is who understands the guest, who remembers that a regular hates cilantro, and who can survive the dinner rush without sending the wrong order to the wrong table.
+
+AI agents are the same. Low-level coding ability matters, but what users actually feel is whether the task was caught, whether the result came back, and whether the next session can continue from there.
+</ClawdNote>
+
+---
+
+## The Real Signal
+
+Early AI agent products looked like every company trying to build the whole machine.
+
+Now the ecosystem is splitting. Some teams build models. Some build execution engines. Some build user surfaces. Some build workflow. Some build memory. When an ecosystem starts forming layers, it is no longer just a demo. It is moving toward maintainable systems.
+
+So Hermes and OpenClaw adopting Codex app-server is not a small feature.
+
+It is a signal: Codex is becoming the low-level engine for coding agents.
+
+The agent-framework battlefield is moving above the engine.

--- a/src/content/posts/sd-24-20260515-codex-runtime-kernel.mdx
+++ b/src/content/posts/sd-24-20260515-codex-runtime-kernel.mdx
@@ -1,0 +1,124 @@
+---
+ticketId: "SD-24"
+title: "Codex 正在變成 AI Agent 的 runtime kernel"
+originalDate: "2026-05-15"
+translatedDate: "2026-05-15"
+source: "ShroomDog Lab"
+sourceUrl: "https://hermes-agent.nousresearch.com/docs/user-guide/features/codex-app-server-runtime"
+lang: "zh-tw"
+summary: "OpenClaw 和 Hermes 都開始把寫程式 agent 的底層執行交給 Codex 執行伺服器。這不是單純換模型，而是 AI agent 產品開始把模型、執行引擎、聊天入口拆成三層。"
+tags: ["shroomdog-original", "codex", "openclaw", "hermes-agent", "agent-harness", "runtime", "architecture"]
+scores:
+  tribunalVersion: 3
+  freshEyes:
+    readability: 8
+    firstImpression: 8
+    score: 8
+    date: "2026-05-16"
+    model: "gpt-5.5"
+  vibe:
+    persona: 8
+    clawdNote: 8
+    vibe: 8
+    clarity: 9
+    narrative: 8
+    score: 8
+    date: "2026-05-16"
+    model: "gpt-5.5"
+---
+
+import ClawdNote from '../../components/ClawdNote.astro';
+
+AI agent 的下一個分工點，可能不是「換哪個模型」。
+
+而是：誰負責思考，誰負責動手，誰負責把結果送回人手上。
+
+2026 年五月，Hermes 和 OpenClaw 都把「真正下去寫程式碼、跑終端命令、改檔案」那一層，接到 Codex 執行伺服器。Hermes 的說明在 [Codex 應用伺服器執行環境](https://hermes-agent.nousresearch.com/docs/user-guide/features/codex-app-server-runtime)，OpenClaw 的說明在 [Codex harness](https://docs.openclaw.ai/plugins/codex-harness)。
+
+這件事有趣，不是因為 Codex 多了一個入口。
+
+有趣的是：AI agent 產品開始承認，模型、執行引擎、聊天入口，其實是三件事。
+
+---
+
+## 三層拆開了
+
+以前問一個 agent「現在是 GPT-5.5 還是 GPT-5.4？跑在 OpenClaw 還是 Codex？」這句話很容易混在一起。
+
+現在比較清楚了。
+
+模型，是腦袋。GPT-5.5、GPT-5.4、其他模型，決定思考品質。
+
+執行引擎，是手腳。誰真的去跑命令、改檔案、處理程式碼任務，這一層可以是 Codex 執行伺服器。
+
+聊天入口，是櫃檯。Telegram、Discord、Apple 訊息、網頁介面，只是人把任務交出去、再把結果收回來的地方。
+
+OpenClaw 和 Hermes 這次做的事情，就是把「手腳」這層交給 Codex，自己繼續做櫃檯、流程、記憶、派工、回報。
+
+<ClawdNote>
+這很像餐廳分工。
+
+模型是主廚腦袋，知道菜要怎麼做。
+Codex 是廚房，負責開火、切菜、真的把菜煮出來。
+OpenClaw / Hermes 是外場，負責接單、排隊、送餐、記住熟客偏好。
+
+以前很多 agent 產品想自己當主廚、自己蓋廚房、自己當外場。聽起來很完整，實際上很容易變成一間什麼都自己修的餐廳。水管爆了也自己修，冰箱壞了也自己修，最後菜還沒上，老闆已經在地下室跟排水管搏鬥。
+
+╮(╯▽╰)╭
+</ClawdNote>
+
+---
+
+## 為什麼要交給 Codex
+
+第一個理由是：廚房很難蓋。
+
+寫程式 agent 的底層工作不是只有「叫終端跑一下」。它要安全地改檔案、知道什麼時候要套修改、知道怎麼處理長任務、知道上下文快滿時怎麼整理。這些事情做錯會炸，做好了又很少變成產品賣點。
+
+第二個理由是：Codex 已經專門在做這件事。
+
+如果有一個底層引擎專門服務寫程式 agent，那 OpenClaw 和 Hermes 繼續重做同一層，收益就沒那麼高。更聰明的做法是把力氣放到 Codex 不負責的地方：任務怎麼進來、哪些操作要先問過人、結果怎麼送回去、記憶怎麼留下、下一次怎麼接著做。
+
+第三個理由是：帳號和額度也開始變成架構的一部分。
+
+Hermes 文件提到可以沿用 Codex CLI 的登入流程。OpenClaw 文件也把模型、Codex 這個執行引擎、Telegram / Discord 這些入口分開講。細節不需要背，真正重點是：以後問「這個 agent 用哪個模型」還不夠，還要問「它在哪個引擎裡跑」。
+
+---
+
+## 這不是誰輸給誰
+
+這件事很容易被講成「OpenClaw / Hermes 輸給 Codex」。
+
+但這個說法不太準。
+
+比較像不同瀏覽器採用同一顆 JavaScript 引擎。底層引擎可以共用，但每個瀏覽器的價值仍然不一樣：介面、同步、隱私、擴充套件、生態、預設體驗，全部都還能競爭。
+
+同樣地，OpenClaw 和 Hermes 採用 Codex 執行伺服器，不代表外層產品消失。它只是承認：底層寫程式碼的廚房，可以交給更專門的廚房。
+
+真正的競爭會往上移。
+
+誰的記憶比較好？誰讓人確認危險操作時比較順？誰能把 Telegram、定時任務、工作流程、團隊協作接得更自然？誰能讓 agent 做完事情後真的回到人手上，而不是躺在某個紀錄檔裡等人撿？
+
+這些才是外層產品的戰場。
+
+<ClawdNote>
+這裡真正有料的地方是：產品開始承認「會寫程式」不是唯一賣點。
+
+當所有人都能借同一間高級廚房，差異就不在誰有鍋子，而在誰比較懂客人、誰記得熟客不吃香菜、誰能在尖峰時間不把單送錯桌。
+
+AI agent 也是一樣。底層會寫程式很重要，但使用者真正感受到的是：任務有沒有被接住，結果有沒有回來，下一次能不能延續。
+</ClawdNote>
+
+---
+
+## 真正的訊號
+
+早期 AI agent 生態很像每家公司都在蓋整台機器。
+
+後來開始分工：有人做模型，有人做底層執行，有人做使用者入口，有人做工作流程，有人做記憶。當一個生態開始分層，代表它不再只是展示品，而是在往可維護的系統走。
+
+所以 Codex 執行伺服器被 Hermes 和 OpenClaw 採用，不是小功能。
+
+它是訊號：Codex 正在變成寫程式 agent 的底層引擎。
+
+而 agent 框架的戰場，正在往引擎之上移動。


### PR DESCRIPTION
Adds SD-24 ShroomDog Original on Codex becoming the runtime kernel for coding agents.\n\nValidation:\n- ZH FreshEyes: 8/8 PASS\n- ZH Vibe: 8 PASS\n- EN FreshEyes: 8/8 PASS\n- EN Vibe: 8 PASS\n- pnpm run validate:posts\n- pnpm run build