### PR TITLE
Fix Tribunal Codex PATH guard

### DIFF
--- a/scripts/cc-tribunal-loop-wrapper.sh
+++ b/scripts/cc-tribunal-loop-wrapper.sh
@@ -8,7 +8,7 @@
 
 set -euo pipefail
 export TZ=Asia/Taipei
-export PATH="$HOME/bin:$HOME/.local/bin:$PATH"
+export PATH="$HOME/.local/bin:$HOME/bin:$PATH"
 export CLAUDE_CODE_OAUTH_TOKEN
 CLAUDE_CODE_OAUTH_TOKEN=$(head -1 "$HOME/.cc-cron-token")
 

--- a/scripts/tests/test-tribunal-runner-error-guard.sh
+++ b/scripts/tests/test-tribunal-runner-error-guard.sh
@@ -22,6 +22,10 @@ if [ "${1:-}" = "exec" ] && [ "${2:-}" = "--help" ]; then
   echo "fake codex exec help"
   exit 0
 fi
+if [ "${1:-}" = "--version" ]; then
+  echo "codex-cli 0.128.0"
+  exit 0
+fi
 if [ "${1:-}" = "exec" ]; then
   echo "fake codex runner crashed before writing score" >&2
   exit 1
@@ -70,3 +74,35 @@ if ! grep -q 'runner_error propagated' "$ROOT_DIR/scripts/tribunal-quota-loop.sh
   fail "quota loop does not drain on tribunal runner_error"
 fi
 pass "quota loop drains instead of sweeping the queue after runner_error"
+
+old_bin="$TMP/old-bin"
+mkdir -p "$old_bin"
+cat > "$old_bin/codex" <<'OLD_CODEX'
+#!/usr/bin/env bash
+if [ "${1:-}" = "exec" ] && [ "${2:-}" = "--help" ]; then
+  echo "old codex exec help"
+  exit 0
+fi
+if [ "${1:-}" = "--version" ]; then
+  echo "codex-cli 0.106.0"
+  exit 0
+fi
+echo "old codex should not run a judge" >&2
+exit 1
+OLD_CODEX
+chmod +x "$old_bin/codex"
+
+old_progress="$TMP/old-progress.json"
+printf '{}\n' > "$old_progress"
+set +e
+PATH="$old_bin:$PATH" \
+TRIBUNAL_SCORE_ONLY_PROGRESS_FILE="$old_progress" \
+bash "$TRIBUNAL" --score-only --only-stage factChecker sp-1-20260128-demo.mdx \
+  >"$TMP/old.out" 2>"$TMP/old.err"
+old_rc=$?
+set -e
+
+[ "$old_rc" -eq 70 ] || fail "old Codex CLI should exit 70 before judging, got $old_rc"
+[ "$(jq 'length' "$old_progress")" = "0" ] || fail "old Codex CLI should not initialize article progress"
+grep -q 'older than required' "$TMP/old.err" || fail "old Codex rejection did not explain version requirement"
+pass "old Codex CLI is rejected before article progress is touched"

--- a/scripts/tests/test-tribunal-safety-contract.sh
+++ b/scripts/tests/test-tribunal-safety-contract.sh
@@ -8,6 +8,7 @@ ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 TRIBUNAL="$ROOT_DIR/scripts/tribunal.sh"
 VIBE="$ROOT_DIR/scripts/vibe-scorer.sh"
 HELPERS="$ROOT_DIR/scripts/tribunal-helpers.sh"
+WRAPPER="$ROOT_DIR/scripts/cc-tribunal-loop-wrapper.sh"
 CODEX_AGENTS_DIR="$ROOT_DIR/.codex/agents"
 CODEX_WRITER="$CODEX_AGENTS_DIR/tribunal-writer.toml"
 
@@ -75,6 +76,12 @@ pass "Codex agent specs are separated from Claude Code frontmatter"
 
 if ! grep -q -- '--model gpt-5.5' "$HELPERS"; then
   fail "Codex tribunal helper is not pinned to GPT-5.5"
+fi
+if ! grep -q 'MIN_CODEX_VERSION="0.128.0"' "$TRIBUNAL"; then
+  fail "Tribunal does not reject known-broken old Codex CLI versions"
+fi
+if ! grep -Fq 'export PATH="$HOME/.local/bin:$HOME/bin:$PATH"' "$WRAPPER"; then
+  fail "Tribunal systemd wrapper does not prefer the current ~/.local/bin Codex before stale ~/bin"
 fi
 if ! grep -q 'local model_id="gpt-5.5"' "$TRIBUNAL"; then
   fail "Tribunal frontmatter/logging model_id is not pinned to GPT-5.5"

--- a/scripts/tribunal-helpers.sh
+++ b/scripts/tribunal-helpers.sh
@@ -151,6 +151,25 @@ tribunal_codex_cmd() {
   return 1
 }
 
+tribunal_codex_version() {
+  local codex_cmd
+  codex_cmd="$(tribunal_codex_cmd)" || return 1
+  $codex_cmd --version 2>/dev/null | awk '{print $NF; exit}'
+}
+
+tribunal_codex_version_at_least() {
+  local actual="$1" required="$2"
+  python3 - "$actual" "$required" <<'PY'
+import re, sys
+
+def parts(v):
+    nums = [int(x) for x in re.findall(r'\d+', v)[:3]]
+    return tuple((nums + [0, 0, 0])[:3])
+
+sys.exit(0 if parts(sys.argv[1]) >= parts(sys.argv[2]) else 1)
+PY
+}
+
 # Run a repo-local agent spec through Codex. Codex custom agents live in
 # `.codex/agents/*.toml`, but `codex exec` has no stable `--agent` flag for this
 # non-interactive tribunal path, so we inline the project-scoped Codex agent

--- a/scripts/tribunal.sh
+++ b/scripts/tribunal.sh
@@ -943,7 +943,13 @@ for _cmd in jq python3 pnpm git flock timeout; do
 done
 if ! tribunal_codex_cmd >/dev/null 2>&1; then
   echo "ERROR: Required Codex CLI missing: install codex or provide the bundled node entrypoint" >&2
-  exit 1
+  exit 70
+fi
+CODEX_VERSION="$(tribunal_codex_version || true)"
+MIN_CODEX_VERSION="0.128.0"
+if [ -z "$CODEX_VERSION" ] || ! tribunal_codex_version_at_least "$CODEX_VERSION" "$MIN_CODEX_VERSION"; then
+  echo "ERROR: Codex CLI version $CODEX_VERSION is older than required $MIN_CODEX_VERSION; check tribunal service PATH" >&2
+  exit 70
 fi
 
 if [ -d .git/rebase-merge ] || [ -d .git/rebase-apply ]; then


### PR DESCRIPTION
## Summary
- Prefer ~/.local/bin Codex before stale ~/bin in tribunal systemd wrapper
- Reject known-broken old Codex CLI before article progress is initialized
- Extend runner-error regression coverage for old CLI version drift

## Tests
- bash scripts/tests/test-tribunal-runner-error-guard.sh
- bash scripts/tests/test-tribunal-safety-contract.sh
- bash scripts/tests/test-frontmatter-scores-v5.sh
- bash -n scripts/tribunal.sh scripts/tribunal-helpers.sh scripts/cc-tribunal-loop-wrapper.sh