### PR TITLE
Fix Tribunal interrupted attempt accounting

### DIFF
--- a/scripts/tests/test-tribunal-runner-error-guard.sh
+++ b/scripts/tests/test-tribunal-runner-error-guard.sh
@@ -106,3 +106,42 @@ set -e
 [ "$(jq 'length' "$old_progress")" = "0" ] || fail "old Codex CLI should not initialize article progress"
 grep -q 'older than required' "$TMP/old.err" || fail "old Codex rejection did not explain version requirement"
 pass "old Codex CLI is rejected before article progress is touched"
+
+interrupted_progress="$TMP/interrupted-progress.json"
+cat > "$interrupted_progress" <<'JSON'
+{
+  "sp-1-20260128-demo.mdx": {
+    "article": "sp-1-20260128-demo.mdx",
+    "topLevelAttempts": 5,
+    "tribunalVersion": 5,
+    "stages": {
+      "factChecker": {
+        "status": "in_progress",
+        "score": null,
+        "model": "codex-gpt-5.5-medium",
+        "attempts": 1,
+        "tribunalVersion": 5
+      }
+    }
+  }
+}
+JSON
+
+set +e
+PATH="$fake_bin:$PATH" \
+TRIBUNAL_SCORE_ONLY_PROGRESS_FILE="$interrupted_progress" \
+TRIBUNAL_CODEX_TIMEOUT_SEC=5 \
+TRIBUNAL_CODEX_IDLE_TIMEOUT_SEC=5 \
+TRIBUNAL_CODEX_IDLE_POLL_SEC=1 \
+bash "$TRIBUNAL" --score-only --only-stage factChecker sp-1-20260128-demo.mdx \
+  >"$TMP/interrupted.out" 2>"$TMP/interrupted.err"
+interrupted_rc=$?
+set -e
+
+[ "$interrupted_rc" -eq 70 ] || fail "interrupted in-progress retry should surface runner error, got $interrupted_rc"
+[ "$(jq -r '."sp-1-20260128-demo.mdx".status' "$interrupted_progress")" = "RUNNER_ERROR" ] || fail "interrupted retry should be RUNNER_ERROR"
+[ "$(jq -r '."sp-1-20260128-demo.mdx".topLevelAttempts' "$interrupted_progress")" = "0" ] || fail "interrupted retry should reset non-terminal attempts"
+if jq -e '."sp-1-20260128-demo.mdx".status == "EXHAUSTED"' "$interrupted_progress" >/dev/null; then
+  fail "interrupted in-progress retry must not become EXHAUSTED"
+fi
+pass "interrupted in-progress runs do not consume attempts or exhaust articles"

--- a/scripts/tribunal.sh
+++ b/scripts/tribunal.sh
@@ -239,16 +239,25 @@ init_article_progress() {
       tlog "Resuming existing progress for $article"
     fi
 
-    # Increment + cap check
-    local attempts
+    # topLevelAttempts counts terminal content failures, not process starts.
+    # A worker killed mid-stage leaves status in-progress/no-score; restarting
+    # that article must not burn an attempt or eventually poison it as
+    # EXHAUSTED.
+    local attempts article_status
     attempts=$(jq -r --arg a "$article" '.[$a].topLevelAttempts // 0' "$PROGRESS_FILE")
-    attempts=$((attempts + 1))
-    jq --arg a "$article" --argjson n "$attempts" \
-       '.[$a].topLevelAttempts = $n' \
-       "$PROGRESS_FILE" > "$tmp" && mv "$tmp" "$PROGRESS_FILE"
-    tlog "Top-level attempt $attempts/$MAX_TOP_ATTEMPTS for $article"
+    article_status=$(jq -r --arg a "$article" '.[$a].status // ""' "$PROGRESS_FILE")
+    if ! [[ "$attempts" =~ ^[0-9]+$ ]]; then attempts=0; fi
 
-    if [ "$attempts" -gt "$MAX_TOP_ATTEMPTS" ]; then
+    if [ "$article_status" != "FAILED" ] && [ "$attempts" -gt 0 ]; then
+      jq --arg a "$article" '.[$a].topLevelAttempts = 0' \
+         "$PROGRESS_FILE" > "$tmp" && mv "$tmp" "$PROGRESS_FILE"
+      attempts=0
+      tlog "Reset non-terminal topLevelAttempts for $article after interrupted/non-content run."
+    fi
+
+    tlog "Top-level attempt $((attempts + 1))/$MAX_TOP_ATTEMPTS for $article"
+
+    if [ "$article_status" = "FAILED" ] && [ "$attempts" -ge "$MAX_TOP_ATTEMPTS" ]; then
       tlog "ERROR: $article exceeded MAX_TOP_ATTEMPTS=$MAX_TOP_ATTEMPTS. Marking EXHAUSTED."
       jq --arg a "$article" \
          --argjson tribunalVersion "$TRIBUNAL_VERSION" \
@@ -280,7 +289,11 @@ mark_article_failed() {
        --arg s "$failed_stage" \
        --argjson tribunalVersion "$TRIBUNAL_VERSION" \
        --arg ts "$(TZ=Asia/Taipei date -Iseconds)" \
-       '.[$a].status = "FAILED" | .[$a].failedStage = $s | .[$a].finishedAt = $ts | .[$a].tribunalVersion = $tribunalVersion' \
+       '.[$a].topLevelAttempts = ((.[$a].topLevelAttempts // 0) + 1)
+        | .[$a].status = "FAILED"
+        | .[$a].failedStage = $s
+        | .[$a].finishedAt = $ts
+        | .[$a].tribunalVersion = $tribunalVersion' \
        "$PROGRESS_FILE" > "$tmp" && mv "$tmp" "$PROGRESS_FILE"
   ) 9>>"$RC_PROGRESS_LOCK"
 }
@@ -302,7 +315,7 @@ mark_article_runner_error() {
         | .[$a].failedStage = $s
         | .[$a].finishedAt = $ts
         | .[$a].tribunalVersion = $tribunalVersion
-        | .[$a].topLevelAttempts = ([((.[$a].topLevelAttempts // 0) - 1), 0] | max)
+        | .[$a].topLevelAttempts = (.[$a].topLevelAttempts // 0)
         | .[$a].stages[$s] = {
             status: "runner_error",
             score: null,


### PR DESCRIPTION
## Summary
- Count topLevelAttempts only for terminal content failures, not process starts
- Reset non-terminal interrupted/in-progress attempt counters
- Add regression coverage for stale in_progress/no-score runs so they cannot become EXHAUSTED

## Tests
- bash scripts/tests/test-tribunal-runner-error-guard.sh
- bash scripts/tests/test-tribunal-safety-contract.sh
- bash scripts/tests/test-frontmatter-scores-v5.sh
- bash -n scripts/tribunal.sh scripts/tests/test-tribunal-runner-error-guard.sh