### PR TITLE
Add glossary creation policy

### DIFF
--- a/GU-LOG_WRITER_PROMPT.md
+++ b/GU-LOG_WRITER_PROMPT.md
@@ -222,11 +222,34 @@ Google 2017 年丟出這顆核彈後，整個 NLP 界直接進入新紀元。
 
 **Boundary ownership**：可接受 English terms 的邊界 SHALL 每次新增或移除前都先與 ShroomDog 討論。這會直接影響 gu-log 的閱讀流與語感，不是 agent 可以自己憑「看起來合理」決定的工程清單。Deterministic checker 負責執行已決定的邊界；ShroomDog 負責決定哪些英文詞在繁中正文裡自然。
 
-**何時加 glossary？**：
-- 同一個英文 term 在多篇文章重複出現、且中文沒有同等精準/簡潔的對應
-- 業界討論時直接講英文是 standard（譬如 RLHF、Token、Prompt）
-- term 有特定技術意義，中文翻譯會丟失資訊
-不是「我懶得翻」就加。先想：寫成中文是不是真的失準？如果只是順手沒想自然中文，那是晶晶體不是技術詞。
+**Glossary creation standard（問 / 建 / 不建）**：
+
+Glossary 不是英文詞垃圾桶。它的工作是替 gu-log 保存「讀者之後會反覆遇到，而且需要穩定 mental model」的術語。
+
+**建 glossary item**：
+- Canonical English term 是產品、協定、架構層、研究方法或社群固定講法，讀者之後需要拿它去對官方文件 / X / GitHub 討論。例如 `Codex app server`、`MCP`、`RLHF`。
+- 中文硬翻會失真、變長、變論文腔，或讓讀者對不上英文世界的討論。
+- term 是該篇的核心概念，而且很可能在 gu-log 後續文章再次出現；即使目前只出現一篇，也值得先建立穩定 anchor。
+- term 需要一段固定 ClawdNote / ShroomDog-style 解釋，避免每篇都重新解釋一次。
+
+**先問 ShroomDog**：
+- 新增或移除 accepted English term / glossary entry 會改變 zh-tw 正文的閱讀流。
+- 這個詞介於「自然的工程英文」和「晶晶體」之間，只有 ShroomDog 能判斷舒服不舒服。
+- 要把既有中文譯法改成 canonical English term，或把既有 English term 改成中文。
+- 這是一次新的術語分類邊界，不只是單篇文章修字。
+
+**不建 glossary item**：
+- 普通英文有自然中文可寫：`framing` →「包裝」、`takeaway` →「真正的重點」、`generalist` →「通才」。這種要翻，不要建 glossary。
+- 單篇 source 裡的一次性 label、活動名稱、內部專案代號，讀者不需要長期記住；文內解釋一次就好。
+- 已經是 universally understood acronym / proper noun / model name / product name，而且不需要 gu-log 額外定義；放 allowlist 或 glossaryExclude 就好。
+- 只是因為 lint 擋住、或 agent 懶得想自然中文。Lint 失敗不是建 glossary 的理由，只是提醒「翻中文」或「提術語決策」。
+
+**文內解釋即可**：
+- term 只在該篇服務一個小段落，但不會成為 gu-log 長期詞彙。
+- 中文翻法雖然不是完美，但讀者能順暢理解，而且不需要拿英文去查外部文件。
+- source-specific 說法只需要保留 attribution，不需要納入 gu-log 詞彙系統。
+
+**PR checklist**：真的新增 glossary term 時，同一個 PR 要更新 `src/data/glossary.json`，必要時更新 `src/config/glossary.ts`，第一次出現連 `/glossary#...`，英文版連 `/en/glossary#...`，並確保 `scripts/check-jingjing.mjs` 通過。若決策來自 ShroomDog feedback，也要 append 到 `docs/shroomdog-editorial-feedback.md`。
 
 **術語 checkpoint（不要硬翻研究論文腔）**：遇到像「擴展測試時運算」這種語意看得懂、但中文讀起來很卡的譯法，先停下來判斷：
 - 如果業界主要用英文討論，正文保留 canonical English term，第一次出現連到 glossary，glossary 裡補可能的 zh-tw 譯法。

--- a/docs/shroomdog-editorial-feedback.md
+++ b/docs/shroomdog-editorial-feedback.md
@@ -247,6 +247,13 @@
 
 ## 2026-05-16 — SD-24 Codex Runtime Kernel
 
+### Feedback: Glossary creation needs a decision standard, not ad hoc ShroomDog catches
+
+- ShroomDog feedback：I think we should have a standard of asking/create/do not create glossary items? I don't think everytime i need to point that out is a good system
+- 情境：SD-24 把 `Codex app server` 硬翻成「Codex 執行伺服器」後，ShroomDog 指出這個 term 本身有長期價值，應保留英文並加 glossary。問題不只是單篇漏詞，而是 pipeline 沒有明確判斷：何時該翻、何時該文內解釋、何時該建 glossary、何時該先問 ShroomDog。
+- 修法：把 glossary creation standard 升級進 `GU-LOG_WRITER_PROMPT.md`：建 glossary 的條件是 canonical / reusable / 翻譯失真 / 需要穩定 gu-log mental-model anchor；borderline English-term boundary 要先問 ShroomDog；普通英文、一次性 source label、只是 lint 擋住的詞，不准為了省事建 glossary。同步更新 `scripts/check-jingjing.mjs` 與 `src/config/glossary.ts` 註解，讓 lint failure 不會自動變成「加 glossary」。
+- Reusable lesson：Glossary 是 gu-log 的長期詞彙系統，不是每篇文章的補丁區。Agent 應該先做術語決策：翻中文、文內解釋、建 glossary、或請 ShroomDog 決策；不能等 ShroomDog 每次在 production 文章裡指出該建哪個 term。
+
 ### Feedback: Architecture posts should deliver the mental model, not the spec tour
 
 - ShroomDog feedback：`Interesting, but too long, too many detailed that should be linked. But seems there r some interesting insights that worth starting a SD post from this`

--- a/scripts/check-jingjing.mjs
+++ b/scripts/check-jingjing.mjs
@@ -13,8 +13,10 @@
 //   5. Universally understood acronyms (API, SDK, CLI, PM, CEO, ML, LLM, etc.)
 //
 // Anything else is 晶晶體 → flag. Fix by translating to natural zh-tw, OR
-// add the term to src/data/glossary.json in the same PR if it's a real
-// canonical industry term that loses meaning when translated.
+// add the term to src/data/glossary.json in the same PR only if it passes
+// GU-LOG_WRITER_PROMPT.md's glossary creation standard: canonical term,
+// likely reused, loses meaning when translated, and useful as a stable
+// gu-log mental-model anchor. A lint failure alone is never enough.
 //
 // Boundary ownership: adding or removing accepted English terms SHALL be
 // discussed with ShroomDog first. This list encodes ShroomDog's reading-flow
@@ -730,7 +732,7 @@ if (!__isCli) {
   console.error(
     `Fix options:\n` +
       `  1. Translate to natural zh-tw (preferred — see GU-LOG_WRITER_PROMPT.md §術語處理).\n` +
-      `  2. If genuinely a canonical industry term, discuss the boundary with ShroomDog, then add to src/data/glossary.json with definition + clawdNote.\n` +
+      `  2. If genuinely a canonical/reusable term, apply GU-LOG_WRITER_PROMPT.md's glossary creation standard, discuss the boundary with ShroomDog, then add to src/data/glossary.json with definition + clawdNote.\n` +
       `  3. If proper noun (product/people/lab) misclassified, discuss with ShroomDog before adding to ALLOWLIST_RAW in scripts/check-jingjing.mjs.\n` +
       (baselineRef
         ? `\nNote: --baseline-ref=${baselineRef} was used, so only new violations are reported; historical grandfathered violations are ignored.\n`

--- a/src/config/glossary.ts
+++ b/src/config/glossary.ts
@@ -36,7 +36,11 @@ export const glossaryExclude = [
 ];
 
 // Terms that SHOULD be in glossary (for reference when writing)
-// This is synced with /glossary page
+// This is synced with /glossary page.
+// Creation rule: add a term only when it is canonical/reusable, loses useful
+// meaning when translated, and needs a stable gu-log mental-model anchor.
+// Do not add entries merely to silence check-jingjing; translate ordinary
+// English to natural zh-tw instead.
 export const glossaryInclude = [
   'Ralph',
   'Vibe Coding',


### PR DESCRIPTION
## Summary\n- add a concrete ask/create/do-not-create standard for glossary items\n- update check-jingjing guidance so lint failures do not automatically become glossary additions\n- record ShroomDog's feedback in the editorial feedback corpus\n\n## Verification\n- pnpm run format:check\n- pnpm run lint