### PR TITLE
feat(clawdnote): add foldable notes and glossary link

### DIFF
--- a/scripts/validate-posts.mjs
+++ b/scripts/validate-posts.mjs
@@ -46,9 +46,11 @@ const REDUNDANT_BOTTOM_CITATION_PATTERNS = [
   /\n##\s*原文出處/,
 ];
 const CLAWD_NOTE_REDUNDANT_PREFIX = [
-  /<ClawdNote>\s*\n?\s*\*\*Clawd[：:]\*\*/i,
-  /<ClawdNote>\s*\n?\s*Clawd[：:]\s/i,
+  /<ClawdNote\b[^>]*>\s*\n?\s*\*\*Clawd[：:]\*\*/i,
+  /<ClawdNote\b[^>]*>\s*\n?\s*Clawd[：:]\s/i,
 ];
+const LONG_CLAWD_NOTE_CHARS = 420;
+const MAX_CLAWD_NOTE_SUMMARY_CHARS = 120;
 
 // ─── Helpers ───────────────────────────────────────────────────────
 function parseFrontmatter(content) {
@@ -161,8 +163,40 @@ function validateScoreBlock(fmText, judge, dimensions) {
   return errors;
 }
 
+function extractClawdNotes(content) {
+  const notes = [];
+  const pattern = /<ClawdNote\b([^>]*)>([\s\S]*?)<\/ClawdNote>/g;
+  let match;
+
+  while ((match = pattern.exec(content)) !== null) {
+    const attrs = match[1] ?? '';
+    const inner = match[2] ?? '';
+    const summaryMatch =
+      attrs.match(/\bsummary\s*=\s*"([^"]*)"/) ??
+      attrs.match(/\bsummary\s*=\s*'([^']*)'/) ??
+      attrs.match(/\bsummary\s*=\s*\{`([^`]*)`\}/) ??
+      attrs.match(/\bsummary\s*=\s*\{"([^"]*)"\}/) ??
+      attrs.match(/\bsummary\s*=\s*\{'([^']*)'\}/);
+
+    const text = inner
+      .replace(/```[\s\S]*?```/g, '')
+      .replace(/`[^`\n]+`/g, '')
+      .replace(/<[^>]+>/g, '')
+      .replace(/\s+/g, '');
+
+    notes.push({
+      index: notes.length + 1,
+      length: text.length,
+      hasSummary: Boolean(summaryMatch?.[1]?.trim()),
+      summaryLength: summaryMatch?.[1]?.trim().length ?? 0,
+    });
+  }
+
+  return notes;
+}
+
 // ─── Validation Rules ──────────────────────────────────────────────
-function validatePost(filepath, allPosts) {
+function validatePost(filepath, allPosts, options = {}) {
   const filename = path.basename(filepath);
   const content = fs.readFileSync(filepath, 'utf-8');
   const fm = parseFrontmatter(content);
@@ -248,7 +282,23 @@ function validatePost(filepath, allPosts) {
     }
   }
 
-  // ── Rule 10: Minimum content length ──
+  // ── Rule 10: Long ClawdNote requires writer-authored summary ──
+  if (options.enforceLongClawdNoteSummary) {
+    for (const note of extractClawdNotes(content)) {
+      if (note.length > LONG_CLAWD_NOTE_CHARS && !note.hasSummary) {
+        errors.push(
+          `ClawdNote #${note.index} is long (${note.length} chars) and needs summary="短版一句話"`
+        );
+      }
+      if (note.summaryLength > MAX_CLAWD_NOTE_SUMMARY_CHARS) {
+        errors.push(
+          `ClawdNote #${note.index} summary is too long (${note.summaryLength} chars, max ${MAX_CLAWD_NOTE_SUMMARY_CHARS})`
+        );
+      }
+    }
+  }
+
+  // ── Rule 11: Minimum content length ──
   // Strip imports and component tags for length check
   const cleanBody = body
     .replace(/^import\s+.*$/gm, '')
@@ -258,12 +308,12 @@ function validatePost(filepath, allPosts) {
     errors.push(`Content too short (${cleanBody.length} chars, minimum ${MIN_CONTENT_LENGTH})`);
   }
 
-  // ── Rule 11: summary not too long (for index page) ──
+  // ── Rule 12: summary not too long (for index page) ──
   if (fm.summary && fm.summary.length > 300) {
     warnings.push(`summary is ${fm.summary.length} chars (recommend ≤300 for index page)`);
   }
 
-  // ── Rule 12: ticketId uniqueness (cross-file check) ──
+  // ── Rule 13: ticketId uniqueness (cross-file check) ──
   // Exempt PENDING — multiple parallel drafts legitimately share the
   // PENDING placeholder; real numbers get allocated per-draft at deploy.
   if (fm.ticketId && allPosts && !fm.ticketId.endsWith('-PENDING')) {
@@ -277,7 +327,7 @@ function validatePost(filepath, allPosts) {
     }
   }
 
-  // ── Rule 13: Translation pair ticketId consistency ──
+  // ── Rule 14: Translation pair ticketId consistency ──
   if (fm.ticketId && allPosts) {
     const baseName = getBaseFilename(filename);
     const pair = allPosts.find(
@@ -290,7 +340,7 @@ function validatePost(filepath, allPosts) {
     }
   }
 
-  // ── Rule 14: translatedBy.model must have version number ──
+  // ── Rule 15: translatedBy.model must have version number ──
   if (fm.translatedBy?.model) {
     const model = fm.translatedBy.model;
     // Must contain a version number (e.g., "Opus 4.6", "Sonnet 4.5", "Gemini 3 Pro")
@@ -330,13 +380,13 @@ function validatePost(filepath, allPosts) {
     errors.push('Missing kaomoji — every gu-log post needs at least one (brand voice)');
   }
 
-  // ── Rule 15: Filename includes date ──
+  // ── Rule 17: Filename includes date ──
   const dateInFilename = filename.match(/\d{8}/);
   if (!dateInFilename) {
     warnings.push('Filename does not contain a date (YYYYMMDD)');
   }
 
-  // ── Rule 17: No raw ```mermaid code fences ──
+  // ── Rule 18: No raw ```mermaid code fences ──
   // Astro doesn't auto-render mermaid code fences — must use <Mermaid chart={...} /> component.
   // Match ```mermaid (with optional whitespace) that's NOT inside another code block example.
   const mermaidFencePattern = /^```mermaid\s*$/m;
@@ -636,11 +686,14 @@ function main() {
     filesToValidate = allFiles.map((f) => path.join(POSTS_DIR, f));
   }
 
+  const isFileListMode = args.length > 0;
   let totalErrors = 0;
   let totalWarnings = 0;
 
   for (const filepath of filesToValidate) {
-    const result = validatePost(filepath, allPosts);
+    const result = validatePost(filepath, allPosts, {
+      enforceLongClawdNoteSummary: isFileListMode,
+    });
 
     if (result.errors.length > 0 || result.warnings.length > 0) {
       console.log(`\n📄 ${result.filename}`);
@@ -661,7 +714,6 @@ function main() {
   // specific missing pairs for the staged files; in full-repo mode we
   // print a summary count to keep noise down. The hard gate lives in
   // CI (scripts/check-translation-pairs.mjs --strict --pr-base=…).
-  const isFileListMode = args.length > 0;
   const scope = isFileListMode
     ? new Set(
         filesToValidate.map((fp) => {

--- a/src/components/ClawdNote.astro
+++ b/src/components/ClawdNote.astro
@@ -9,11 +9,13 @@
 interface Props {
   /** Optional custom prefix. If not provided, one is selected based on content */
   prefix?: string;
+  /** Writer-authored short version for long notes. Long notes with summary auto-collapse. */
+  summary?: string;
   /** Visual variant: "note" (default) | "murmur" (casual 碎碎念) */
   variant?: 'note' | 'murmur';
 }
 
-const { prefix, variant = 'note' } = Astro.props;
+const { prefix, summary, variant = 'note' } = Astro.props;
 
 // Detect language from URL path
 const isEnglish = Astro.url.pathname.startsWith('/en/');
@@ -92,17 +94,105 @@ function hashString(str: string): number {
 // Select prefix based on content hash (deterministic but varied)
 const contentHash = hashString(slotContent);
 const selectedPrefix = prefix || prefixes[contentHash % prefixes.length];
+const prefixStartsWithClawd = selectedPrefix.startsWith('Clawd');
+const prefixSuffix = prefixStartsWithClawd ? selectedPrefix.slice('Clawd'.length) : selectedPrefix;
 const isNote = variant === 'note';
+const hasSummary = Boolean(summary?.trim());
+const contentId = `clawd-note-content-${contentHash}`;
+const clawdGlossaryLabel = isEnglish ? 'Clawd glossary entry' : 'Clawd 詞彙說明';
 ---
 
-<blockquote class:list={['claude-note', { 'claude-note--murmur': !isNote }]}>
+<blockquote
+  class:list={['claude-note', { 'claude-note--murmur': !isNote }]}
+  data-clawd-note
+  data-has-summary={hasSummary ? 'true' : 'false'}
+>
   <strong class="clawd-prefix">
-    <img src="/clawd-picks-icon.png" alt="Clawd" class="clawd-prefix-icon" width="20" height="20" />
-    {selectedPrefix}
+    {
+      prefixStartsWithClawd && (
+        <a href="/glossary#clawd" class="clawd-prefix-link" aria-label={clawdGlossaryLabel}>
+          <img
+            src="/clawd-picks-icon.png"
+            alt=""
+            class="clawd-prefix-icon"
+            width="20"
+            height="20"
+          />
+          <span>Clawd</span>
+        </a>
+      )
+    }
+    <span>{prefixSuffix}</span>
   </strong>
-  <br />
-  <Fragment set:html={slotContent} />
+
+  {
+    hasSummary && (
+      <div class="clawd-note-summary" hidden>
+        <span class="clawd-note-summary-label">短版</span>
+        <p>{summary}</p>
+      </div>
+    )
+  }
+
+  <div class="clawd-note-content" id={contentId}>
+    <Fragment set:html={slotContent} />
+  </div>
+
+  {
+    hasSummary && (
+      <button
+        class="clawd-note-toggle"
+        type="button"
+        aria-expanded="false"
+        aria-controls={contentId}
+        hidden
+      >
+        <span class="clawd-note-toggle-icon" aria-hidden="true">
+          ▾
+        </span>
+        <span class="clawd-note-toggle-label">展開長註解</span>
+      </button>
+    )
+  }
 </blockquote>
+
+<script>
+  const COLLAPSE_THRESHOLD_PX = 260;
+
+  function setCollapsed(note: HTMLElement, collapsed: boolean) {
+    const content = note.querySelector<HTMLElement>('.clawd-note-content');
+    const toggle = note.querySelector<HTMLButtonElement>('.clawd-note-toggle');
+    const label = note.querySelector<HTMLElement>('.clawd-note-toggle-label');
+
+    note.dataset.collapsed = collapsed ? 'true' : 'false';
+    if (content) content.hidden = collapsed;
+    if (toggle) toggle.setAttribute('aria-expanded', (!collapsed).toString());
+    if (label) label.textContent = collapsed ? '展開長註解' : '收合';
+  }
+
+  function initClawdNote(note: HTMLElement) {
+    if (note.dataset.hasSummary !== 'true') return;
+
+    const content = note.querySelector<HTMLElement>('.clawd-note-content');
+    const summary = note.querySelector<HTMLElement>('.clawd-note-summary');
+    const toggle = note.querySelector<HTMLButtonElement>('.clawd-note-toggle');
+    if (!content || !summary || !toggle) return;
+
+    const shouldCollapse = content.scrollHeight > COLLAPSE_THRESHOLD_PX;
+    if (!shouldCollapse) return;
+
+    summary.hidden = false;
+    toggle.hidden = false;
+    note.dataset.collapsible = 'true';
+    setCollapsed(note, true);
+
+    toggle.addEventListener('click', () => {
+      setCollapsed(note, note.dataset.collapsed !== 'true');
+    });
+  }
+
+  document.querySelectorAll<HTMLElement>('[data-clawd-note]').forEach(initClawdNote);
+</script>
 
 <style>
   .clawd-prefix {
@@ -114,11 +204,73 @@ const isNote = variant === 'note';
     margin-bottom: 0.3rem;
   }
 
+  .clawd-prefix-link {
+    color: inherit;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    text-decoration: none;
+  }
+
+  .clawd-prefix-link:hover {
+    text-decoration: underline;
+    text-underline-offset: 0.18em;
+  }
+
   .clawd-prefix-icon {
     display: inline-block;
     vertical-align: middle;
     width: 20px;
     height: 20px;
+  }
+
+  .clawd-note-content {
+    margin-top: 1.25rem;
+  }
+
+  .clawd-note-summary {
+    margin-top: 0.55rem;
+  }
+
+  .clawd-note-summary-label {
+    color: var(--color-clawd-orange);
+    display: inline-block;
+    font-size: 0.82rem;
+    font-weight: 700;
+    margin-bottom: 0.25rem;
+  }
+
+  .clawd-note-summary p {
+    margin-bottom: 0;
+  }
+
+  .clawd-note-toggle {
+    align-items: center;
+    background: transparent;
+    border: 0;
+    color: var(--color-clawd-orange);
+    cursor: pointer;
+    display: inline-flex;
+    font: inherit;
+    font-size: 0.9rem;
+    font-weight: 700;
+    gap: 0.35rem;
+    margin-top: 0.7rem;
+    padding: 0;
+  }
+
+  .clawd-note-toggle:hover {
+    text-decoration: underline;
+    text-underline-offset: 0.18em;
+  }
+
+  .clawd-note-toggle-icon {
+    display: inline-block;
+    transition: transform 160ms ease;
+  }
+
+  .claude-note[data-collapsed='false'] .clawd-note-toggle-icon {
+    transform: rotate(180deg);
   }
 
   /* Murmur variant styling */

--- a/src/data/glossary.json
+++ b/src/data/glossary.json
@@ -112,6 +112,17 @@
     "enClawdNote": "Boris is the kind of person where you think you are watching a tool demo, then realize he is quietly redefining how engineers work."
   },
   {
+    "term": "Clawd",
+    "en": "Clawd",
+    "definition": "gu-log 面向讀者的 AI 旁白 persona。正文負責忠實翻譯或整理來源內容；Clawd 則負責註解、吐槽、延伸觀點、來源修正與台灣讀者比較好入口的比喻。簡單講：正文是原文，ClawdNote 是旁白。",
+    "clawdNote": "把 Clawd 當成 gu-log 的場邊球評就好。球賽照打，旁邊那位負責補脈絡、吐槽戰術、偶爾指出裁判是不是看錯。希望如此，至少合約上是這樣寫。",
+    "url": "/about",
+    "aliases": ["ShroomClawd", "ClawdNote", "Clawd Note"],
+    "related": ["Agent", "OpenClaw", "Claude Code"],
+    "definedIn": [],
+    "category": "people"
+  },
+  {
     "term": "Codex",
     "en": "Codex",
     "definition": "OpenAI 生態裡的同名異物，「Codex」至少可以指：\n• 舊模型（2021）：程式碼生成模型，2023 年已下架\n• 新產品（2025）：agentic coding 工具，背後跑 codex-1（基於 o3）\n• 系統框架：模型 + 執行環境 + 介面整合體，整包都叫 Codex\n\nOpenAI 官方人員自己也承認這名字讓人一頭霧水。用戶只能自己猜。",

--- a/src/pages/glossary.astro
+++ b/src/pages/glossary.astro
@@ -23,6 +23,21 @@ const categoryLabel: Record<string, string> = {
   people: '人物',
 };
 
+function isExternalUrl(url: string) {
+  return /^https?:\/\//.test(url);
+}
+
+function urlLabel(url: string) {
+  if (!isExternalUrl(url)) return `gu-log${url}`;
+
+  const u = new URL(url);
+  const host = u.hostname.replace('www.', '');
+  const parts = u.pathname.split('/').filter(Boolean);
+  const skip = /^(en|zh|ja|ko|de|fr|es|pt|ru)$/i;
+  const first = parts.find((p) => !skip.test(p));
+  return first ? `${host}/${first}` : host;
+}
+
 // Group by first letter
 const grouped: { letter: string; items: typeof glossary }[] = [];
 let currentLetter = '';
@@ -113,16 +128,13 @@ const allLetters = grouped.map((g) => g.letter);
                     {item.clawdNote && <ClawdNote>{item.clawdNote}</ClawdNote>}
                     {item.url && (
                       <p class="term-meta">
-                        <a href={item.url} target="_blank" rel="noopener noreferrer">
-                          {(() => {
-                            const u = new URL(item.url);
-                            const host = u.hostname.replace('www.', '');
-                            const parts = u.pathname.split('/').filter(Boolean);
-                            const skip = /^(en|zh|ja|ko|de|fr|es|pt|ru)$/i;
-                            const first = parts.find((p) => !skip.test(p));
-                            return first ? `${host}/${first}` : host;
-                          })()}{' '}
-                          ↗
+                        <a
+                          href={item.url}
+                          target={isExternalUrl(item.url) ? '_blank' : undefined}
+                          rel={isExternalUrl(item.url) ? 'noopener noreferrer' : undefined}
+                        >
+                          {urlLabel(item.url)}
+                          {isExternalUrl(item.url) && ' ↗'}
                         </a>
                       </p>
                     )}


### PR DESCRIPTION
## Summary
- add writer-authored summary support and rendered-height folding for long ClawdNote blocks
- link ClawdNote prefixes to the new Clawd glossary entry instead of /about directly
- add a Clawd glossary entry that links onward to /about
- enforce summaries for long ClawdNotes in file-list/pre-commit validation

## Verification
- node scripts/validate-posts.mjs
- node scripts/validate-posts.mjs src/content/posts/sp-161-20260405-voxyz-ai-anthropic-openclaw-prompt-gpt-5-4.mdx
- pnpm exec prettier --check src/components/ClawdNote.astro src/pages/glossary.astro scripts/validate-posts.mjs
- pnpm exec astro check
- pnpm run build
- UI audit: /private/tmp/gu-log-uiux-clawdnote/uiux-audit-clawdnote.json