### PR TITLE
chore: detect mac-cdx runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,6 +87,7 @@ tmp/
 # Score loop runtime artifacts (daemon writes these, not tracked)
 .score-loop/raw/
 .score-loop/logs/
+.score-loop/pilots/
 .score-loop/opus-url-burn/
 
 # Tribunal v2 in-progress state files (saved by pipeline.onProgress)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,13 +162,13 @@ vercel logs --since 1h         # 查最近 1h request logs（需 vercel login）
 
 ## Dev Workflow
 
-### CC vs CCC: Who am I, and what can I do?
+### mac-cdx / mac-CC vs CCC: Who am I, and what can I do?
 
-兩種 Codex instance 會碰這個 repo。**開場第一件事先跑 `./scripts/detect-env.sh`** 確認自己是哪個，然後讀對應的 playbook：
+幾種 Codex / local agent instance 會碰這個 repo。**開場第一件事先跑 `./scripts/detect-env.sh`** 確認自己是哪個，然後讀對應的 playbook：
 
 | Instance | 跑在哪 | Playbook |
 |---|---|---|
-| **mac-CC** (Local Codex) | user 個人 Mac，互動式 iterate | [`playbooks/mac-CC-playbook.md`](playbooks/mac-CC-playbook.md) |
+| **mac-cdx / mac-CC** (Local Codex / local harness) | user 個人 Mac，互動式 iterate | [`playbooks/mac-CC-playbook.md`](playbooks/mac-CC-playbook.md) |
 | **CCC** (Cloud Codex) | Codex 網頁版，Linux sandbox，auto-branch | [`playbooks/CCC-playbook.md`](playbooks/CCC-playbook.md) |
 
 Playbook 各自是 SSOT，定義各自的精神、scope ceiling、失敗處理、merge policy、品質 gate。**不要在這個檔案重複那些規則。** 有要加規則就去編對應的 playbook 檔。
@@ -211,7 +211,7 @@ gu-log 的文章草稿有三種來源，全部最終都變成 `src/content/posts
      - 自動補 frontmatter、自動 bump `scripts/article-counter.json`
      - 自動跑 `validate-posts.mjs`
    - 完整設定和 workflow 在 `OBSIDIAN_SETUP.md`
-2. **VS Code / Cursor / CC 直接編 MDX**（手動 + AI 輔助）
+2. **VS Code / Cursor / mac-cdx / CC 直接編 MDX**（手動 + AI 輔助）
    - 走原本流程：手動填 frontmatter → validate → commit
    - 適合改現有文章、寫需要複雜元件的文章
 3. **Clawd / CP pipeline 自動產**（VPS 上的 agent）
@@ -223,7 +223,7 @@ gu-log 的文章草稿有三種來源，全部最終都變成 `src/content/posts
 ### 其他 workflow 規則
 
 - **User 只看 production**（gu-log.vercel.app）。不要叫 user 開 dev server。
-- **CC 自己跑 `pnpm run dev`** 來 iterate，用 `playwright-cli` 截圖驗證 UI（skill 在 `.Codex/skills/playwright-cli/`）。
+- **mac-cdx / CC 自己跑 `pnpm run dev`** 來 iterate，用 `playwright-cli` 截圖驗證 UI（skill 在 `.Codex/skills/playwright-cli/`）。
 - **UI/UX 品質**：改完任何視覺的東西（CSS、component、color、spacing、typography、layout）就跑 `uiux-auditor` skill（`.Codex/skills/uiux-auditor/`）。它會強制兩個主題都截圖、算 WCAG 對比、flag 寫死的 hex。不要等 user 來挑錯。
 - **建立 / 修改 skill**：用 `skill-creator` skill（`.Codex/skills/skill-creator/`）— 官方 anthropic/skills 的來源。
 - **沙箱網路能力**（2026-04-23 實測修正）：command-line HTTPS（curl、`sp-pipeline` 的 FetchGeneric）**是通的**，不要假設沒外網。真正受限的是 `playwright-cli` 的 browser navigation——`goto` 在 `domcontentloaded` 卡死，fonts.googleapis.com 之類 CSS 外鏈拿不到。每次 navigate 前先用 `run-code` 裝一個 route handler：localhost/data: 放行，其他一律 abort。uiux-auditor skill 裡有完整範本。
@@ -242,7 +242,7 @@ gu-log 的文章草稿有三種來源，全部最終都變成 `src/content/posts
 
 ### Tribunal runtime ops
 
-Daemon 行為、graceful stop、2-worker 平行化、worker worktree 管理，全部寫在 **`docs/tribunal-runbook.md`**。**碰 tribunal 自動化之前先讀這個檔**，特別是 worker worktree 不會跟著 main 自動更新這個雷，要用 `scripts/tribunal-worker-bootstrap.sh sync` 手動刷。mac-CC 可以 SSH 到 VM 查即時狀態——用 `/tribunal-monitor` skill 或見 [`mac-CC-playbook`](playbooks/mac-CC-playbook.md)。
+Daemon 行為、graceful stop、2-worker 平行化、worker worktree 管理，全部寫在 **`docs/tribunal-runbook.md`**。**碰 tribunal 自動化之前先讀這個檔**，特別是 worker worktree 不會跟著 main 自動更新這個雷，要用 `scripts/tribunal-worker-bootstrap.sh sync` 手動刷。mac-cdx / mac-CC 可以 SSH 到 VM 查即時狀態——用 `/tribunal-monitor` skill 或見 [`mac-CC-playbook`](playbooks/mac-CC-playbook.md)。
 
 ## Style Guide (Quick Ref)
 

--- a/playbooks/mac-CC-playbook.md
+++ b/playbooks/mac-CC-playbook.md
@@ -1,27 +1,29 @@
-# mac-CC Playbook
+# mac-cdx / mac-CC Playbook
 
-> **mac-CC** = **Mac-local Claude Code** — 跑在 user 個人 Mac 上的 Claude Code（terminal / VS Code / Cursor / 各式 harness）。
+> **mac-cdx** = **Mac-local Codex Desktop / Codex CLI** — 跑在 user 個人 Mac 上的 Codex runtime。
 >
-> 這份 playbook 只給 mac-CC 看。CCC（Cloud Claude Code）讀 `CCC-playbook.md`。用 `./scripts/detect-env.sh` 確認自己是誰。
+> **mac-CC** = **Mac-local Claude Code-compatible harness** — 歷史名稱仍保留在檔名與部分 workflow 裡，避免打斷舊 script。
+>
+> 這份 playbook 給 mac-cdx / mac-CC 看。CCC（Cloud Codex / Cloud Claude Code）讀 `CCC-playbook.md`。用 `./scripts/detect-env.sh` 確認自己是誰。
 
 ## 精神
 
-跟 CCC 一樣：**move fast, be independent, make good decisions, don't be a 伸手牌**。User 常開 yolo mode 離開現場，mac-CC 該自己做 research / 自己判斷 / 自己動手。**不要一有模糊就問 user**——先讀 docs、讀 code、跑 script、試驗、查 git log。問 user 是最後一步，不是第一步。
+跟 CCC 一樣：**move fast, be independent, make good decisions, don't be a 伸手牌**。User 常開 yolo mode 離開現場，mac-cdx / mac-CC 該自己做 research / 自己判斷 / 自己動手。**不要一有模糊就問 user**——先讀 docs、讀 code、跑 script、試驗、查 git log。問 user 是最後一步，不是第一步。
 
 ## 差別只在環境，規則跟 CCC 共用
 
-**工作規則**（commit discipline、scope ceiling、失敗處理、品質 gate）**全部共用 CCC-playbook.md 的內容**。那些是 Claude Code 在這個 repo 的通則，不是 CCC 專屬。讀 CCC-playbook 的這幾段當 mac-CC 自己的規則：
+**工作規則**（commit discipline、scope ceiling、失敗處理、品質 gate）**全部共用 CCC-playbook.md 的內容**。那些是 agent 在這個 repo 的通則，不是 CCC 專屬。讀 CCC-playbook 的這幾段當 mac-cdx / mac-CC 自己的規則：
 
 - Commit discipline（atomic commits）
 - Scope ceiling（相關路徑 + prod/CI 緊急事件例外）
 - 品質 gate（不能跳任何 hook 或 tribunal）
 - 失敗處理（forward fix → opus subagent → revert）
 
-## 環境差異（mac-CC 該知道、CCC 不會遇到）
+## 環境差異（mac-cdx / mac-CC 該知道、CCC 不會遇到）
 
 ### Branch 位置不固定
 
-mac-CC 可能在任何 branch 上，不一定在 `claude/xxx`：
+mac-cdx / mac-CC 可能在任何 branch 上，不一定在 `claude/xxx`：
 - 可能在 `main`（solo author 直接開發）
 - 可能在 worktree（user 常用 `git worktree`，一次開多個 feature）
 - 可能在 feature branch
@@ -39,7 +41,7 @@ git log --oneline -5
 
 ### Merge flow 更直接
 
-mac-CC 不一定要走 PR + self-merge 流程：
+mac-cdx / mac-CC 不一定要走 PR + self-merge 流程：
 - 在 main 上 → commit + push 就直接 Vercel deploy 上 prod（solo author policy 授權的）
 - 在 feature branch 上 → push 到同名 remote branch，要不要開 PR 看情況
 - 在 worktree 上 → 照該 worktree 的 scope 做事
@@ -48,7 +50,7 @@ GitHub MCP 不一定可用（看 user 的 Claude Code 設定）。可能有 `gh`
 
 ### 本地環境優勢，該用
 
-mac-CC 有的 CCC 沒有的：
+mac-cdx / mac-CC 有的 CCC 沒有的：
 - **本地 dev server**：自己跑 `pnpm run dev` iterate，不要煩 user（user 只看 production）
 - **playwright-cli skill**（`.claude/skills/playwright-cli/`）：截圖驗證 UI
 - **uiux-auditor skill**（`.claude/skills/uiux-auditor/`）：改完視覺跑一次，強制雙主題截圖 + WCAG 對比
@@ -58,8 +60,12 @@ mac-CC 有的 CCC 沒有的：
 
 這些都該主動用，不要因為 CCC 不能用就不用。
 
+### Codex Desktop 專屬提醒
+
+mac-cdx 會有 `CODEX_SHELL=1`、`CODEX_INTERNAL_ORIGINATOR_OVERRIDE` 或 `__CFBundleIdentifier=com.openai.codex` 這類環境線索。需要判斷 runtime 時，先用這些訊號，不要只靠舊的 `CC` 命名。舊命名還在，是為了讓 automation 活著，不是為了讓人類困惑。
+
 ## 這份 playbook 是 living doc
 
-mac-CC 如果遇到 Mac 專屬的狀況需要 codify（例如發現某個本地工具的坑、某個 skill 的新用法、某個 iCloud sync 的陷阱），直接編輯這份 playbook 加進去。
+mac-cdx / mac-CC 如果遇到 Mac 專屬的狀況需要 codify（例如發現某個本地工具的坑、某個 skill 的新用法、某個 iCloud sync 的陷阱），直接編輯這份 playbook 加進去。
 
 保持精簡——這份不是 CCC-playbook 的 duplicate，只寫 Mac-specific 的部分。

--- a/scripts/detect-env.sh
+++ b/scripts/detect-env.sh
@@ -1,17 +1,18 @@
 #!/usr/bin/env bash
-# detect-env.sh — 判斷這個 Claude Code instance 是 mac-CC 還是 CCC
+# detect-env.sh — 判斷這個 coding-agent instance 是 mac-cdx / mac-CC 還是 CCC
 #
-# mac-CC (Local Claude Code):  user 個人 Mac，互動式 iterate
-# CCC    (Cloud Claude Code):  Claude Code 網頁版，Linux 沙箱，auto-branch
+# mac-cdx (Local Codex Desktop): user 個人 Mac，Codex Desktop / Codex CLI，互動式 iterate
+# mac-CC  (Local Claude Code):   user 個人 Mac，Claude Code-compatible local harness
+# CCC     (Cloud Codex/CC):      Cloud sandbox，auto-branch
 #
 # 用法：
 #   ./scripts/detect-env.sh             # 印 mode (stdout) + 提示 (stderr)
 #   mode=$(./scripts/detect-env.sh)     # 只拿 mode 字串
 #
-# 第一件事：任何 Claude session 開場就跑一下這個，確認自己是誰，
+# 第一件事：任何 agent session 開場就跑一下這個，確認自己是誰，
 # 然後去讀對應的 playbook：
-#   - mac-CC → playbooks/mac-CC-playbook.md
-#   - CCC    → playbooks/CCC-playbook.md
+#   - mac-cdx / mac-CC → playbooks/mac-CC-playbook.md
+#   - CCC              → playbooks/CCC-playbook.md
 #
 # （mode 字串維持 CC / CCC 的 legacy 輸出，避免破壞舊 script。）
 
@@ -20,6 +21,13 @@ set -euo pipefail
 branch="$(git branch --show-current 2>/dev/null || echo 'unknown')"
 uname_s="$(uname -s)"
 cwd="$(pwd)"
+codex_origin="${CODEX_INTERNAL_ORIGINATOR_OVERRIDE:-}"
+bundle_id="${__CFBundleIdentifier:-}"
+
+codex_runtime=false
+if [[ -n "${CODEX_SHELL:-}" || "$bundle_id" == "com.openai.codex" || "$codex_origin" == *Codex* ]]; then
+  codex_runtime=true
+fi
 
 # CCC 判斷條件（三個都要中才算 CCC）：
 #   1. branch 開頭是 claude/（harness 自動建的 branch）
@@ -34,8 +42,13 @@ ccc_cwd=false
 
 if $ccc_branch && $ccc_os && $ccc_cwd; then
   mode=CCC
+  human_mode=CCC
+elif $codex_runtime; then
+  mode=CC
+  human_mode=mac-cdx
 else
   mode=CC
+  human_mode=mac-CC
 fi
 
 echo "$mode"
@@ -43,15 +56,24 @@ echo "$mode"
 # 提示訊息走 stderr，這樣 `mode=$(./scripts/detect-env.sh)` 只會拿到純 mode
 {
   echo
-  echo "env: branch=$branch os=$uname_s cwd=$cwd"
+  echo "env: mode=$human_mode branch=$branch os=$uname_s cwd=$cwd"
   if [[ "$mode" == "CCC" ]]; then
     cat <<'TIPS'
 
-You are Cloud Claude Code (CCC).
+You are Cloud Codex/Claude Code (CCC).
   - Move fast, merge fast, fix fast — this branch is disposable
   - Self-merge after CI green; forward fix before revert
   - Quality gates (pre-commit, pre-push, tribunal) are non-negotiable
   - FULL PLAYBOOK: playbooks/CCC-playbook.md ← read this next
+TIPS
+  elif [[ "$human_mode" == "mac-cdx" ]]; then
+    cat <<'TIPS'
+
+You are Local Codex Desktop / Codex CLI (mac-cdx).
+  - Observe env first: git worktree list, current branch, git status
+  - User often uses worktrees — do NOT assume you're on main
+  - Use Codex-native tools when available; do not assume Claude Code-only tooling
+  - FULL PLAYBOOK: playbooks/mac-CC-playbook.md ← legacy path, mac-cdx rules live there
 TIPS
   else
     cat <<'TIPS'


### PR DESCRIPTION
## Summary
- teach detect-env to identify Codex Desktop as mac-cdx while keeping legacy CC/CCC stdout
- update local playbook and AGENTS wording for mac-cdx/mac-CC
- ignore score-only tribunal pilot outputs under .score-loop/pilots

## Verification
- bash -n scripts/detect-env.sh
- ./scripts/detect-env.sh
- git diff --check
- pre-commit checks via git commit
- pre-push checks via git push