### PR TITLE
Fix Tribunal runner error guard

### DIFF
--- a/scripts/tests/test-tribunal-runner-error-guard.sh
+++ b/scripts/tests/test-tribunal-runner-error-guard.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Regression test: a broken judge runner must stop Tribunal as infrastructure
+# failure, not mark the article FAILED/EXHAUSTED.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TRIBUNAL="$ROOT_DIR/scripts/tribunal.sh"
+
+fail() { echo "x $*" >&2; exit 1; }
+pass() { echo "ok $*"; }
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+fake_bin="$TMP/bin"
+mkdir -p "$fake_bin"
+cat > "$fake_bin/codex" <<'FAKE_CODEX'
+#!/usr/bin/env bash
+if [ "${1:-}" = "exec" ] && [ "${2:-}" = "--help" ]; then
+  echo "fake codex exec help"
+  exit 0
+fi
+if [ "${1:-}" = "exec" ]; then
+  echo "fake codex runner crashed before writing score" >&2
+  exit 1
+fi
+echo "fake codex" >&2
+exit 1
+FAKE_CODEX
+chmod +x "$fake_bin/codex"
+
+progress="$TMP/progress.json"
+printf '{}\n' > "$progress"
+
+set +e
+PATH="$fake_bin:$PATH" \
+TRIBUNAL_SCORE_ONLY_PROGRESS_FILE="$progress" \
+TRIBUNAL_CODEX_TIMEOUT_SEC=5 \
+TRIBUNAL_CODEX_IDLE_TIMEOUT_SEC=5 \
+TRIBUNAL_CODEX_IDLE_POLL_SEC=1 \
+bash "$TRIBUNAL" --score-only --only-stage factChecker sp-1-20260128-demo.mdx \
+  >"$TMP/tribunal.out" 2>"$TMP/tribunal.err"
+rc=$?
+set -e
+
+if [ "$rc" -ne 70 ]; then
+  sed -n '1,120p' "$TMP/tribunal.out" >&2 || true
+  sed -n '1,120p' "$TMP/tribunal.err" >&2 || true
+  fail "runner crash should exit 70, got $rc"
+fi
+pass "runner crash exits with temporary infrastructure failure"
+
+article_status="$(jq -r '."sp-1-20260128-demo.mdx".status // empty' "$progress")"
+stage_status="$(jq -r '."sp-1-20260128-demo.mdx".stages.factChecker.status // empty' "$progress")"
+attempts="$(jq -r '."sp-1-20260128-demo.mdx".topLevelAttempts // empty' "$progress")"
+
+[ "$article_status" = "RUNNER_ERROR" ] || fail "article status should be RUNNER_ERROR, got '$article_status'"
+[ "$stage_status" = "runner_error" ] || fail "stage status should be runner_error, got '$stage_status'"
+[ "$attempts" = "0" ] || fail "runner error should not consume topLevelAttempts, got '$attempts'"
+pass "runner error is recorded as retryable infrastructure state"
+
+if jq -e '."sp-1-20260128-demo.mdx".status == "FAILED" or ."sp-1-20260128-demo.mdx".status == "EXHAUSTED"' "$progress" >/dev/null; then
+  fail "runner crash polluted content status as FAILED/EXHAUSTED"
+fi
+pass "runner crash does not become content failure/exhaustion"
+
+if ! grep -q 'runner_error propagated' "$ROOT_DIR/scripts/tribunal-quota-loop.sh"; then
+  fail "quota loop does not drain on tribunal runner_error"
+fi
+pass "quota loop drains instead of sweeping the queue after runner_error"

--- a/scripts/tribunal-quota-loop.sh
+++ b/scripts/tribunal-quota-loop.sh
@@ -762,7 +762,8 @@ spawn_worker() {
 }
 
 # Wait for ANY worker to finish. Releases its claim, logs outcome, clears
-# tracking state. Propagates rc=77 (stopped_by_request) to exit_stopped.
+# tracking state. Propagates rc=77 (stopped_by_request) and rc=70
+# (runner infrastructure failure) into drain mode.
 wait_any_worker() {
   # bash: wait -n returns when ANY child exits, sets $? to its status.
   local rc=0
@@ -794,6 +795,11 @@ wait_any_worker() {
     77) tlog "  [worker-$finished_id] $article_slug — stopped_by_request propagated."
         stop_requested=true
         stop_source="${stop_source:-propagated-from-worker}"
+        ;;
+    70) tlog "  [worker-$finished_id] $article_slug — runner_error propagated; draining to avoid poisoning more articles."
+        stop_requested=true
+        stop_source="${stop_source:-runner-error}"
+        rc_write_state "draining" "runner_error article=$article_slug"
         ;;
     *)  tlog "  [worker-$finished_id] $article_slug — failed (rc=$rc)" ;;
   esac

--- a/scripts/tribunal.sh
+++ b/scripts/tribunal.sh
@@ -285,6 +285,36 @@ mark_article_failed() {
   ) 9>>"$RC_PROGRESS_LOCK"
 }
 
+mark_article_runner_error() {
+  local article="$1" failed_stage="$2" model="$3" attempts="$4" reason="$5"
+  (
+    flock -x 9
+    local tmp
+    tmp="$(mktemp)"
+    jq --arg a "$article" \
+       --arg s "$failed_stage" \
+       --arg model "$model" \
+       --arg reason "$reason" \
+       --argjson attempts "$attempts" \
+       --argjson tribunalVersion "$TRIBUNAL_VERSION" \
+       --arg ts "$(TZ=Asia/Taipei date -Iseconds)" \
+       '.[$a].status = "RUNNER_ERROR"
+        | .[$a].failedStage = $s
+        | .[$a].finishedAt = $ts
+        | .[$a].tribunalVersion = $tribunalVersion
+        | .[$a].topLevelAttempts = ([((.[$a].topLevelAttempts // 0) - 1), 0] | max)
+        | .[$a].stages[$s] = {
+            status: "runner_error",
+            score: null,
+            model: $model,
+            attempts: $attempts,
+            tribunalVersion: $tribunalVersion,
+            error: $reason
+          }' \
+       "$PROGRESS_FILE" > "$tmp" && mv "$tmp" "$PROGRESS_FILE"
+  ) 9>>"$RC_PROGRESS_LOCK"
+}
+
 mark_article_passed() {
   local article="$1"
   (
@@ -697,15 +727,15 @@ PROMPT
 
     # ── Validate score JSON ───────────────────────────────────────────────────
     if ! validate_judge_score_json "$validate_name" "$score_tmp"; then
-      tlog "  ERROR: Invalid/missing $label score JSON schema on attempt $attempt; failing loudly without writer rewrite."
+      tlog "  ERROR: Invalid/missing $label score JSON schema on attempt $attempt; treating as runner infrastructure failure."
       if [ -f "$score_tmp" ]; then
         local raw
         raw="$(head -3 "$score_tmp" 2>/dev/null | tr '\n' ' ')"
         tlog "  Raw (head): $raw"
       fi
-      write_stage_progress "$post_file" "$stage_key" "fail" "null" "$runner_label" "$attempt"
+      mark_article_runner_error "$post_file" "$stage_key" "$runner_label" "$attempt" "invalid_or_missing_score_json"
       rm -f "$score_tmp"
-      return 1
+      return 70
     fi
 
     local score_json composite verdict
@@ -945,9 +975,15 @@ for stage_def in "${STAGES[@]}"; do
     continue
   fi
 
-  if ! run_stage \
-      "$stage_key" "$agent_name" "$validate_name" "$label" \
-      "$max_loops" "$runner_label" "$POST_FILE" "$fm_judge_key"; then
+  stage_rc=0
+  run_stage \
+    "$stage_key" "$agent_name" "$validate_name" "$label" \
+    "$max_loops" "$runner_label" "$POST_FILE" "$fm_judge_key" || stage_rc=$?
+  if [ "$stage_rc" -eq 70 ]; then
+    tlog "=== RUNNER ERROR at stage: $label ==="
+    commit_progress "tribunal(${POST_FILE%.mdx}): RUNNER_ERROR at $label stage"
+    exit 70
+  elif [ "$stage_rc" -ne 0 ]; then
     tlog "=== FAILED at stage: $label ==="
     mark_article_failed "$POST_FILE" "$stage_key"
     commit_progress "tribunal(${POST_FILE%.mdx}): FAILED at $label stage"


### PR DESCRIPTION
## Summary
- Treat missing/invalid judge score JSON as Tribunal runner infrastructure failure instead of content failure
- Record retryable RUNNER_ERROR without consuming top-level article attempts
- Drain quota loop on runner_error so one broken judge cannot poison the queue

## Tests
- bash scripts/tests/test-tribunal-runner-error-guard.sh
- bash scripts/tests/test-tribunal-safety-contract.sh
- bash scripts/tests/test-frontmatter-scores-v5.sh
- bash -n scripts/tribunal.sh scripts/tribunal-quota-loop.sh scripts/tests/test-tribunal-runner-error-guard.sh