### PR TITLE
SP-208: OpenAI Codex Goals official guide

### DIFF
--- a/scripts/article-counter.json
+++ b/scripts/article-counter.json
@@ -5,7 +5,7 @@
     "description": "Original articles written by ShroomDog"
   },
   "SP": {
-    "next": 208,
+    "next": 209,
     "label": "ShroomDog Picks",
     "description": "Articles picked by ShroomDog, translated by Clawd"
   },

--- a/src/content/posts/en-sp-207-20260518-pawelhuryn-agent-goal-intent.mdx
+++ b/src/content/posts/en-sp-207-20260518-pawelhuryn-agent-goal-intent.mdx
@@ -45,7 +45,7 @@ That is progress. But a goal alone does not define safe work.
 
 The basic idea behind `/goal` is simple: give the agent a measurable completion condition. Tests pass. A feature works. An existing flow does not break. The agent no longer waits for every next instruction; it keeps moving around that finish line.
 
-gu-log has already covered [Codex](/glossary#codex) [`/goal` mode](/posts/sp-197-20260512-chrishayduk-codex-goals/) and the difference between [Codex Goals and long-running agent safety](/posts/sp-192-20260508-article-agent-ralph/). But this post only needs one idea: goal mode can help an agent avoid stopping too early. It does not automatically create production governance.
+gu-log has already covered [Codex](/en/glossary#codex) [`/goal` mode](/en/posts/en-sp-197-20260512-chrishayduk-codex-goals/), the difference between [Codex Goals and long-running agent safety](/en/posts/en-sp-192-20260508-article-agent-ralph/), and OpenAI's official [Codex Goals guide](/en/posts/en-sp-208-20260509-openai-codex-goals-cookbook/). But this post only needs one idea: goal mode can help an agent avoid stopping too early. It does not automatically create production governance.
 
 This is not a claim that OpenAI Codex and Anthropic [Claude Code](/glossary#claude-code) ship the exact same product behavior. Product details should be checked against each vendor. The useful point here is the governance gap that Paweł Huryn's intent framework helps name.
 

--- a/src/content/posts/en-sp-208-20260509-openai-codex-goals-cookbook.mdx
+++ b/src/content/posts/en-sp-208-20260509-openai-codex-goals-cookbook.mdx
@@ -1,0 +1,184 @@
+---
+ticketId: "SP-208"
+title: "OpenAI's Codex Goals Guide: Agents Should Not Finish by Vibes"
+originalDate: "2026-05-09"
+translatedDate: "2026-05-20"
+translatedBy:
+  model: "GPT-5.5"
+  harness: "Codex CLI"
+  pipeline:
+    - role: "Written"
+      model: "GPT-5.5"
+      harness: "Codex CLI"
+    - role: "Reviewed"
+      model: "GPT-5.5"
+      harness: "Codex CLI"
+source: "OpenAI Cookbook"
+sourceUrl: "https://developers.openai.com/cookbook/examples/codex/using_goals_in_codex"
+lang: "en"
+summary: "OpenAI's Cookbook frames Codex Goals as a thread-scoped completion contract: the objective persists, but completion must be checked against evidence. This post fills in the official spec angle around SP-192, SP-197, and SP-207."
+tags: ["shroom-picks", "codex", "agent", "ai-engineering"]
+---
+
+import ClawdNote from '../../components/ClawdNote.astro';
+
+The most dangerous fantasy around long-running [agents](/en/glossary#agent) is confusing "it keeps going" with "it is still right."
+
+OpenAI's Cookbook guide gives Codex Goals a cleaner definition than the hype usually does. A Goal is not just a longer [prompt](/en/glossary#prompt), and it is not an agent roaming freely in the background. It is a completion contract attached to a thread: what should be true, what evidence should prove it, and which constraints must stay intact.
+
+That makes this worth adding to gu-log. [SP-192](/en/posts/en-sp-192-20260508-article-agent-ralph/) covered Codex Goals and long-running agent drift. [SP-197](/en/posts/en-sp-197-20260512-chrishayduk-codex-goals/) covered the practical loop: finish line, tests, and file memory. [SP-207](/en/posts/en-sp-207-20260518-pawelhuryn-agent-goal-intent/) put goals inside a larger governance frame. The official guide adds the product language: **the objective can persist, but evidence decides whether the work is done.**
+
+<ClawdNote summary="This is not a rewrite of the earlier posts. It is the official calibration point.">
+If this post simply repeated how to use /goal, it would be duplicate content. SP-197 already did the practical version well, and SP-207 already covered the governance gap.
+
+The useful thing here is OpenAI's mental model: a Goal is a thread-scoped completion contract. In plain words, this thread now has a work order, but it cannot be closed by vibes. It needs evidence.
+</ClawdNote>
+
+## A prompt says the next step. A Goal says what done means.
+
+The guide's most important distinction is the difference between a prompt and a Goal.
+
+A prompt says: do this next thing.
+
+A Goal says: keep working until this outcome is true.
+
+That sounds subtle, but it changes the operating model. A normal prompt is like handing someone a sticky note: "fix this bug." They work once, report back, and wait. A Goal is more like a ticket: if the issue is not actually resolved, the ticket should not close itself.
+
+OpenAI's examples are also well chosen: performance tuning, flaky test investigation, dependency migration, bug reproduction, multi-step refactors, benchmark-driven tuning, and research work. These tasks have a definable endpoint, but the path depends on what the agent learns along the way.
+
+So Goals are not for "fix this typo." A normal prompt is better there. Goals are for work where every iteration changes the next best move.
+
+~~~text
+/goal Reduce p95 checkout latency below 120 ms on the checkout benchmark while keeping the correctness suite green
+~~~
+
+That is not just a fancier way to say "make checkout faster." It defines three things at once: p95 latency must be under 120ms, the checkout benchmark is the proof surface, and the correctness suite must remain green. After every round, the agent can compare the actual state against those conditions instead of asking, "does this feel better?"
+
+<ClawdNote>
+"Does this feel better?" is a dangerous phrase in agent workflows. It is like asking a designer to make the UI "more premium." Three hours later, the screen may be black, purple, glassy, and every button looks like nightclub admission. Lots of effort. No acceptance criteria. (◕‿◕)
+</ClawdNote>
+
+---
+
+## A good Goal has six parts, not just more words
+
+The Cookbook breaks a strong Goal into six pieces:
+
+1. Outcome: what should be true when the work is done.
+2. Verification surface: the test, benchmark, report, artifact, command output, or source material that proves it.
+3. Constraints: what must not regress.
+4. Boundaries: which files, tools, data, repositories, or resources the agent may use.
+5. Iteration policy: how the agent should pick the next useful action after each attempt.
+6. Blocked stop condition: when the agent should stop and report that no defensible path remains.
+
+The point is not making the prompt longer. The point is making completion auditable.
+
+A weak Goal looks like this:
+
+~~~text
+/goal Improve performance
+~~~
+
+A stronger Goal says:
+
+~~~text
+/goal Reduce p95 checkout latency below 120 ms, verified by the checkout benchmark, while keeping the correctness suite green. Use only the checkout service, benchmark fixtures, and related tests. Between iterations, record what changed, what the benchmark showed, and the next best experiment to try. If the benchmark cannot run or no valid paths remain, stop with the attempted paths, the evidence gathered, the blocker, and the next input needed.
+~~~
+
+The difference is not length. The second version tells the agent how to finish, and also when it is not allowed to claim success.
+
+If p95 drops from 180ms to 135ms, the Goal is not done. If it drops to 110ms but the correctness suite fails, the Goal is still not done. If the benchmark cannot run, that is a blocker, not completion. This separates "lots of activity" from "the condition is satisfied."
+
+This matches the lesson gu-log keeps circling back to: long-running agents are not short on effort. They are short on acceptance criteria. Without acceptance criteria, an agent can treat "I did many things" as "I got closer."
+
+<ClawdNote>
+It is like fitness. "Get healthier" lets almost anything count: jog for five minutes, drink water, buy new shoes. "Run 5K under 30 minutes in three months without knee pain, while logging pace and recovery every week" is harder to fake.
+
+Agents are similar. Wishes start the motion. Measurement tells the system whether the motion is going anywhere useful.
+</ClawdNote>
+
+---
+
+## A Goal is thread state, not global memory
+
+The architecture section has one boundary that matters: Goals are persisted thread state, not global memory and not project-level instructions.
+
+In normal engineering language: the Goal belongs to the thread because the evidence belongs to the thread. The files Codex inspected, the commands it ran, the diffs it produced, the logs it saw, and the reasoning trail it built all live in that conversation context. Attaching the Goal there is more precise than putting it in global memory or project config.
+
+This also explains why Goals are not background autonomy.
+
+The official continuation policy is conservative. Codex considers continuing only when the thread is idle, the Goal is active, no user input is queued, no other thread work is pending, and the Goal is within budget. Plan-only work does not trigger continuation. Interruptions pause the objective. If a continuation turn makes no tool call, the next automatic continuation is suppressed so Codex does not spin.
+
+That sounds boring. It is also the part that makes the feature product-shaped. If Goals were just a while loop, they would quickly become an expensive spinner. A usable long-running system needs rules for when not to continue.
+
+<ClawdNote>
+This is the most engineering-shaped part of the guide. It is not selling the dream that "the agent will finish everything alone." It is describing boundaries.
+
+"Continue only when idle, stop when the user is queued, suppress empty continuations" sounds tiny, but this is how an autonomous loop grows up from a toy into a product. Without this, Goal mode can turn from "watch the ticket" into "burn quota all night in a very confident oven."
+</ClawdNote>
+
+---
+
+## Completion should be audited, not believed
+
+OpenAI keeps returning to evidence-based completion. A Goal should not be marked complete because the model believes it is probably done. It should be checked against concrete evidence: files, tests, logs, benchmark output, generated artifacts, or research evidence.
+
+For coding work, that is easy to understand. Tests pass. Benchmarks hit the target. The build succeeds. But the Cookbook's research example is more interesting.
+
+It uses a reproduction of the Deep Hedging paper. A weak Goal would be:
+
+~~~text
+/goal Reproduce Buehler et al., "Deep Hedging"
+~~~
+
+That is too loose. Which result should be reproduced? What counts as reproduction? If the paper does not provide the original seeds, training paths, TensorFlow graph, optimizer state, checkpoints, or simulation state, how should the agent distinguish approximate reconstruction from exact replay?
+
+The stronger Goal asks Codex to produce the strongest evidence-backed reproduction using the available materials and local resources, attempt the headline results, and end with a report that separates reproduced mechanics, approximate trained results, blocked exact replay, and remaining uncertainty.
+
+That version does not force the agent to pretend the world is complete. When the data is missing, the Goal asks the agent to label the evidence level honestly.
+
+A final ledger entry can look like this:
+
+~~~text
+Claim: Deep hedging approximates complete-market Heston hedge without transaction costs.
+Route: Rebuilt model mechanics, reference hedge comparison, and trained neural policy.
+Evidence surface: Price checks, histograms, and hedge surfaces.
+Status: Close approximate reproduction.
+Remaining uncertainty: Original training paths, seeds, and checkpoints are unavailable.
+~~~
+
+Here, the Goal is not just making research faster. It is making the meaning of "done" more honest. Rebuilt mechanics are called rebuilt mechanics. Approximate results are called approximate. Missing materials are called blockers. The agent can keep working, but the conclusion is not allowed to inflate.
+
+This matters for AI writing and research too. The scary failure mode is often not pure hallucination. It is proxy evidence being presented as a confirmed finding. A well-written Goal can force the final report to preserve evidence levels instead of flattening "looks plausible" into "proved."
+
+---
+
+## When not to use Goals
+
+The negative rules are just as useful.
+
+Do not use a Goal for a one-line edit, a simple explanation, a short code review, or a question where the desired behavior is one answer and then stop. That is like using a construction crane to pick up a sticky note.
+
+Do not use a Goal when the finish line is vague. "Make this better" and "refactor this code" are weak unless the expected end state, tests, and constraints are defined.
+
+Do not use a Goal to hide uncertainty. If data may be unavailable, say so. If a benchmark may be flaky, define how to handle that. If proxy evidence is acceptable, define how it should be labeled.
+
+Those rules are very practical. A Goal should not make uncertainty disappear. It should make uncertainty part of the work contract.
+
+<ClawdNote>
+The easiest way to misuse Goal mode is treating it like a "think less upfront" button. It is the opposite. The longer the task may run, the more clearly the requester needs to define what completion, blocked, and partial evidence mean.
+
+Otherwise the agent will work very hard. That is the scary part. Lazy wrong work is easy to stop. Diligent wrong work builds a whole beautiful building in the wrong city.
+</ClawdNote>
+
+---
+
+## Conclusion
+
+OpenAI's official guide is not valuable because it lists /goal commands. It is valuable because it defines the boundary of responsibility.
+
+A Goal keeps an objective alive, but it does not create unlimited autonomy. It belongs to a thread, not global memory. It can let Codex continue when idle, but continuation has conservative conditions. It can drive long-running work, but completion must be audited. It can handle research uncertainty, but the final result must separate confirmed, approximate, blocked, and uncertain claims.
+
+That is why this belongs in the SP series. It turns several gu-log lessons into official language: the point of long-running agents is not "keep going."
+
+The real point is: let the objective persist, and let evidence decide.

--- a/src/content/posts/sp-207-20260518-pawelhuryn-agent-goal-intent.mdx
+++ b/src/content/posts/sp-207-20260518-pawelhuryn-agent-goal-intent.mdx
@@ -62,7 +62,7 @@ import ClawdNote from '../../components/ClawdNote.astro';
 
 先把背景補平。`/goal` 這類能力，就是把「完成條件」交給 Agent：例如測試要全過、某個功能要能用、某個流程不能壞。Agent 不再每一步都等人推，而是圍著這個終點自己往前走。
 
-前面 gu-log 已經拆過 [Codex](/glossary#codex) 的 [`/goal` 目標模式](/posts/sp-197-20260512-chrishayduk-codex-goals/)，也拆過 [Codex Goals 和長跑 Agent 安全](/posts/sp-192-20260508-article-agent-ralph/) 的差別。沒看過那兩篇也沒關係，這篇只需要抓住一件事：目標模式讓 Agent 比較不容易太早停下來，但不等於正式環境治理已經完成。
+前面 gu-log 已經拆過 [Codex](/glossary#codex) 的 [`/goal` 目標模式](/posts/sp-197-20260512-chrishayduk-codex-goals/)，也拆過 [Codex Goals 和長跑 Agent 安全](/posts/sp-192-20260508-article-agent-ralph/) 的差別；如果要看 OpenAI 官方怎麼定義目標模式，直接看 [SP-208：Codex Goals 官方指南](/posts/sp-208-20260509-openai-codex-goals-cookbook/)。沒看過那幾篇也沒關係，這篇只需要抓住一件事：目標模式讓 Agent 比較不容易太早停下來，但不等於正式環境治理已經完成。
 
 換句話說，這裡不是把 OpenAI 的 Codex 或 Anthropic 的 [Claude Code](/glossary#claude-code) 宣傳成同一套功能；產品細節要回到各自來源，這篇只處理這套意圖工程框架能補上的治理缺口。
 

--- a/src/content/posts/sp-208-20260509-openai-codex-goals-cookbook.mdx
+++ b/src/content/posts/sp-208-20260509-openai-codex-goals-cookbook.mdx
@@ -1,0 +1,184 @@
+---
+ticketId: "SP-208"
+title: "Codex Goals 官方指南：Agent 不是繼續做，是拿證據收工"
+originalDate: "2026-05-09"
+translatedDate: "2026-05-20"
+translatedBy:
+  model: "GPT-5.5"
+  harness: "Codex CLI"
+  pipeline:
+    - role: "Written"
+      model: "GPT-5.5"
+      harness: "Codex CLI"
+    - role: "Reviewed"
+      model: "GPT-5.5"
+      harness: "Codex CLI"
+source: "OpenAI Cookbook"
+sourceUrl: "https://developers.openai.com/cookbook/examples/codex/using_goals_in_codex"
+lang: "zh-tw"
+summary: "OpenAI 官方指南把 Codex Goals 講成對話串範圍內的完成契約：目標會持續存在，但完成必須靠測試、基準測試、報告或研究證據判定。這篇補上 SP-192、SP-197、SP-207 缺的官方規格角度。"
+tags: ["shroom-picks", "codex", "agent", "ai-engineering"]
+---
+
+import ClawdNote from '../../components/ClawdNote.astro';
+
+長跑型 [Agent](/glossary#agent) 最危險的幻想，是把「會繼續做」誤認成「會做對」。
+
+OpenAI 這篇官方指南把 Codex Goals 的定位講得很乾淨：目標模式不是一句比較長的 [Prompt](/glossary#prompt)，也不是把 Agent 放出去自由打獵。它是一個黏在對話串上的完成契約：什麼狀態算完成、用什麼證據檢查、哪些限制不能壞，都要先寫清楚。
+
+這個角度很值得補進 gu-log。前面 [SP-192](/posts/sp-192-20260508-article-agent-ralph/) 已經拆過 Codex Goals 和長跑 Agent 跑偏的問題，[SP-197](/posts/sp-197-20260512-chrishayduk-codex-goals/) 講過實務上要有終點、測試和檔案記憶，[SP-207](/posts/sp-207-20260518-pawelhuryn-agent-goal-intent/) 則把目標放進更大的治理框架。這篇官方文件補上的，是產品本身想讓開發者記住的核心語言：**目標可以持續，完成要靠證據。**
+
+<ClawdNote summary="這篇不是重寫前面三篇，而是官方說法的校準點。">
+這篇如果硬寫成「如何使用 `/goal`」會很重複。SP-197 已經把實作心得講得很好，SP-207 也講過目標之外還要治理。
+
+所以這篇的價值不在於再列一次指令，而是把 OpenAI 官方的心智模型釘住：目標模式是對話串範圍內的完成契約。用白話講，就是「這個對話串現在有一張工單，但收工不能靠感覺，要拿證據結案」。
+</ClawdNote>
+
+## Prompt 是下一步，目標是完成條件
+
+官方文件最值得記的一句話，是 Prompt 和目標模式的差別。
+
+Prompt 說的是：接下來做這件事。
+
+目標模式說的是：一直工作，直到某個結果是真的。
+
+這個差別看起來很小，實際上是兩種完全不同的操作模式。一般 Prompt 像把一張便利貼交給工程師：「修一下這個錯誤。」工程師做完一輪，回報結果，等待下一張便利貼。目標模式比較像工單系統：問題還沒真的解掉時，工單不該自己關掉。
+
+官方給的典型場景也很精準：效能調校、不穩定測試調查、依賴遷移、錯誤重現、多步驟重構、基準測試驅動調校、研究任務。這些任務有共同特徵：終點可以定義，但路徑要邊做邊發現。
+
+所以目標模式不是給「幫忙改個錯字」用的。那種事用普通 Prompt 就好。目標模式適合的是每一輪結果都會改變下一步選擇的工作。
+
+~~~text
+/goal Reduce p95 checkout latency below 120 ms on the checkout benchmark while keeping the correctness suite green
+~~~
+
+這句不是「讓結帳流程變快」的華麗版。它同時定義了三件事：p95 延遲要低於 120ms、用結帳流程基準測試驗證、正確性測試不能紅。Agent 每跑一輪，都可以拿現況對照這三個條件，而不是問自己「感覺有沒有比較好」。
+
+<ClawdNote>
+「感覺有沒有比較好」是 Agent 工作流裡很危險的一句話。這就像請設計師改 UI，只說「高級一點」。三小時後螢幕上可能出現黑底、紫光、玻璃擬態、每個按鈕都像夜店門票。很努力，但沒有人知道驗收標準在哪裡。(◕‿◕)
+</ClawdNote>
+
+---
+
+## 好目標要寫六件事，不是寫更長
+
+官方指南把強目標拆成六個零件：
+
+1. 結果：完成時世界應該變成什麼樣子。
+2. 驗證表面：用哪個測試、基準測試、報告、成品、指令輸出或來源材料證明。
+3. 限制：工作過程不能弄壞什麼。
+4. 邊界：允許碰哪些檔案、工具、資料、程式碼庫、資源。
+5. 迭代規則：每一輪之後怎麼選下一個最有價值的動作。
+6. 受阻停止條件：沒有合理路徑時，何時停下來回報阻礙。
+
+這裡的重點不是把 Prompt 寫成小作文，而是把「完成」變成可審計的東西。
+
+弱目標會長這樣：
+
+~~~text
+/goal Improve performance
+~~~
+
+強目標則會說：
+
+~~~text
+/goal Reduce p95 checkout latency below 120 ms, verified by the checkout benchmark, while keeping the correctness suite green. Use only the checkout service, benchmark fixtures, and related tests. Between iterations, record what changed, what the benchmark showed, and the next best experiment to try. If the benchmark cannot run or no valid paths remain, stop with the attempted paths, the evidence gathered, the blocker, and the next input needed.
+~~~
+
+差別不是字數。差別是第二句讓 Agent 知道怎麼收工，也知道什麼情況不能硬收工。
+
+p95 從 180ms 降到 135ms，還沒完成。降到 110ms 但正確性測試紅了，也還沒完成。基準測試跑不起來，更不是完成，而是阻礙。這種規格會把「看起來有進度」和「真的達標」分開。
+
+這也是 gu-log 前面幾篇一直繞回來的核心：長跑 Agent 不缺勤奮，缺的是驗收標準。沒有驗收標準，Agent 會把「做了很多事」當成「接近成功」。
+
+<ClawdNote>
+這裡很像健身。目標如果是「變健康」，那今天慢跑五分鐘、喝一杯水、買一雙鞋都可以假裝算進度。目標如果是「三個月後 5K 跑進 30 分鐘，膝蓋不能痛，每週記錄配速和恢復狀況」，那就比較難自欺欺人。
+
+Agent 也是。願望會讓它開始跑；量測會讓它知道自己是不是在跑對方向。
+</ClawdNote>
+
+---
+
+## 目標不是全域記憶，是對話串狀態
+
+官方文件在架構層講了一個很重要的邊界：目標是被持久保存的對話串狀態，不是全域記憶，也不是專案層指令。
+
+翻成正常工程語言：目標屬於這個對話串，因為證據也活在這個對話串裡。Codex 看過哪些檔案、跑過哪些指令、產生哪些 diff、看過哪些 log、建立過哪些推理痕跡，都是這條對話串的上下文。目標黏在線程上，比黏在全域記憶或專案設定上合理。
+
+這個設計也解釋了為什麼目標模式不是「背景自治」。
+
+官方文件把續跑設計得很保守：只有在對話串閒置、目標啟用、沒有排隊中的使用者輸入、沒有其他待處理工作，而且還在預算內時，Codex 才會考慮繼續。純規劃工作不觸發續跑；被打斷會暫停；如果續跑回合沒有呼叫工具，下一次自動續跑會被壓住，避免空轉。
+
+這些細節有點無聊，但很關鍵。長跑功能如果只是無限迴圈，很快就會變成昂貴的轉圈圈機器。真正能進產品的版本，必須知道什麼時候不該自動繼續。
+
+<ClawdNote>
+這段是 Clawd 覺得官方文件最工程的地方：它不是在賣「Agent 會自己做完一切」的夢，而是在講安全邊界。
+
+「閒置才繼續、有人排隊就停、沒工具呼叫就別再自嗨」這些規則聽起來很小，但這正是自主迴圈從玩具變成產品時需要的煞車。沒有這些東西，目標模式很容易從「幫忙盯工單」變成「半夜自己燒額度的烤箱」。
+</ClawdNote>
+
+---
+
+## 完成不能靠相信，要靠 audit
+
+官方文件反覆強調基於證據的完成判定。目標不應該因為模型「相信大概好了」就完成。完成要對照具體證據：檔案、測試、log、基準測試輸出、生成成品、研究證據。
+
+這句話在 coding 任務裡很好懂：測試要過、基準測試要達標、建置要成功。但官方指南最有意思的是研究案例。
+
+它用一篇深度避險論文的復現當例子。弱目標是：
+
+~~~text
+/goal Reproduce Buehler et al., "Deep Hedging"
+~~~
+
+這太鬆。復現哪個結果？什麼算復現？原始隨機種子、訓練路徑、計算圖、最佳化器狀態、檢查點、模擬狀態都沒有時，該怎麼區分「近似重建」和「精確重播」？
+
+強目標改成：用可取得材料和本地資源，做出證據最完整的復現；嘗試主要結果；最後報告要分清楚已復現的機制、近似訓練結果、被擋住的精確重播，以及剩餘不確定性。
+
+這個版本的妙處是，它沒有逼 Agent 假裝世界很完整。資料不夠時，目標不是要求 Agent 變魔術，而是要求它誠實標記不同等級的證據。
+
+最後的證據帳本會像這樣：
+
+~~~text
+Claim: Deep hedging approximates complete-market Heston hedge without transaction costs.
+Route: Rebuilt model mechanics, reference hedge comparison, and trained neural policy.
+Evidence surface: Price checks, histograms, and hedge surfaces.
+Status: Close approximate reproduction.
+Remaining uncertainty: Original training paths, seeds, and checkpoints are unavailable.
+~~~
+
+這裡的目標不是把研究變快，而是把「完成」的語意變誠實。可以重建的就說重建；只能近似的就說近似；缺資料的就說被擋住。Agent 繼續工作，但結論不能膨脹。
+
+這點對 AI 內容工作也很重要。很多自動研究或自動寫作最可怕的地方，不是完全胡說，而是把替代證據包裝成已確認發現。目標如果寫得好，至少會要求最後報告保留證據等級，不會把「看起來像」直接升級成「證明了」。
+
+---
+
+## 什麼時候不要用目標模式
+
+官方指南的反面規則也值得收下。
+
+一行修改、短解釋、小型 code review、只想要一個答案就停的問題，不需要目標模式。用目標模式只會讓工具變重，像拿工地吊車夾便利貼。
+
+完成線模糊時，也不要用目標模式。「make this better」和「refactor this code」都太弱，除非補上預期完成狀態、測試和限制。
+
+不確定性很高時，更不能用目標模式把不確定藏起來。如果資料可能不存在，就寫進目標；如果基準測試可能不穩，就先定義怎麼處理；如果允許替代證據，就先定義要如何標記。
+
+這三條其實很有實務味。目標模式不是把不確定問題丟給 Agent 自己消化，而是先把不確定寫成工作契約的一部分。
+
+<ClawdNote>
+目標模式最容易被濫用的方式，就是把它當成「不用想清楚」按鈕。這正好反過來。越長跑的任務，越要先想清楚什麼算完成、什麼算被擋住、什麼證據只能算旁證。
+
+不然 Agent 真的會很努力。這才恐怖。錯得懶惰還好救，錯得勤奮就會蓋出一整棟漂亮的錯誤大樓。
+</ClawdNote>
+
+---
+
+## 結語
+
+OpenAI 這篇官方指南真正補上的，不是 `/goal` 指令表，而是目標模式的責任邊界。
+
+目標模式讓目標持續存在，但不是讓 Agent 無邊界自治。它屬於對話串，不屬於全域記憶；它可以讓 Codex 在閒置時繼續，但續跑有保守條件；它可以推動長跑工作，但完成必須被審計；它可以處理研究不確定性，但最後要誠實分出已確認、近似、受阻、不確定。
+
+這就是為什麼這篇值得收進 SP 系列。它把前面幾篇 gu-log 的經驗補成官方語言：長跑 Agent 的關鍵不是「再繼續一下」。
+
+真正的關鍵是：目標可以黏住，證據要說了算。


### PR DESCRIPTION
## Summary
- publish SP-208 covering OpenAI Cookbook official Codex Goals guide
- position it against existing SP-192 / SP-197 / SP-207 instead of duplicating those posts
- add SP-207 cross-links to the new official-guide treatment

## Checks
- node scripts/check-jingjing.mjs src/content/posts/sp-207-20260518-pawelhuryn-agent-goal-intent.mdx src/content/posts/sp-208-20260509-openai-codex-goals-cookbook.mdx
- node scripts/validate-posts.mjs
- pnpm run build
- node scripts/check-links.mjs --internal-only --ci
