### PR TITLE
fix: include user bin in tribunal wrapper path

### DIFF
--- a/scripts/cc-tribunal-loop-wrapper.sh
+++ b/scripts/cc-tribunal-loop-wrapper.sh
@@ -8,6 +8,7 @@
 
 set -euo pipefail
 export TZ=Asia/Taipei
+export PATH="$HOME/bin:$HOME/.local/bin:$PATH"
 export CLAUDE_CODE_OAUTH_TOKEN
 CLAUDE_CODE_OAUTH_TOKEN=$(head -1 "$HOME/.cc-cron-token")
 


### PR DESCRIPTION
## Summary
- Add $HOME/bin and $HOME/.local/bin to the tribunal service wrapper PATH.
- This lets the daemon find the user-level Codex wrapper on clawd-vm instead of the broken /usr/bin/codex symlink when usage-monitor needs codex login status for auth refresh.

## Verification
- bash -n scripts/cc-tribunal-loop-wrapper.sh
- pre-commit hooks passed
- pre-push bundle budget gate passed