### PR TITLE
Teach librarian glossary candidate policy

### DIFF
--- a/.claude/agents/librarian.md
+++ b/.claude/agents/librarian.md
@@ -15,20 +15,31 @@ You have ZERO context from the parent conversation. No bias.
 
 ## Setup (MUST do first)
 
-1. Read `src/data/glossary.json` — the blog's canonical term definitions
-2. Read the post file provided in the task prompt
-3. Scan `src/content/posts/` for existing post slugs (use Glob) to verify internal links
+1. Read `GU-LOG_WRITER_PROMPT.md` §術語處理 — especially the glossary creation standard
+2. Read `src/data/glossary.json` — the blog's canonical term definitions
+3. Read the post file provided in the task prompt
+4. Scan `src/content/posts/` for existing post slugs (use Glob) to verify internal links
 
 ## Four Curation Dimensions (each 0-10)
 
 ### 1. glossary
-Technical terms in the post that exist in glossary.json SHOULD be linked or explained.
-- Scan for every term that exists in glossary.json
-- Flag terms that appear but are NOT linked
-- **10** = All glossary terms linked or naturally explained
-- **8** = 1-2 minor terms unlinked but key terms covered
-- **5** = Multiple key terms used without glossary connection
-- **2** = Full of terms with zero glossary integration
+Glossary is gu-log's long-term mental-model anchor system, not a dictionary and not an English allowlist.
+
+Check two things:
+- Existing glossary coverage: technical terms in the post that exist in `glossary.json` SHOULD be linked or explained.
+- Missing glossary candidates: canonical/reusable terms that lose meaning when translated SHOULD be flagged as candidates, not silently hard-translated or left as floating English.
+
+Creation standard:
+- **Create / recommend glossary** when a canonical English term is a product, protocol, architecture layer, research method, or fixed community term; readers will need it again; Chinese hard-translation loses useful meaning; and a stable gu-log mental-model anchor would help.
+- **Ask ShroomDog** when adding/removing the accepted-English boundary would change zh-tw reading flow.
+- **Do not create glossary** for ordinary English with natural zh-tw, one-off source labels, or anything added merely to satisfy lint. Translate ordinary English instead.
+- **Inline explanation only** when the term serves just this post and is not likely to become gu-log vocabulary.
+
+Score anchors:
+- **10** = All existing glossary terms linked or naturally explained, and no obvious missing glossary candidates.
+- **8** = 1-2 minor existing terms unlinked, or a borderline candidate is explicitly treated as a terminology decision.
+- **5** = Multiple key terms used without glossary connection, or an obvious reusable canonical term is hard-translated / left unexplained.
+- **2** = Glossary treated as a link checklist or English allowlist, with no mental-model-anchor judgment.
 
 ### 2. crossRef
 Do `/posts/slug/` links point to real, existing posts? Are relevant connections made?
@@ -86,7 +97,7 @@ Then print a human-readable summary.
   "score": 8,
   "verdict": "PASS",
   "reasons": {
-    "glossary": "All key terms linked to glossary, no gaps.",
+    "glossary": "All key terms linked to glossary; no missing long-term glossary candidates.",
     "crossRef": "3 relevant posts referenced, ShroomDog identity link present.",
     "sourceAlign": "Content clearly derived from declared sourceUrl.",
     "attribution": "Quotes and stats properly attributed throughout."

--- a/.claude/agents/tribunal-writer.md
+++ b/.claude/agents/tribunal-writer.md
@@ -36,7 +36,7 @@ For each failing dimension, the fix is different:
 
 | Judge | Low dimension | Typical fix |
 |-------|---------------|-------------|
-| Librarian | glossary | Add links to `glossary.json` terms |
+| Librarian | glossary | Add links to `glossary.json` terms; for missing candidates, apply the glossary creation standard instead of treating glossary as an English allowlist |
 | Librarian | crossRef | Add internal `/posts/slug/` links, add identity links for ShroomDog/Clawd |
 | Librarian | sourceAlign | Ensure post content aligns with sourceUrl topic |
 | Librarian | attribution | Attribute quotes to named speakers; label ClawdNote opinions as opinions; add source citations |

--- a/.claude/agents/vibe-opus-scorer.md
+++ b/.claude/agents/vibe-opus-scorer.md
@@ -21,7 +21,7 @@ You are an **independent, harsh quality reviewer** for gu-log blog posts. You ha
 Read these files to calibrate before scoring anything:
 1. `scripts/vibe-scoring-standard.md` — THE rubric with calibration examples and score anchors
 2. `GU-LOG_WRITER_PROMPT.md` — LHY persona definition, pronoun rules, narrative structure, **晶晶體 enforcement (glossary as allowlist)**
-3. `src/data/glossary.json` — the **canonical English allowlist** for zh-tw posts. ANY English word in zh-tw body that is NOT a glossary term, proper noun, code identifier, direct quote, or universally-understood acronym (API/SDK/CLI/PM/CEO/ML/LLM/UI/UX) is 晶晶體 and must be flagged.
+3. `src/data/glossary.json` — existing glossary terms. Glossary is gu-log's long-term mental-model anchor system, not a generic English allowlist. ANY English word in zh-tw body that is NOT a glossary term, proper noun, code identifier, direct quote, or universally-understood acronym (API/SDK/CLI/PM/CEO/ML/LLM/UI/UX) is 晶晶體 and must be flagged.
 
 Then read the ENTIRE post file provided in the task prompt. Every line.
 
@@ -79,7 +79,7 @@ Does the post have genuine narrative structure, or is it a linear report with de
 - Motivational-poster closing → vibe -2
 - ClawdNote = pure definition → clawdNote -2
 - SP-158 decorative persona pattern → persona cap 5, narrative cap 5
-- **晶晶體 (any non-allowlist English in zh-tw body or ClawdNote)** → clarity -3 AND vibe -4. Severity scales: 1-3 instances = -3 clarity / -4 vibe; 4-10 instances = clarity capped at 6, vibe capped at 6; 10+ instances = clarity capped at 5, vibe capped at 5, persona capped at 6 (because LHY would never let this past). This is **not stylistic preference** — it's repository policy. If a non-allowlist English word genuinely needs to stay (say it's emerging industry standard), the **fix is to add it to `src/data/glossary.json` in the same PR**, not to keep it as 晶晶體.
+- **晶晶體 (any non-allowlist English in zh-tw body or ClawdNote)** → clarity -3 AND vibe -4. Severity scales: 1-3 instances = -3 clarity / -4 vibe; 4-10 instances = clarity capped at 6, vibe capped at 6; 10+ instances = clarity capped at 5, vibe capped at 5, persona capped at 6 (because LHY would never let this past). This is **not stylistic preference** — it's repository policy. If a non-allowlist English word genuinely needs to stay, apply `GU-LOG_WRITER_PROMPT.md`'s glossary creation standard: ordinary English should become natural zh-tw; canonical/reusable terms that lose meaning when translated can become glossary entries; borderline accepted-English boundary decisions must be discussed with ShroomDog.
 
 ## Protocol
 

--- a/docs/shroomdog-editorial-feedback.md
+++ b/docs/shroomdog-editorial-feedback.md
@@ -254,6 +254,13 @@
 - 修法：把 glossary creation standard 升級進 `GU-LOG_WRITER_PROMPT.md`：建 glossary 的條件是 canonical / reusable / 翻譯失真 / 需要穩定 gu-log mental-model anchor；borderline English-term boundary 要先問 ShroomDog；普通英文、一次性 source label、只是 lint 擋住的詞，不准為了省事建 glossary。同步更新 `scripts/check-jingjing.mjs` 與 `src/config/glossary.ts` 註解，讓 lint failure 不會自動變成「加 glossary」。
 - Reusable lesson：Glossary 是 gu-log 的長期詞彙系統，不是每篇文章的補丁區。Agent 應該先做術語決策：翻中文、文內解釋、建 glossary、或請 ShroomDog 決策；不能等 ShroomDog 每次在 production 文章裡指出該建哪個 term。
 
+### Feedback: Librarian must own glossary candidate judgment too
+
+- ShroomDog feedback：I believe this mental model should also be in the librarian
+- 情境：前一輪把 glossary creation standard 寫進 writer prompt / lint guidance，但 Librarian rubric 仍偏向「已存在 glossary term 有沒有連結」。這會讓 writer 端學會 ask/create/do-not-create，審稿端卻只做 link checklist，漏掉「該建 glossary 的 canonical term 被硬翻或飄過」這種問題。
+- 修法：同步更新 Librarian agent prompt、vibe scoring standard 的 Stage 2 glossary rubric、tribunal librarian runner prompt，以及 tribunal writer / vibe scorer 的相關說明。Librarian 的 glossary 維度改成兩件事：既有 glossary coverage + missing glossary candidate judgment。worker pass 仍只補 link，不直接發明新 glossary anchor；candidate 要在 summary / judge reasons 裡指出。
+- Reusable lesson：Glossary policy 不能只放 writer 端。Librarian 是 gu-log 知識庫守門員，必須把 glossary 視為長期 mental-model anchor system，而不是「看見已存在 term 就補 link」的機械流程。
+
 ### Feedback: Architecture posts should deliver the mental model, not the spec tour
 
 - ShroomDog feedback：`Interesting, but too long, too many detailed that should be linked. But seems there r some interesting insights that worth starting a SD post from this`

--- a/scripts/vibe-scoring-standard.md
+++ b/scripts/vibe-scoring-standard.md
@@ -72,15 +72,27 @@ Agents self-assess `pass` but the pass-bar lib wins. Log the discrepancy.
 
 ## Stage 2: Librarian (GPT-5.5) — 4 Dimensions
 
-### glossary — Glossary Term Coverage
-Does every technical term that exists in `src/data/glossary.json` get linked or explained?
+### glossary — Glossary Term Coverage + Candidate Judgment
+Does every technical term that exists in `src/data/glossary.json` get linked or explained? Does the post contain any canonical/reusable term that should become a glossary mental-model anchor?
+
+Glossary is gu-log's long-term mental-model anchor system, not a dictionary and not an English allowlist.
+
+Librarian checks two things:
+- Existing coverage: terms already in `src/data/glossary.json` should be linked or naturally explained.
+- Missing candidates: canonical English terms that readers will need again, and that lose meaning when translated, should be flagged as glossary candidates.
+
+Creation judgment:
+- Recommend/create glossary when the term is canonical/reusable, likely to recur, loses useful meaning when translated, and needs a stable gu-log explanation.
+- Ask ShroomDog for borderline accepted-English boundary decisions that affect zh-tw reading flow.
+- Do not create glossary for ordinary English with natural zh-tw, one-off source labels, or terms added merely to satisfy lint.
+- Inline explanation is enough when the term only serves the current post and does not need to become gu-log vocabulary.
 
 | Score | Description |
 |-------|-------------|
-| 10 | All glossary terms linked or naturally explained |
-| 8 | 1-2 minor terms unlinked but all key terms covered |
-| 5 | Multiple key terms used without glossary connection |
-| 2 | Full of terms with zero glossary integration |
+| 10 | All existing glossary terms linked or naturally explained; no obvious missing long-term glossary candidates |
+| 8 | 1-2 minor terms unlinked, or a borderline glossary candidate is explicitly treated as a terminology decision |
+| 5 | Multiple key terms used without glossary connection, or an obvious reusable canonical term is hard-translated / left unexplained |
+| 2 | Glossary treated as a link checklist or English allowlist, with no mental-model-anchor judgment |
 
 ### crossRef — Internal Cross-References + Identity Linking
 Do internal `/posts/slug/` links resolve? Are relevant connections made?

--- a/src/lib/tribunal-v2/runners/stage-runners.ts
+++ b/src/lib/tribunal-v2/runners/stage-runners.ts
@@ -195,7 +195,7 @@ export const stage3LibrarianRunner: StageRunner<
       timeoutSec: TIMEOUT.WORKER_LIBRARIAN,
       buildPrompt: (outputPath) => `Add library links to this post: ${articlePath}
 
-Per your agent instructions, add glossary links and cross-references where appropriate. Do NOT modify text or facts — only add links. Use your Write tool to save the updated file.
+Per your agent instructions, add glossary links and cross-references where appropriate. Apply the glossary creation standard as judgment, but this worker pass is link-only: do NOT create new glossary entries, invent anchors, modify text, or change facts. If a term looks like a missing glossary candidate, leave the prose unchanged and mention it in your stdout summary.
 
 Write the v2 LibrarianOutput JSON (glossary_links_added + cross_references_added) to: ${outputPath}
 Confirm with a one-line status on stdout.`,


### PR DESCRIPTION
## Summary\n- teach Librarian that glossary is a long-term mental-model anchor system, not just a link checklist\n- update Stage 2 glossary scoring to include missing glossary candidate judgment\n- keep the tribunal worker link-only while requiring missing candidates to be surfaced in summaries/reasons\n- align tribunal writer/vibe prompts and record ShroomDog feedback\n\n## Verification\n- pnpm run format:check\n- pnpm run lint\n- pnpm exec astro sync && pnpm exec tsc --noEmit --pretty false