### PR TITLE
fix: auto-fold long ShroomDogNotes

### DIFF
--- a/docs/shroomdog-editorial-feedback.md
+++ b/docs/shroomdog-editorial-feedback.md
@@ -50,6 +50,13 @@
 - 修法：先改成「每天固定完成一段『不用 AI 手寫 code 的配額』」仍然太硬；再依 ShroomDog 指示改成「每天固定手寫一定量的 code」。
 - Reusable lesson：中英混寫時，不要把 English shorthand 直譯成缺賓語或硬組裝的中文名詞片語。`handwritten-code quota` 要寫成「每天固定手寫一定量的 code」這種正常中文動作句，不要寫「手寫配額」或「手寫 code 的配額」。
 
+### Feedback: ShroomDogNote 太長時要自動收合，不要把 Note 牆砸到讀者臉上
+
+- ShroomDog feedback：`ShroomDogNote should also be auto-folded when too long. Do not throw a wall of text of *Note to reader's face`
+- 情境：SP-205 的 ShroomDogNote 承載了 ShroomDog 本人的長段吐槽。拆成 ShroomDogNote 是對的，但如果整段直接展開，讀者會在正文前被一大塊 note 擋住，閱讀節奏被打斷。
+- 修法：在 `ShroomDogNote.astro` 加入預設啟用的 auto-fold。內容高度超過門檻時，先顯示前段 preview + 漸層淡出 +「展開完整 ShroomDogNote」按鈕；短 note 維持原樣。保留 `autoFold={false}` 和 `collapseThreshold` 讓個別 note 可覆寫。
+- Reusable lesson：所有 *Note 元件都要避免「牆式插話」。Note 是旁白，不是路障；長 note 應該預設收合，讓讀者自己選擇是否展開。
+
 ## 2026-05-08 — SP-192 Codex Goals
 
 ### Feedback: weird prompt delimiter 要 fact-check，也要解釋

--- a/src/components/ShroomDogNote.astro
+++ b/src/components/ShroomDogNote.astro
@@ -6,9 +6,13 @@
 interface Props {
   /** Optional custom prefix */
   prefix?: string;
+  /** Auto-collapse notes taller than this many pixels. Set autoFold={false} to disable. */
+  collapseThreshold?: number;
+  /** Whether long ShroomDogNotes should auto-collapse. Defaults to true. */
+  autoFold?: boolean;
 }
 
-const { prefix } = Astro.props;
+const { prefix, collapseThreshold = 260, autoFold = true } = Astro.props;
 
 // Detect language from URL path
 const isEnglish = Astro.url.pathname.startsWith('/en/');
@@ -57,16 +61,80 @@ function hashString(str: string): number {
 
 const contentHash = hashString(slotContent);
 const selectedPrefix = prefix || prefixes[contentHash % prefixes.length];
+const contentId = `shroomdog-note-content-${contentHash}`;
+const expandLabel = isEnglish ? 'Read full ShroomDogNote' : '展開完整 ShroomDogNote';
+const collapseLabel = isEnglish ? 'Collapse ShroomDogNote' : '收合 ShroomDogNote';
 ---
 
-<blockquote class="shroomdog-note">
+<blockquote
+  class="shroomdog-note"
+  data-shroomdog-note
+  data-auto-fold={autoFold ? 'true' : 'false'}
+  data-collapse-threshold={collapseThreshold}
+>
   <strong class="shroomdog-prefix">
     <img src="/avatar.jpg" alt="ShroomDog" class="shroomdog-prefix-icon" width="22" height="22" />
     {selectedPrefix}
   </strong>
-  <br />
-  <Fragment set:html={slotContent} />
+  <div class="shroomdog-note-content" id={contentId}>
+    <Fragment set:html={slotContent} />
+  </div>
+  {
+    autoFold && (
+      <button
+        class="shroomdog-note-toggle"
+        type="button"
+        aria-expanded="false"
+        aria-controls={contentId}
+        data-expand-label={expandLabel}
+        data-collapse-label={collapseLabel}
+        hidden
+      >
+        <span class="shroomdog-note-toggle-icon" aria-hidden="true">
+          ▾
+        </span>
+        <span class="shroomdog-note-toggle-label">{expandLabel}</span>
+      </button>
+    )
+  }
 </blockquote>
+
+<script>
+  function setShroomDogNoteCollapsed(note: HTMLElement, collapsed: boolean) {
+    const toggle = note.querySelector<HTMLButtonElement>('.shroomdog-note-toggle');
+    const label = note.querySelector<HTMLElement>('.shroomdog-note-toggle-label');
+    const expandLabel = toggle?.dataset.expandLabel || '展開完整 ShroomDogNote';
+    const collapseLabel = toggle?.dataset.collapseLabel || '收合 ShroomDogNote';
+
+    note.dataset.collapsed = collapsed ? 'true' : 'false';
+    if (toggle) toggle.setAttribute('aria-expanded', (!collapsed).toString());
+    if (label) label.textContent = collapsed ? expandLabel : collapseLabel;
+  }
+
+  function initShroomDogNote(note: HTMLElement) {
+    if (note.dataset.autoFold !== 'true' || note.dataset.initialized === 'true') return;
+
+    const content = note.querySelector<HTMLElement>('.shroomdog-note-content');
+    const toggle = note.querySelector<HTMLButtonElement>('.shroomdog-note-toggle');
+    if (!content || !toggle) return;
+
+    note.dataset.initialized = 'true';
+    const threshold = Number(note.dataset.collapseThreshold) || 260;
+    content.style.setProperty('--shroomdog-note-collapsed-height', `${threshold}px`);
+
+    if (content.scrollHeight <= threshold) return;
+
+    note.dataset.collapsible = 'true';
+    toggle.hidden = false;
+    setShroomDogNoteCollapsed(note, true);
+
+    toggle.addEventListener('click', () => {
+      setShroomDogNoteCollapsed(note, note.dataset.collapsed !== 'true');
+    });
+  }
+
+  document.querySelectorAll<HTMLElement>('[data-shroomdog-note]').forEach(initShroomDogNote);
+</script>
 
 <style>
   .shroomdog-note {
@@ -88,6 +156,69 @@ const selectedPrefix = prefix || prefixes[contentHash % prefixes.length];
     margin-bottom: 0.3rem;
   }
 
+  .shroomdog-note-content {
+    margin-top: 0.55rem;
+    position: relative;
+  }
+
+  .shroomdog-note-content :global(p:first-child) {
+    margin-top: 0;
+  }
+
+  .shroomdog-note-content :global(p:last-child) {
+    margin-bottom: 0;
+  }
+
+  .shroomdog-note[data-collapsed='true'] .shroomdog-note-content {
+    max-height: var(--shroomdog-note-collapsed-height, 260px);
+    overflow: hidden;
+  }
+
+  .shroomdog-note[data-collapsed='true'] .shroomdog-note-content::after {
+    background: linear-gradient(
+      to bottom,
+      rgba(108, 157, 58, 0),
+      rgba(108, 157, 58, 0.06) 72%,
+      rgba(108, 157, 58, 0.12)
+    );
+    bottom: 0;
+    content: '';
+    height: 4.5rem;
+    left: 0;
+    pointer-events: none;
+    position: absolute;
+    right: 0;
+  }
+
+  .shroomdog-note-toggle {
+    align-items: center;
+    background: transparent;
+    border: 0;
+    color: #5a8a2e;
+    cursor: pointer;
+    display: inline-flex;
+    font: inherit;
+    font-size: 0.9rem;
+    font-weight: 700;
+    gap: 0.35rem;
+    margin-top: 0.8rem;
+    padding: 0;
+  }
+
+  .shroomdog-note-toggle:hover {
+    text-decoration: underline;
+    text-underline-offset: 0.18em;
+  }
+
+  .shroomdog-note-toggle-icon {
+    display: inline-block;
+    transition: transform 160ms ease;
+  }
+
+  .shroomdog-note[data-collapsed='false'] .shroomdog-note-toggle-icon {
+    transform: rotate(180deg);
+  }
+
   .shroomdog-prefix-icon {
     display: inline-block;
     vertical-align: middle;
@@ -105,7 +236,14 @@ const selectedPrefix = prefix || prefixes[contentHash % prefixes.length];
     font-style: normal;
   }
 
-  :global([data-theme='dark']) .shroomdog-prefix {
+  :global([data-theme='dark']) .shroomdog-prefix,
+  :global([data-theme='dark']) .shroomdog-note-toggle {
     color: #93bd98;
+  }
+
+  :global([data-theme='dark'])
+    .shroomdog-note[data-collapsed='true']
+    .shroomdog-note-content::after {
+    background: linear-gradient(to bottom, rgba(0, 0, 0, 0), var(--color-surface) 82%);
   }
 </style>

--- a/tests/shroomdog-note.spec.ts
+++ b/tests/shroomdog-note.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect } from './fixtures';
+
+test.describe('ShroomDogNote auto-fold', () => {
+  const testPostUrl = '/posts/sp-205-20260517-addyosmani-dont-outsource-learning/';
+
+  test('GIVEN a long ShroomDogNote WHEN page loads THEN it is collapsed behind a toggle', async ({ page }) => {
+    await page.goto(testPostUrl);
+
+    const note = page.locator('.shroomdog-note').first();
+    await expect(note).toBeVisible();
+    await expect(note).toHaveAttribute('data-collapsible', 'true');
+    await expect(note).toHaveAttribute('data-collapsed', 'true');
+
+    const toggle = note.locator('.shroomdog-note-toggle');
+    await expect(toggle).toBeVisible();
+    await expect(toggle).toContainText('展開完整 ShroomDogNote');
+    await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  test('GIVEN a collapsed ShroomDogNote WHEN reader clicks toggle THEN it expands and can collapse again', async ({ page }) => {
+    await page.goto(testPostUrl);
+
+    const note = page.locator('.shroomdog-note').first();
+    const toggle = note.locator('.shroomdog-note-toggle');
+
+    await toggle.click();
+    await expect(note).toHaveAttribute('data-collapsed', 'false');
+    await expect(toggle).toContainText('收合 ShroomDogNote');
+    await expect(toggle).toHaveAttribute('aria-expanded', 'true');
+
+    await toggle.click();
+    await expect(note).toHaveAttribute('data-collapsed', 'true');
+    await expect(toggle).toContainText('展開完整 ShroomDogNote');
+    await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+  });
+});


### PR DESCRIPTION
## Summary
- Auto-collapse ShroomDogNote when rendered content is taller than the default threshold
- Show a preview + fade + expand/collapse button instead of throwing a note wall at readers
- Keep short ShroomDogNotes unchanged
- Add props for opt-out (`autoFold={false}`) and threshold override (`collapseThreshold`)
- Add Playwright coverage for SP-205 long ShroomDogNote
- Record ShroomDog feedback in the editorial corpus

## Test Plan
- pnpm exec astro check
- pnpm run build
- node scripts/validate-posts.mjs src/content/posts/sp-205-20260517-addyosmani-dont-outsource-learning.mdx src/content/posts/en-sp-205-20260517-addyosmani-dont-outsource-learning.mdx
- node scripts/check-jingjing.mjs src/content/posts/sp-205-20260517-addyosmani-dont-outsource-learning.mdx
- pnpm exec playwright test tests/shroomdog-note.spec.ts --project="Desktop Chrome"
- pnpm run links:check -- --internal-only --ci
