### PR TITLE
Tribunal: decouple runtime ledger and add publisher foundation

### DIFF
--- a/docs/tribunal-runbook.md
+++ b/docs/tribunal-runbook.md
@@ -27,7 +27,8 @@ git push origin main
 ssh clawd-vm
 cd ~/clawd/projects/gu-log
 git stash push -m "wip" --include-untracked        # uncommitted tribunal rewrites live here
-git checkout main && git pull
+git fetch origin main
+git checkout main && git merge --ff-only origin/main
 git stash pop
 
 # If scripts/tribunal-loop.service changed, redeploy + reload:
@@ -82,6 +83,10 @@ Restart after stop: `systemctl --user start tribunal-loop`. `rc_exit_stopped` re
 # Live state
 cat .score-loop/state/runtime.json
 # Expected states: running / draining / idle_wait / stopped_by_request / stopped_by_quota
+
+# Runtime ledger + remote drift observability
+cat .score-loop/state/tribunal-progress.json
+cat .score-loop/state/runtime-git.json
 
 # Active claims (one per in-flight article)
 ls .score-loop/claims/
@@ -284,7 +289,7 @@ systemctl --user start tribunal-loop
 | Workers dispatched but log stays quiet for >1min | Worker sleeping inside `wait_for_*` (quota/quiet-hours left over from old code) | `sync` workers + restart |
 | Service inactive, `rc_exit_stopped` in log, flag still present | Someone touched the flag manually; supervisor cleared it on exit | `systemctl --user start tribunal-loop` |
 | Same article claimed by a dead pid, new workers blocked | Worker crashed without releasing claim | `scripts/tribunal-worker-bootstrap.sh status` to confirm workers are alive; supervisor runs `rc_gc_stale_claims` at startup; to force now: `rm -rf .score-loop/claims/<slug>.claim` |
-| `git pull failed: unstaged changes` warning in supervisor log | Dirty tribunal rewrites in main worktree from an earlier partial run | Non-fatal; supervisor continues with its current checkout. Clean up via `git stash` or `git checkout -- .` when safe. |
+| `Git drift: state=behind` or `state=diverged` in supervisor log | origin/main advanced while runtime kept local progress / content edits | Expected in fetch-only mode. Runtime keeps processing its current snapshot; use publisher or an explicit operator sync instead of rebasing the daemon worktree. |
 | New code on main isn't reaching running workers | Worker worktrees are stale (see "Worker worktree gotcha" above) | `scripts/tribunal-worker-bootstrap.sh sync` — or restart (supervisor auto-syncs) |
 | Article marked EXHAUSTED after 5 attempts | Real content / scoring issue, or model-induced flakiness | Open the stage log, look at scorer reasons; rewrite manually or flag for human review |
 | Controller stuck in `floor_stop` even though quota looks OK | usage-monitor cache stale, or feedforward over-counting | Check `quota-controller.json` for `five_hr_pct` / `seven_day_pct`; force cache refresh: `rm /tmp/usage-monitor-cache/claude.json` |

--- a/scripts/score-helpers.sh
+++ b/scripts/score-helpers.sh
@@ -12,6 +12,7 @@ ensure_score_dirs() {
   mkdir -p \
     "$SCORE_ROOT/scores" \
     "$SCORE_ROOT/.score-loop/logs" \
+    "$SCORE_ROOT/.score-loop/state" \
     "$SCORE_ROOT/.score-loop/tmp"
 
   [ -e "$SCORE_ROOT/scores/.gitkeep" ] || : > "$SCORE_ROOT/scores/.gitkeep"

--- a/scripts/tests/test-tribunal-progress-ledger-migration.sh
+++ b/scripts/tests/test-tribunal-progress-ledger-migration.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+source "$ROOT_DIR/scripts/tribunal-helpers.sh"
+
+fail() { echo "x $*" >&2; exit 1; }
+pass() { echo "ok $*"; }
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+repo="$TMP/repo"
+mkdir -p "$repo/scores"
+cat > "$repo/scores/tribunal-progress.json" <<'JSON'
+{
+  "sp-test.mdx": {
+    "status": "PASS",
+    "tribunalVersion": 5
+  }
+}
+JSON
+
+target="$(tribunal_progress_file_default "$repo")"
+ensure_tribunal_progress_file "$target" "$repo"
+
+[ -f "$target" ] || fail "migrated ignored progress file missing"
+cmp "$repo/scores/tribunal-progress.json" "$target" >/dev/null || fail "migrated progress content mismatch"
+
+backup_count="$(find "$repo/.score-loop/state/migrations" -type f | wc -l | tr -d ' ')"
+[ "$backup_count" = "1" ] || fail "expected one migration backup, got $backup_count"
+
+ensure_tribunal_progress_file "$target" "$repo"
+backup_count_after="$(find "$repo/.score-loop/state/migrations" -type f | wc -l | tr -d ' ')"
+[ "$backup_count_after" = "1" ] || fail "migration should be idempotent once ignored ledger exists"
+pass "legacy tracked progress migrates once into ignored ledger"

--- a/scripts/tests/test-tribunal-publisher.sh
+++ b/scripts/tests/test-tribunal-publisher.sh
@@ -24,38 +24,62 @@ mkdir -p "$seed/src/content/posts"
 cat > "$seed/src/content/posts/sp-1-test.mdx" <<'POST'
 ---
 ticketId: SP-1
+title: "SP1"
+originalDate: 2026-05-20
 translatedDate: 2026-05-21
+source: "X"
+sourceUrl: "https://example.com/sp1"
+summary: "Summary one."
+lang: zh-tw
 scores:
   tribunalVersion: 5
 ---
-Base one.
+This is a sufficiently long body for publisher validation. It explains one coherent idea, adds supporting detail, and stays comfortably above the minimum content length that the deterministic content validator requires for a real publishable artifact in gu-log.
 POST
 cat > "$seed/src/content/posts/en-sp-1-test.mdx" <<'POST'
 ---
 ticketId: SP-1
+title: "SP1 EN"
+originalDate: 2026-05-20
 translatedDate: 2026-05-21
+source: "X"
+sourceUrl: "https://example.com/sp1"
+summary: "Summary one en."
+lang: en
 scores:
   tribunalVersion: 5
 ---
-Base one en.
+This is a sufficiently long English body for publisher validation. It mirrors the publishable structure expected by the content validator and avoids failing on missing metadata or minimum-length requirements during the clean batch materialization step.
 POST
 cat > "$seed/src/content/posts/sp-2-test.mdx" <<'POST'
 ---
 ticketId: SP-2
+title: "SP2"
+originalDate: 2026-05-20
 translatedDate: 2026-05-21
+source: "X"
+sourceUrl: "https://example.com/sp2"
+summary: "Summary two."
+lang: zh-tw
 scores:
   tribunalVersion: 5
 ---
-Base two.
+This is another sufficiently long body for publisher validation. It exists so the test can later turn it into an invalid candidate and verify that validation-blocked events isolate only the broken article instead of stopping the clean publisher batch.
 POST
 cat > "$seed/src/content/posts/en-sp-2-test.mdx" <<'POST'
 ---
 ticketId: SP-2
+title: "SP2 EN"
+originalDate: 2026-05-20
 translatedDate: 2026-05-21
+source: "X"
+sourceUrl: "https://example.com/sp2"
+summary: "Summary two en."
+lang: en
 scores:
   tribunalVersion: 5
 ---
-Base two en.
+This is another sufficiently long English body for publisher validation. It gives the test a clean bilingual pair so the batch publisher can materialize both files and still isolate the broken candidate later when the zh file is intentionally damaged.
 POST
 
 git -C "$seed" add .
@@ -70,6 +94,16 @@ mkdir -p "$runtime/scripts"
 cp "$ROOT_DIR/scripts/tribunal-publisher.sh" "$runtime/scripts/tribunal-publisher.sh"
 cp "$ROOT_DIR/scripts/tribunal-helpers.sh" "$runtime/scripts/tribunal-helpers.sh"
 chmod +x "$runtime/scripts/tribunal-publisher.sh"
+cat > "$runtime/scripts/test-validate-hook.sh" <<'HOOK'
+#!/usr/bin/env bash
+set -euo pipefail
+article="$1"
+if [ "${TRIBUNAL_PUBLISHER_FORCE_INVALID:-}" = "$article" ]; then
+  exit 1
+fi
+exit 0
+HOOK
+chmod +x "$runtime/scripts/test-validate-hook.sh"
 mkdir -p "$runtime/.score-loop/state"
 
 cat > "$runtime/.score-loop/state/tribunal-progress.json" <<'JSON'
@@ -79,7 +113,7 @@ cat > "$runtime/.score-loop/state/tribunal-progress.json" <<'JSON'
 }
 JSON
 
-out="$(cd "$runtime" && bash scripts/tribunal-publisher.sh --dry-run --max 10)"
+out="$(cd "$runtime" && TRIBUNAL_PUBLISHER_DISABLE_GH_SCAN=1 bash scripts/tribunal-publisher.sh --dry-run --max 10)"
 grep -q 'publishable PASS: 1' <<<"$out" || fail "dry-run should report one publishable PASS"
 grep -q 'FAILED metadata: 1' <<<"$out" || fail "dry-run should report one FAILED article"
 pass "dry-run reports publishable and failed counts"
@@ -88,7 +122,7 @@ printf 'Runtime rewritten one.\n' >> "$runtime/src/content/posts/sp-1-test.mdx"
 printf 'Runtime rewritten one en.\n' >> "$runtime/src/content/posts/en-sp-1-test.mdx"
 
 batch_dir="$TMP/batch-worktree"
-apply_out="$(cd "$runtime" && bash scripts/tribunal-publisher.sh --apply --max 10 --branch publisher/test-batch --worktree "$batch_dir")"
+apply_out="$(cd "$runtime" && TRIBUNAL_PUBLISHER_DISABLE_GH_SCAN=1 TRIBUNAL_PUBLISHER_SKIP_BUILD=1 TRIBUNAL_PUBLISHER_VALIDATE_HOOK="$runtime/scripts/test-validate-hook.sh" bash scripts/tribunal-publisher.sh --apply --max 10 --branch publisher/test-batch --worktree "$batch_dir")"
 
 [ -e "$batch_dir/.git" ] || fail "apply should create publisher worktree"
 grep -q 'selected sp-1-test.mdx' <<<"$apply_out" || fail "apply should select PASS article"
@@ -97,3 +131,50 @@ grep -q 'publishState' "$runtime/.score-loop/state/tribunal-publisher.json" || f
 grep -q 'Runtime rewritten one.' "$batch_dir/src/content/posts/sp-1-test.mdx" || fail "publisher worktree should receive runtime artifact"
 grep -q 'Runtime rewritten one en.' "$batch_dir/src/content/posts/en-sp-1-test.mdx" || fail "publisher worktree should receive runtime EN artifact"
 pass "apply materializes PASS artifact into clean origin/main-based worktree"
+
+pr_list_json="$TMP/pr-list.json"
+pr_files_dir="$TMP/pr-files"
+mkdir -p "$pr_files_dir"
+cat > "$pr_list_json" <<'JSON'
+[
+  {
+    "number": 77,
+    "title": "Editorial rewrite in progress",
+    "headRefName": "editorial/sp-1",
+    "labels": []
+  }
+]
+JSON
+cat > "$pr_files_dir/77.json" <<'JSON'
+{
+  "files": [
+    { "path": "src/content/posts/sp-1-test.mdx" }
+  ]
+}
+JSON
+cat > "$runtime/.score-loop/state/tribunal-progress.json" <<'JSON'
+{
+  "sp-1-test.mdx": { "status": "PASS", "tribunalVersion": 5 },
+  "sp-2-test.mdx": { "status": "PASS", "tribunalVersion": 5 }
+}
+JSON
+out_conflict="$(cd "$runtime" && TRIBUNAL_PUBLISHER_PR_LIST_JSON_FILE="$pr_list_json" TRIBUNAL_PUBLISHER_PR_FILES_DIR="$pr_files_dir" bash scripts/tribunal-publisher.sh --dry-run --max 10)"
+grep -q 'conflicted: 1' <<<"$out_conflict" || fail "dry-run should report one conflicted article"
+grep -q 'publishable PASS: 1' <<<"$out_conflict" || fail "conflicted article should not block clean publishable article"
+grep -q 'sp-2-test.mdx' <<<"$out_conflict" || fail "clean article should remain publishable"
+grep -q 'conflict' "$runtime/.score-loop/state/tribunal-triage-events.json" || fail "conflict event should be recorded"
+pass "conflict triage blocks only overlapping article and leaves clean article publishable"
+
+cat > "$runtime/src/content/posts/sp-2-test.mdx" <<'POST'
+---
+ticketId: SP-2
+translatedDate: 2026-05-21
+---
+too short
+POST
+batch_dir2="$TMP/batch-worktree-2"
+apply_out2="$(cd "$runtime" && TRIBUNAL_PUBLISHER_PR_LIST_JSON_FILE="$pr_list_json" TRIBUNAL_PUBLISHER_PR_FILES_DIR="$pr_files_dir" TRIBUNAL_PUBLISHER_SKIP_BUILD=1 TRIBUNAL_PUBLISHER_VALIDATE_HOOK="$runtime/scripts/test-validate-hook.sh" TRIBUNAL_PUBLISHER_FORCE_INVALID="sp-2-test.mdx" bash scripts/tribunal-publisher.sh --apply --max 10 --branch publisher/test-batch-2 --worktree "$batch_dir2")"
+grep -q 'validation_blocked sp-2-test.mdx' <<<"$apply_out2" || fail "invalid candidate should become validation_blocked"
+grep -q 'selected sp-1-test.mdx' <<<"$apply_out2" && fail "conflicted article should not be selected into batch"
+[ "$(jq -r '[.events[] | select(.kind=="validation_blocked")] | length' "$runtime/.score-loop/state/tribunal-triage-events.json")" = "1" ] || fail "validation_blocked event should be recorded once"
+pass "candidate validation failure is isolated into triage event"

--- a/scripts/tests/test-tribunal-publisher.sh
+++ b/scripts/tests/test-tribunal-publisher.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+PUBLISHER="$ROOT_DIR/scripts/tribunal-publisher.sh"
+
+fail() { echo "x $*" >&2; exit 1; }
+pass() { echo "ok $*"; }
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+origin="$TMP/origin.git"
+seed="$TMP/seed"
+runtime="$TMP/runtime"
+
+git init --bare "$origin" >/dev/null
+git clone "$origin" "$seed" >/dev/null 2>&1
+git -C "$seed" config user.email test@example.invalid
+git -C "$seed" config user.name "Tribunal Publisher Test"
+mkdir -p "$seed/src/content/posts"
+
+cat > "$seed/src/content/posts/sp-1-test.mdx" <<'POST'
+---
+ticketId: SP-1
+translatedDate: 2026-05-21
+scores:
+  tribunalVersion: 5
+---
+Base one.
+POST
+cat > "$seed/src/content/posts/en-sp-1-test.mdx" <<'POST'
+---
+ticketId: SP-1
+translatedDate: 2026-05-21
+scores:
+  tribunalVersion: 5
+---
+Base one en.
+POST
+cat > "$seed/src/content/posts/sp-2-test.mdx" <<'POST'
+---
+ticketId: SP-2
+translatedDate: 2026-05-21
+scores:
+  tribunalVersion: 5
+---
+Base two.
+POST
+cat > "$seed/src/content/posts/en-sp-2-test.mdx" <<'POST'
+---
+ticketId: SP-2
+translatedDate: 2026-05-21
+scores:
+  tribunalVersion: 5
+---
+Base two en.
+POST
+
+git -C "$seed" add .
+git -C "$seed" commit -m "base" >/dev/null
+git -C "$seed" push origin HEAD:main >/dev/null 2>&1
+
+git clone "$origin" "$runtime" >/dev/null 2>&1
+git -C "$runtime" checkout -b tribunal-runtime origin/main >/dev/null 2>&1
+git -C "$runtime" config user.email test@example.invalid
+git -C "$runtime" config user.name "Runtime"
+mkdir -p "$runtime/scripts"
+cp "$ROOT_DIR/scripts/tribunal-publisher.sh" "$runtime/scripts/tribunal-publisher.sh"
+cp "$ROOT_DIR/scripts/tribunal-helpers.sh" "$runtime/scripts/tribunal-helpers.sh"
+chmod +x "$runtime/scripts/tribunal-publisher.sh"
+mkdir -p "$runtime/.score-loop/state"
+
+cat > "$runtime/.score-loop/state/tribunal-progress.json" <<'JSON'
+{
+  "sp-1-test.mdx": { "status": "PASS", "tribunalVersion": 5 },
+  "sp-2-test.mdx": { "status": "FAILED", "tribunalVersion": 5 }
+}
+JSON
+
+out="$(cd "$runtime" && bash scripts/tribunal-publisher.sh --dry-run --max 10)"
+grep -q 'publishable PASS: 1' <<<"$out" || fail "dry-run should report one publishable PASS"
+grep -q 'FAILED metadata: 1' <<<"$out" || fail "dry-run should report one FAILED article"
+pass "dry-run reports publishable and failed counts"
+
+printf 'Runtime rewritten one.\n' >> "$runtime/src/content/posts/sp-1-test.mdx"
+printf 'Runtime rewritten one en.\n' >> "$runtime/src/content/posts/en-sp-1-test.mdx"
+
+batch_dir="$TMP/batch-worktree"
+apply_out="$(cd "$runtime" && bash scripts/tribunal-publisher.sh --apply --max 10 --branch publisher/test-batch --worktree "$batch_dir")"
+
+[ -e "$batch_dir/.git" ] || fail "apply should create publisher worktree"
+grep -q 'selected sp-1-test.mdx' <<<"$apply_out" || fail "apply should select PASS article"
+grep -q 'publishState' "$runtime/.score-loop/state/tribunal-publisher.json" || fail "publisher state file missing"
+[ "$(jq -r '.entries["sp-1-test.mdx"].publishState' "$runtime/.score-loop/state/tribunal-publisher.json")" = "batch_selected" ] || fail "PASS article should move to batch_selected"
+grep -q 'Runtime rewritten one.' "$batch_dir/src/content/posts/sp-1-test.mdx" || fail "publisher worktree should receive runtime artifact"
+grep -q 'Runtime rewritten one en.' "$batch_dir/src/content/posts/en-sp-1-test.mdx" || fail "publisher worktree should receive runtime EN artifact"
+pass "apply materializes PASS artifact into clean origin/main-based worktree"

--- a/scripts/tests/test-tribunal-runtime-git-hygiene.sh
+++ b/scripts/tests/test-tribunal-runtime-git-hygiene.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+source "$ROOT_DIR/scripts/tribunal-helpers.sh"
+
+fail() { echo "x $*" >&2; exit 1; }
+pass() { echo "ok $*"; }
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+origin="$TMP/origin.git"
+seed="$TMP/seed"
+runtime="$TMP/runtime"
+publisher="$TMP/publisher"
+log="$TMP/fetch.log"
+
+git init --bare "$origin" >/dev/null
+git clone "$origin" "$seed" >/dev/null 2>&1
+git -C "$seed" config user.email test@example.invalid
+git -C "$seed" config user.name "Tribunal Test"
+printf 'base\n' > "$seed/post.txt"
+git -C "$seed" add post.txt
+git -C "$seed" commit -m "base" >/dev/null
+git -C "$seed" push origin HEAD:main >/dev/null 2>&1
+
+git clone "$origin" "$runtime" >/dev/null 2>&1
+git -C "$runtime" checkout -b tribunal-runtime origin/main >/dev/null 2>&1
+git -C "$runtime" config user.email test@example.invalid
+git -C "$runtime" config user.name "Tribunal Runtime"
+
+printf 'runtime local\n' >> "$runtime/post.txt"
+git -C "$runtime" add post.txt
+git -C "$runtime" commit -m "local runtime progress" >/dev/null
+before_head="$(git -C "$runtime" rev-parse HEAD)"
+
+git clone "$origin" "$publisher" >/dev/null 2>&1
+git -C "$publisher" checkout main >/dev/null 2>&1
+git -C "$publisher" config user.email test@example.invalid
+git -C "$publisher" config user.name "Publisher"
+printf 'remote main\n' >> "$publisher/post.txt"
+git -C "$publisher" add post.txt
+git -C "$publisher" commit -m "remote main update" >/dev/null
+git -C "$publisher" push origin HEAD:main >/dev/null 2>&1
+
+state_file="$TMP/runtime-git.json"
+summary="$(tribunal_fetch_and_report_origin_main "$runtime" "$log" "$state_file")"
+after_head="$(git -C "$runtime" rev-parse HEAD)"
+
+[ "$before_head" = "$after_head" ] || fail "fetch-only drift check mutated runtime HEAD"
+[ "$(jq -r '.state' "$state_file")" = "diverged" ] || fail "expected diverged state"
+[ "$(jq -r '.ahead' "$state_file")" = "1" ] || fail "expected ahead=1"
+[ "$(jq -r '.behind' "$state_file")" = "1" ] || fail "expected behind=1"
+[ "$(printf '%s' "$summary" | cut -d'|' -f1)" = "true" ] || fail "fetch should report success"
+pass "fetch-only drift check updates observability without rebasing runtime"
+
+if grep -q 'git pull --rebase' "$ROOT_DIR/scripts/tribunal-quota-loop.sh"; then
+  fail "quota loop still contains git pull --rebase"
+fi
+pass "quota loop no longer hardcodes pull --rebase"

--- a/scripts/tests/test-tribunal-worker-sync-ref.sh
+++ b/scripts/tests/test-tribunal-worker-sync-ref.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+BOOTSTRAP="$ROOT_DIR/scripts/tribunal-worker-bootstrap.sh"
+
+fail() { echo "x $*" >&2; exit 1; }
+pass() { echo "ok $*"; }
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+repo="$TMP/gu-log"
+mkdir -p "$repo"
+git -C "$repo" init -q
+git -C "$repo" config user.email test@example.invalid
+git -C "$repo" config user.name "Worker Sync Ref Test"
+printf 'one\n' > "$repo/file.txt"
+git -C "$repo" add file.txt
+git -C "$repo" commit -q -m base
+
+mkdir -p "$repo/scripts"
+cp "$BOOTSTRAP" "$repo/scripts/tribunal-worker-bootstrap.sh"
+chmod +x "$repo/scripts/tribunal-worker-bootstrap.sh"
+
+git -C "$repo" worktree add "$TMP/gu-log-worker-a" HEAD >/dev/null 2>&1
+printf 'two\n' >> "$repo/file.txt"
+git -C "$repo" add file.txt
+git -C "$repo" commit -q -m second
+
+(cd "$repo" && TRIBUNAL_WORKER_SYNC_REF=HEAD bash scripts/tribunal-worker-bootstrap.sh sync a >/tmp/worker-sync.out 2>&1)
+
+main_sha="$(git -C "$repo" rev-parse HEAD)"
+worker_sha="$(git -C "$TMP/gu-log-worker-a" rev-parse HEAD)"
+[ "$main_sha" = "$worker_sha" ] || fail "worker did not sync to supervisor HEAD"
+pass "worker sync can follow supervisor HEAD instead of origin/main"

--- a/scripts/tribunal-batch-runner.sh
+++ b/scripts/tribunal-batch-runner.sh
@@ -21,11 +21,14 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$ROOT_DIR"
 
+source "$SCRIPT_DIR/tribunal-helpers.sh"
+
 POSTS_DIR="$ROOT_DIR/src/content/posts"
-PROGRESS_FILE="$ROOT_DIR/scores/tribunal-progress.json"
+PROGRESS_FILE="$(tribunal_progress_file_default "$ROOT_DIR")"
 TRIBUNAL_VERSION=5
 LOG_DIR="$ROOT_DIR/.score-loop/logs"
 LOG_FILE="$LOG_DIR/tribunal-batch-$(date +%Y%m%d-%H%M%S).log"
+RUNTIME_GIT_STATE_FILE="$(tribunal_runtime_git_state_file "$ROOT_DIR")"
 QUOTA_FLOOR_PCT="${QUOTA_FLOOR_PCT:-3}"
 MAX_ARTICLES="${MAX_ARTICLES:-999}"
 DRY_RUN=false
@@ -96,9 +99,7 @@ except Exception:
 # Articles that haven't passed all 4 tribunal stages.
 get_unscored_articles() {
   # Ensure progress file exists
-  if [ ! -f "$PROGRESS_FILE" ] || ! jq empty "$PROGRESS_FILE" 2>/dev/null; then
-    echo '{}' > "$PROGRESS_FILE"
-  fi
+  ensure_tribunal_progress_file "$PROGRESS_FILE" "$ROOT_DIR"
 
   # List zh-tw articles (not en-, not deprecated), sorted newest-first by
   # frontmatter translatedDate. Keep in sync with
@@ -140,9 +141,14 @@ get_unscored_articles() {
 tlog "=== Tribunal Batch Runner started ==="
 tlog "  Floor: ${QUOTA_FLOOR_PCT}%, Max: ${MAX_ARTICLES}, Dry-run: ${DRY_RUN}"
 
-# Pull latest
-tlog "Pulling latest from origin..."
-git pull --rebase origin main >> "$LOG_FILE" 2>&1 || tlog "WARN: git pull failed"
+# Fetch-only drift check
+tlog "Fetching origin/main for drift status..."
+git_drift="$(tribunal_fetch_and_report_origin_main "$ROOT_DIR" "$LOG_FILE" "$RUNTIME_GIT_STATE_FILE")"
+IFS='|' read -r git_fetched git_state git_ahead git_behind git_dirty <<< "$git_drift"
+if [ "$git_fetched" != "true" ]; then
+  tlog "WARN: origin/main fetch failed; continuing with current snapshot."
+fi
+tlog "Git drift: state=$git_state ahead=$git_ahead behind=$git_behind tracked_dirty=$git_dirty"
 
 # Get unscored articles
 mapfile -t ARTICLES < <(get_unscored_articles)

--- a/scripts/tribunal-batch-runner.sh
+++ b/scripts/tribunal-batch-runner.sh
@@ -143,11 +143,13 @@ tlog "  Floor: ${QUOTA_FLOOR_PCT}%, Max: ${MAX_ARTICLES}, Dry-run: ${DRY_RUN}"
 
 # Fetch-only drift check
 tlog "Fetching origin/main for drift status..."
-git_drift="$(tribunal_fetch_and_report_origin_main "$ROOT_DIR" "$LOG_FILE" "$RUNTIME_GIT_STATE_FILE")"
-IFS='|' read -r git_fetched git_state git_ahead git_behind git_dirty <<< "$git_drift"
-if [ "$git_fetched" != "true" ]; then
+if ! tribunal_fetch_and_report_origin_main "$ROOT_DIR" "$LOG_FILE" "$RUNTIME_GIT_STATE_FILE" >/dev/null; then
   tlog "WARN: origin/main fetch failed; continuing with current snapshot."
 fi
+git_state="$(jq -r '.state // "unknown"' "$RUNTIME_GIT_STATE_FILE" 2>/dev/null || printf 'unknown')"
+git_ahead="$(jq -r '.ahead // 0' "$RUNTIME_GIT_STATE_FILE" 2>/dev/null || printf '0')"
+git_behind="$(jq -r '.behind // 0' "$RUNTIME_GIT_STATE_FILE" 2>/dev/null || printf '0')"
+git_dirty="$(jq -r '.trackedDirty // 0' "$RUNTIME_GIT_STATE_FILE" 2>/dev/null || printf '0')"
 tlog "Git drift: state=$git_state ahead=$git_ahead behind=$git_behind tracked_dirty=$git_dirty"
 
 # Get unscored articles

--- a/scripts/tribunal-helpers.sh
+++ b/scripts/tribunal-helpers.sh
@@ -170,6 +170,114 @@ sys.exit(0 if parts(sys.argv[1]) >= parts(sys.argv[2]) else 1)
 PY
 }
 
+tribunal_progress_file_default() {
+  local root="${1:-${REPO_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}}"
+  printf '%s/.score-loop/state/tribunal-progress.json\n' "$root"
+}
+
+tribunal_legacy_progress_file() {
+  local root="${1:-${REPO_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}}"
+  printf '%s/scores/tribunal-progress.json\n' "$root"
+}
+
+tribunal_progress_migration_dir() {
+  local root="${1:-${REPO_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}}"
+  printf '%s/.score-loop/state/migrations\n' "$root"
+}
+
+tribunal_runtime_git_state_file() {
+  local root="${1:-${REPO_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}}"
+  printf '%s/.score-loop/state/runtime-git.json\n' "$root"
+}
+
+ensure_tribunal_progress_file() {
+  local target="$1"
+  local root="${2:-${REPO_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}}"
+  local legacy="${3:-$(tribunal_legacy_progress_file "$root")}"
+
+  mkdir -p "$(dirname "$target")" "$(tribunal_progress_migration_dir "$root")"
+
+  if [ -f "$target" ] && jq empty "$target" >/dev/null 2>&1; then
+    return 0
+  fi
+
+  if [ "$target" != "$legacy" ] && [ -f "$legacy" ] && jq empty "$legacy" >/dev/null 2>&1; then
+    local stamp backup
+    stamp="$(TZ=Asia/Taipei date +%Y%m%d-%H%M%S)"
+    backup="$(tribunal_progress_migration_dir "$root")/legacy-tribunal-progress-$stamp.json"
+    cp "$legacy" "$backup"
+    cp "$legacy" "$target"
+    return 0
+  fi
+
+  printf '{}\n' > "$target"
+}
+
+tribunal_fetch_origin_main() {
+  local repo_dir="$1"
+  local log_file="$2"
+  git -C "$repo_dir" fetch --prune origin main >> "$log_file" 2>&1
+}
+
+tribunal_write_runtime_git_state() {
+  local repo_dir="$1"
+  local state_file="${2:-$(tribunal_runtime_git_state_file "$repo_dir")}"
+  local ts local_ref remote_ref counts ahead behind state tracked_dirty
+
+  mkdir -p "$(dirname "$state_file")"
+
+  ts="$(TZ=Asia/Taipei date -Iseconds)"
+  local_ref="$(git -C "$repo_dir" rev-parse HEAD 2>/dev/null || true)"
+  remote_ref="$(git -C "$repo_dir" rev-parse refs/remotes/origin/main 2>/dev/null || true)"
+  counts="$(git -C "$repo_dir" rev-list --left-right --count HEAD...refs/remotes/origin/main 2>/dev/null || printf '0\t0')"
+  ahead="$(printf '%s' "$counts" | awk '{print $1}')"
+  behind="$(printf '%s' "$counts" | awk '{print $2}')"
+  tracked_dirty="$(git -C "$repo_dir" status --porcelain --untracked-files=no 2>/dev/null | wc -l | tr -d ' ')"
+
+  if [ -z "$local_ref" ] || [ -z "$remote_ref" ]; then
+    state="unknown"
+  elif [ "$ahead" = "0" ] && [ "$behind" = "0" ]; then
+    state="in_sync"
+  elif [ "$ahead" = "0" ]; then
+    state="behind"
+  elif [ "$behind" = "0" ]; then
+    state="ahead"
+  else
+    state="diverged"
+  fi
+
+  jq -n \
+    --arg state "$state" \
+    --arg localHead "$local_ref" \
+    --arg originMainHead "$remote_ref" \
+    --arg updatedAt "$ts" \
+    --argjson ahead "${ahead:-0}" \
+    --argjson behind "${behind:-0}" \
+    --argjson trackedDirty "${tracked_dirty:-0}" \
+    '{state: $state, ahead: $ahead, behind: $behind, trackedDirty: $trackedDirty, localHead: $localHead, originMainHead: $originMainHead, updatedAt: $updatedAt}' \
+    > "$state_file"
+}
+
+tribunal_fetch_and_report_origin_main() {
+  local repo_dir="$1"
+  local log_file="$2"
+  local state_file="${3:-$(tribunal_runtime_git_state_file "$repo_dir")}"
+  local fetched="true"
+
+  if ! tribunal_fetch_origin_main "$repo_dir" "$log_file"; then
+    fetched="false"
+  fi
+
+  tribunal_write_runtime_git_state "$repo_dir" "$state_file"
+
+  local state ahead behind tracked_dirty
+  state="$(jq -r '.state // "unknown"' "$state_file" 2>/dev/null || printf 'unknown')"
+  ahead="$(jq -r '.ahead // 0' "$state_file" 2>/dev/null || printf '0')"
+  behind="$(jq -r '.behind // 0' "$state_file" 2>/dev/null || printf '0')"
+  tracked_dirty="$(jq -r '.trackedDirty // 0' "$state_file" 2>/dev/null || printf '0')"
+  printf '%s|%s|%s|%s|%s\n' "$fetched" "$state" "$ahead" "$behind" "$tracked_dirty"
+}
+
 # Run a repo-local agent spec through Codex. Codex custom agents live in
 # `.codex/agents/*.toml`, but `codex exec` has no stable `--agent` flag for this
 # non-interactive tribunal path, so we inline the project-scoped Codex agent

--- a/scripts/tribunal-helpers.sh
+++ b/scripts/tribunal-helpers.sh
@@ -195,6 +195,11 @@ tribunal_publisher_state_file() {
   printf '%s/.score-loop/state/tribunal-publisher.json\n' "$root"
 }
 
+tribunal_triage_events_file() {
+  local root="${1:-${REPO_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}}"
+  printf '%s/.score-loop/state/tribunal-triage-events.json\n' "$root"
+}
+
 ensure_tribunal_progress_file() {
   local target="$1"
   local root="${2:-${REPO_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}}"

--- a/scripts/tribunal-helpers.sh
+++ b/scripts/tribunal-helpers.sh
@@ -190,6 +190,11 @@ tribunal_runtime_git_state_file() {
   printf '%s/.score-loop/state/runtime-git.json\n' "$root"
 }
 
+tribunal_publisher_state_file() {
+  local root="${1:-${REPO_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}}"
+  printf '%s/.score-loop/state/tribunal-publisher.json\n' "$root"
+}
+
 ensure_tribunal_progress_file() {
   local target="$1"
   local root="${2:-${REPO_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}}"

--- a/scripts/tribunal-helpers.sh
+++ b/scripts/tribunal-helpers.sh
@@ -243,8 +243,13 @@ tribunal_write_runtime_git_state() {
   ahead="$(printf '%s' "$counts" | awk '{print $1}')"
   behind="$(printf '%s' "$counts" | awk '{print $2}')"
   tracked_dirty="$(git -C "$repo_dir" status --porcelain --untracked-files=no 2>/dev/null | wc -l | tr -d ' ')"
+  [[ "$ahead" =~ ^[0-9]+$ ]] || ahead=0
+  [[ "$behind" =~ ^[0-9]+$ ]] || behind=0
+  [[ "$tracked_dirty" =~ ^[0-9]+$ ]] || tracked_dirty=0
+  [ -n "$local_ref" ] || local_ref="unknown"
+  [ -n "$remote_ref" ] || remote_ref="unknown"
 
-  if [ -z "$local_ref" ] || [ -z "$remote_ref" ]; then
+  if [ "$local_ref" = "unknown" ] || [ "$remote_ref" = "unknown" ]; then
     state="unknown"
   elif [ "$ahead" = "0" ] && [ "$behind" = "0" ]; then
     state="in_sync"

--- a/scripts/tribunal-publisher.sh
+++ b/scripts/tribunal-publisher.sh
@@ -13,29 +13,37 @@ source "$SCRIPT_DIR/tribunal-helpers.sh"
 
 PROGRESS_FILE="${PROGRESS_FILE:-$(tribunal_progress_file_default "$ROOT_DIR")}"
 PUBLISHER_STATE_FILE="${PUBLISHER_STATE_FILE:-$(tribunal_publisher_state_file "$ROOT_DIR")}"
+TRIAGE_EVENTS_FILE="${TRIAGE_EVENTS_FILE:-$(tribunal_triage_events_file "$ROOT_DIR")}"
 POSTS_DIR="$ROOT_DIR/src/content/posts"
 MODE="dry-run"
 MAX_BATCH="${MAX_BATCH:-10}"
 WORKTREE_PATH=""
 BRANCH_NAME=""
 KEEP_WORKTREE=0
+PUSH_PR=0
+SKIP_BUILD="${TRIBUNAL_PUBLISHER_SKIP_BUILD:-0}"
+REPO="${GU_LOG_GITHUB_REPO:-chitienhsiehwork-ai/gu-log}"
+GH_BIN="${GH_BIN:-gh}"
 
 usage() {
   cat >&2 <<'USAGE'
 Usage:
   bash scripts/tribunal-publisher.sh --dry-run [--max N]
-  bash scripts/tribunal-publisher.sh --apply [--max N] [--branch NAME] [--worktree PATH] [--keep-worktree]
+  bash scripts/tribunal-publisher.sh --status
+  bash scripts/tribunal-publisher.sh --apply [--max N] [--branch NAME] [--worktree PATH] [--keep-worktree] [--push-pr]
 USAGE
 }
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
     --dry-run) MODE="dry-run"; shift ;;
+    --status) MODE="status"; shift ;;
     --apply) MODE="apply"; shift ;;
     --max) MAX_BATCH="$2"; shift 2 ;;
     --branch) BRANCH_NAME="$2"; shift 2 ;;
     --worktree) WORKTREE_PATH="$2"; shift 2 ;;
     --keep-worktree) KEEP_WORKTREE=1; shift ;;
+    --push-pr) PUSH_PR=1; shift ;;
     -h|--help) usage; exit 0 ;;
     *) echo "Unknown arg: $1" >&2; usage; exit 2 ;;
   esac
@@ -50,6 +58,9 @@ ensure_runtime_files() {
   mkdir -p "$(dirname "$PUBLISHER_STATE_FILE")"
   if [ ! -f "$PUBLISHER_STATE_FILE" ] || ! jq empty "$PUBLISHER_STATE_FILE" >/dev/null 2>&1; then
     jq -n '{schemaVersion: 1, entries: {}, batches: {}}' > "$PUBLISHER_STATE_FILE"
+  fi
+  if [ ! -f "$TRIAGE_EVENTS_FILE" ] || ! jq empty "$TRIAGE_EVENTS_FILE" >/dev/null 2>&1; then
+    jq -n '{schemaVersion: 1, events: {}}' > "$TRIAGE_EVENTS_FILE"
   fi
 }
 
@@ -71,6 +82,26 @@ current_batch_id() {
   jq -r --arg a "$article" '.entries[$a].batchId // ""' "$PUBLISHER_STATE_FILE"
 }
 
+publisher_gh() {
+  local token_file="${GU_LOG_GH_TOKEN_FILE:-$HOME/.config/github-tokens/gu-log-operator.token}"
+  if [ -n "${GU_LOG_GH_TOKEN:-}" ]; then
+    GH_TOKEN="$GU_LOG_GH_TOKEN" "$GH_BIN" "$@"
+    return
+  fi
+  if [ -f "$token_file" ]; then
+    GH_TOKEN="$(cat "$token_file")" "$GH_BIN" "$@"
+    return
+  fi
+  "$GH_BIN" "$@"
+}
+
+publisher_has_gh_auth() {
+  local token_file="${GU_LOG_GH_TOKEN_FILE:-$HOME/.config/github-tokens/gu-log-operator.token}"
+  [ -n "${GU_LOG_GH_TOKEN:-}" ] && return 0
+  [ -f "$token_file" ] && return 0
+  "$GH_BIN" auth status >/dev/null 2>&1
+}
+
 collect_articles_by_status() {
   local status="$1"
   jq -r --arg s "$status" '
@@ -86,7 +117,7 @@ collect_publishable_passes() {
   while IFS= read -r article; do
     [ -n "$article" ] || continue
     state="$(current_publish_state "$article")"
-    if [ "$state" = "ready_for_batch" ]; then
+    if [ "$state" = "ready_for_batch" ] && ! article_has_blocking_event "$article"; then
       printf '%s\n' "$article"
     fi
   done < <(collect_articles_by_status "PASS")
@@ -103,19 +134,225 @@ collect_state_articles() {
   ' "$PUBLISHER_STATE_FILE"
 }
 
+collect_blocking_event_articles() {
+  local kind="$1"
+  jq -r --arg kind "$kind" '
+    .events
+    | to_entries
+    | map(select(.value.kind == $kind))
+    | map(select((.value.state // "") == "open" or (.value.state // "") == "agent_review" or (.value.state // "") == "awaiting_human" or (.value.state // "") == "deferred"))
+    | map(.value.article)
+    | unique
+    | .[]
+  ' "$TRIAGE_EVENTS_FILE"
+}
+
+article_has_blocking_event() {
+  local article="$1"
+  jq -e --arg article "$article" '
+    any(
+      .events[]?;
+      .article == $article and ((.state // "") == "open" or (.state // "") == "agent_review" or (.state // "") == "awaiting_human" or (.state // "") == "deferred")
+    )
+  ' "$TRIAGE_EVENTS_FILE" >/dev/null 2>&1
+}
+
+event_id_for() {
+  local kind="$1" article="$2" fingerprint="$3"
+  printf '%s|%s|%s\n' "$kind" "$article" "$fingerprint" | sha1sum | awk '{print substr($1,1,16)}'
+}
+
+record_event() {
+  local kind="$1" article="$2" fingerprint="$3" targets_json="$4" summary="$5" options_json="$6"
+  local event_id ts tmp
+  event_id="$(event_id_for "$kind" "$article" "$fingerprint")"
+  ts="$(TZ=Asia/Taipei date -Iseconds)"
+  tmp="$(mktemp)"
+  jq \
+    --arg id "$event_id" \
+    --arg kind "$kind" \
+    --arg article "$article" \
+    --arg fingerprint "$fingerprint" \
+    --arg summary "$summary" \
+    --arg updatedAt "$ts" \
+    --argjson targets "$targets_json" \
+    --argjson options "$options_json" '
+      .events[$id] = (
+        .events[$id] // {
+          eventId: $id,
+          kind: $kind,
+          article: $article,
+          state: "open",
+          resolution: null,
+          createdAt: $updatedAt
+        }
+      )
+      | .events[$id].kind = $kind
+      | .events[$id].article = $article
+      | .events[$id].state = "open"
+      | .events[$id].summary = $summary
+      | .events[$id].fingerprint = $fingerprint
+      | .events[$id].comparisonTargets = $targets
+      | .events[$id].decisionOptions = $options
+      | .events[$id].updatedAt = $updatedAt
+    ' "$TRIAGE_EVENTS_FILE" > "$tmp"
+  mv "$tmp" "$TRIAGE_EVENTS_FILE"
+  printf '%s\n' "$event_id"
+}
+
+publisher_label_on_pr() {
+  local pr_json="$1"
+  jq -e 'any(.labels[]?; (.name // "") == "tribunal-publisher")' <<<"$pr_json" >/dev/null 2>&1
+}
+
+open_pr_list_json() {
+  if [ "${TRIBUNAL_PUBLISHER_DISABLE_GH_SCAN:-0}" = "1" ]; then
+    printf '[]\n'
+  elif [ -n "${TRIBUNAL_PUBLISHER_PR_LIST_JSON_FILE:-}" ]; then
+    cat "$TRIBUNAL_PUBLISHER_PR_LIST_JSON_FILE"
+  elif ! publisher_has_gh_auth; then
+    printf '[]\n'
+  else
+    publisher_gh pr list --repo "$REPO" --state open --limit 200 --json number,title,headRefName,labels
+  fi
+}
+
+open_pr_files_json() {
+  local pr_number="$1"
+  if [ "${TRIBUNAL_PUBLISHER_DISABLE_GH_SCAN:-0}" = "1" ]; then
+    printf '{"files":[]}\n'
+  elif [ -n "${TRIBUNAL_PUBLISHER_PR_FILES_DIR:-}" ] && [ -f "$TRIBUNAL_PUBLISHER_PR_FILES_DIR/$pr_number.json" ]; then
+    cat "$TRIBUNAL_PUBLISHER_PR_FILES_DIR/$pr_number.json"
+  elif ! publisher_has_gh_auth; then
+    printf '{"files":[]}\n'
+  else
+    publisher_gh pr view "$pr_number" --repo "$REPO" --json files
+  fi
+}
+
+article_conflict_targets_json() {
+  local article="$1"
+  local rels_json prs_json
+  rels_json="$(post_relpaths_for_article "$article" | jq -R . | jq -s .)"
+  prs_json="$(open_pr_list_json)"
+  python3 - "$article" "$rels_json" "$prs_json" <<'PY'
+import json, os, subprocess, sys
+article = sys.argv[1]
+rels = json.loads(sys.argv[2])
+prs = json.loads(sys.argv[3])
+targets = []
+for pr in prs:
+    labels = pr.get("labels", []) or []
+    if (pr.get("headRefName", "") or "").startswith("publisher/"):
+        continue
+    if any((label.get("name", "") == "tribunal-publisher") for label in labels):
+        continue
+    num = pr["number"]
+    files_dir = os.environ.get("TRIBUNAL_PUBLISHER_PR_FILES_DIR")
+    if files_dir and os.path.isfile(os.path.join(files_dir, f"{num}.json")):
+        with open(os.path.join(files_dir, f"{num}.json"), "r", encoding="utf-8") as fh:
+            files_json = json.load(fh)
+    else:
+        gh_bin = os.environ.get("GH_BIN", "gh")
+        repo = os.environ.get("GU_LOG_GITHUB_REPO", "chitienhsiehwork-ai/gu-log")
+        token = os.environ.get("GU_LOG_GH_TOKEN")
+        token_file = os.environ.get("GU_LOG_GH_TOKEN_FILE", os.path.expanduser("~/.config/github-tokens/gu-log-operator.token"))
+        env = os.environ.copy()
+        if not token and os.path.isfile(token_file):
+            with open(token_file, "r", encoding="utf-8") as fh:
+                env["GH_TOKEN"] = fh.read().strip()
+        elif token:
+            env["GH_TOKEN"] = token
+        out = subprocess.check_output([gh_bin, "pr", "view", str(num), "--repo", repo, "--json", "files"], env=env)
+        files_json = json.loads(out)
+    paths = [f["path"] for f in files_json.get("files", [])]
+    overlap = [p for p in paths if p in rels]
+    if overlap:
+        targets.append({
+            "id": f"pr:{num}",
+            "number": num,
+            "title": pr.get("title", ""),
+            "headRefName": pr.get("headRefName", ""),
+            "paths": overlap,
+        })
+print(json.dumps(targets))
+PY
+}
+
+refresh_conflict_events() {
+  local article targets_json fingerprint summary options_json
+  options_json='["keep_current","accept_tribunal","agent_merge","requeue","defer","no_action"]'
+  while IFS= read -r article; do
+    [ -n "$article" ] || continue
+    targets_json="$(article_conflict_targets_json "$article" <<<"$(open_pr_list_json)")"
+    if [ "$(jq 'length' <<<"$targets_json")" -gt 0 ]; then
+      fingerprint="$(jq -c 'map(.id)' <<<"$targets_json")"
+      summary="Open editorial PR already touches publishable Tribunal paths."
+      record_event "conflict" "$article" "$fingerprint" "$targets_json" "$summary" "$options_json" >/dev/null
+    fi
+  done < <(collect_articles_by_status "PASS")
+}
+
+mark_entry_publish_state() {
+  local article="$1" state="$2"
+  local batch_id="${3:-}"
+  local tmp ts
+  ts="$(TZ=Asia/Taipei date -Iseconds)"
+  tmp="$(mktemp)"
+  jq \
+    --arg article "$article" \
+    --arg state "$state" \
+    --arg batchId "$batch_id" \
+    --arg updatedAt "$ts" '
+      .entries[$article] = ((.entries[$article] // {}) + {
+        publishState: $state,
+        batchId: (if $batchId == "" then (.entries[$article].batchId // null) else $batchId end),
+        updatedAt: $updatedAt
+      })
+    ' "$PUBLISHER_STATE_FILE" > "$tmp"
+  mv "$tmp" "$PUBLISHER_STATE_FILE"
+}
+
+validate_candidate_article() {
+  local article="$1"
+  if [ -n "${TRIBUNAL_PUBLISHER_VALIDATE_HOOK:-}" ]; then
+    "${TRIBUNAL_PUBLISHER_VALIDATE_HOOK}" "$article"
+    return
+  fi
+  local args=("$article")
+  if [ -f "$POSTS_DIR/en-$article" ]; then
+    args+=("en-$article")
+  fi
+  node "$ROOT_DIR/scripts/validate-posts.mjs" "${args[@]}" >/tmp/tribunal-publisher-validate.out 2>&1
+}
+
+record_validation_blocked() {
+  local article="$1" reason="$2"
+  local options_json targets_json fingerprint
+  options_json='["validation_fix","requeue","defer","no_action"]'
+  targets_json="$(post_relpaths_for_article "$article" | jq -R '{path: .}' | jq -s .)"
+  fingerprint="$(printf '%s' "$reason" | sha1sum | awk '{print substr($1,1,16)}')"
+  record_event "validation_blocked" "$article" "$fingerprint" "$targets_json" "$reason" "$options_json" >/dev/null
+}
+
 render_report() {
-  local publishable failed exhausted runner_error batched published
+  refresh_conflict_events
+  local publishable failed exhausted runner_error batched published conflicted validation_blocked
   mapfile -t publishable < <(collect_publishable_passes)
   mapfile -t failed < <(collect_articles_by_status "FAILED")
   mapfile -t exhausted < <(collect_articles_by_status "EXHAUSTED")
   mapfile -t runner_error < <(collect_articles_by_status "RUNNER_ERROR")
   mapfile -t batched < <(collect_state_articles "batch_selected")
   mapfile -t published < <(collect_state_articles "published")
+  mapfile -t conflicted < <(collect_blocking_event_articles "conflict")
+  mapfile -t validation_blocked < <(collect_blocking_event_articles "validation_blocked")
 
   tlog "publishable PASS: ${#publishable[@]}"
   for article in "${publishable[@]:0:$MAX_BATCH}"; do
     tlog "  ready  $article"
   done
+  tlog "conflicted: ${#conflicted[@]}"
+  tlog "validation_blocked: ${#validation_blocked[@]}"
   tlog "FAILED metadata: ${#failed[@]}"
   tlog "EXHAUSTED metadata: ${#exhausted[@]}"
   tlog "RUNNER_ERROR metadata: ${#runner_error[@]}"
@@ -157,9 +394,25 @@ reserve_batch_state() {
 
 apply_batch() {
   local article batch_id branch_name batch_dir
+  refresh_conflict_events
   mapfile -t selected < <(collect_publishable_passes | head -n "$MAX_BATCH")
   if [ "${#selected[@]}" -eq 0 ]; then
     tlog "No publishable PASS artifacts."
+    return 0
+  fi
+
+  local validated=()
+  for article in "${selected[@]}"; do
+    if validate_candidate_article "$article"; then
+      validated+=("$article")
+    else
+      record_validation_blocked "$article" "validate-posts failed for candidate artifact"
+      tlog "  validation_blocked $article"
+    fi
+  done
+
+  if [ "${#validated[@]}" -eq 0 ]; then
+    tlog "No valid publishable PASS artifacts after candidate validation."
     return 0
   fi
 
@@ -176,7 +429,7 @@ apply_batch() {
   mkdir -p "$(dirname "$batch_dir")"
   git worktree add -b "$branch_name" "$batch_dir" origin/main >/dev/null
 
-  for article in "${selected[@]}"; do
+  for article in "${validated[@]}"; do
     while IFS= read -r rel; do
       [ -n "$rel" ] || continue
       mkdir -p "$batch_dir/$(dirname "$rel")"
@@ -191,16 +444,46 @@ apply_batch() {
     git branch -D "$branch_name" >/dev/null 2>&1 || true
     return 0
   fi
+  if [ "$SKIP_BUILD" != "1" ]; then
+    if ! (cd "$batch_dir" && pnpm run build >/tmp/tribunal-publisher-build.out 2>&1); then
+      local reason="whole-site build failed for batch"
+      for article in "${validated[@]}"; do
+        record_validation_blocked "$article" "$reason"
+      done
+      tlog "Batch build failed; emitted validation_blocked events."
+      git worktree remove "$batch_dir" --force
+      git branch -D "$branch_name" >/dev/null 2>&1 || true
+      return 1
+    fi
+  fi
   git -C "$batch_dir" commit -m "publisher: materialize Tribunal batch $batch_id" >/dev/null
 
-  reserve_batch_state "$batch_id" "$branch_name" "${selected[@]}"
+  reserve_batch_state "$batch_id" "$branch_name" "${validated[@]}"
 
   tlog "batch_id=$batch_id"
   tlog "branch=$branch_name"
   tlog "worktree=$batch_dir"
-  for article in "${selected[@]}"; do
+  for article in "${validated[@]}"; do
     tlog "  selected $article"
   done
+
+  if [ "$PUSH_PR" = "1" ]; then
+    git -C "$batch_dir" push -u origin "$branch_name" >/dev/null
+    for article in "${validated[@]}"; do
+      mark_entry_publish_state "$article" "branch_pushed" "$batch_id"
+    done
+    local pr_url
+    pr_url="$(publisher_gh pr create --draft --repo "$REPO" --base main --head "$branch_name" --title "Tribunal publisher batch $batch_id" --body "Automated Tribunal publisher batch." 2>/dev/null || true)"
+    if [ -n "$pr_url" ]; then
+      local pr_number
+      pr_number="$(basename "$pr_url")"
+      publisher_gh pr edit "$pr_number" --repo "$REPO" --add-label tribunal-publisher >/dev/null 2>&1 || true
+      for article in "${validated[@]}"; do
+        mark_entry_publish_state "$article" "pr_open" "$batch_id"
+      done
+      tlog "pr=$pr_url"
+    fi
+  fi
 
   if [ "$KEEP_WORKTREE" != "1" ]; then
     tlog "worktree kept at $batch_dir for inspection"
@@ -211,6 +494,7 @@ ensure_runtime_files
 
 case "$MODE" in
   dry-run) render_report ;;
+  status) render_report ;;
   apply) apply_batch ;;
   *) usage; exit 2 ;;
 esac

--- a/scripts/tribunal-publisher.sh
+++ b/scripts/tribunal-publisher.sh
@@ -1,0 +1,216 @@
+#!/usr/bin/env bash
+# tribunal-publisher.sh — materialize publishable Tribunal PASS artifacts from
+# the ignored runtime ledger into a clean origin/main-based batch worktree.
+
+set -euo pipefail
+export TZ=Asia/Taipei
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$ROOT_DIR"
+
+source "$SCRIPT_DIR/tribunal-helpers.sh"
+
+PROGRESS_FILE="${PROGRESS_FILE:-$(tribunal_progress_file_default "$ROOT_DIR")}"
+PUBLISHER_STATE_FILE="${PUBLISHER_STATE_FILE:-$(tribunal_publisher_state_file "$ROOT_DIR")}"
+POSTS_DIR="$ROOT_DIR/src/content/posts"
+MODE="dry-run"
+MAX_BATCH="${MAX_BATCH:-10}"
+WORKTREE_PATH=""
+BRANCH_NAME=""
+KEEP_WORKTREE=0
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage:
+  bash scripts/tribunal-publisher.sh --dry-run [--max N]
+  bash scripts/tribunal-publisher.sh --apply [--max N] [--branch NAME] [--worktree PATH] [--keep-worktree]
+USAGE
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --dry-run) MODE="dry-run"; shift ;;
+    --apply) MODE="apply"; shift ;;
+    --max) MAX_BATCH="$2"; shift 2 ;;
+    --branch) BRANCH_NAME="$2"; shift 2 ;;
+    --worktree) WORKTREE_PATH="$2"; shift 2 ;;
+    --keep-worktree) KEEP_WORKTREE=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown arg: $1" >&2; usage; exit 2 ;;
+  esac
+done
+
+tlog() {
+  printf '[publisher] %s\n' "$*"
+}
+
+ensure_runtime_files() {
+  ensure_tribunal_progress_file "$PROGRESS_FILE" "$ROOT_DIR"
+  mkdir -p "$(dirname "$PUBLISHER_STATE_FILE")"
+  if [ ! -f "$PUBLISHER_STATE_FILE" ] || ! jq empty "$PUBLISHER_STATE_FILE" >/dev/null 2>&1; then
+    jq -n '{schemaVersion: 1, entries: {}, batches: {}}' > "$PUBLISHER_STATE_FILE"
+  fi
+}
+
+post_relpaths_for_article() {
+  local article="$1"
+  printf 'src/content/posts/%s\n' "$article"
+  if [ -f "$POSTS_DIR/en-$article" ]; then
+    printf 'src/content/posts/en-%s\n' "$article"
+  fi
+}
+
+current_publish_state() {
+  local article="$1"
+  jq -r --arg a "$article" '.entries[$a].publishState // "ready_for_batch"' "$PUBLISHER_STATE_FILE"
+}
+
+current_batch_id() {
+  local article="$1"
+  jq -r --arg a "$article" '.entries[$a].batchId // ""' "$PUBLISHER_STATE_FILE"
+}
+
+collect_articles_by_status() {
+  local status="$1"
+  jq -r --arg s "$status" '
+    to_entries
+    | map(select((.value.status // "") == $s))
+    | sort_by(.key)
+    | .[].key
+  ' "$PROGRESS_FILE"
+}
+
+collect_publishable_passes() {
+  local article state
+  while IFS= read -r article; do
+    [ -n "$article" ] || continue
+    state="$(current_publish_state "$article")"
+    if [ "$state" = "ready_for_batch" ]; then
+      printf '%s\n' "$article"
+    fi
+  done < <(collect_articles_by_status "PASS")
+}
+
+collect_state_articles() {
+  local desired="$1"
+  jq -r --arg desired "$desired" '
+    .entries
+    | to_entries
+    | map(select((.value.publishState // "") == $desired))
+    | sort_by(.key)
+    | .[].key
+  ' "$PUBLISHER_STATE_FILE"
+}
+
+render_report() {
+  local publishable failed exhausted runner_error batched published
+  mapfile -t publishable < <(collect_publishable_passes)
+  mapfile -t failed < <(collect_articles_by_status "FAILED")
+  mapfile -t exhausted < <(collect_articles_by_status "EXHAUSTED")
+  mapfile -t runner_error < <(collect_articles_by_status "RUNNER_ERROR")
+  mapfile -t batched < <(collect_state_articles "batch_selected")
+  mapfile -t published < <(collect_state_articles "published")
+
+  tlog "publishable PASS: ${#publishable[@]}"
+  for article in "${publishable[@]:0:$MAX_BATCH}"; do
+    tlog "  ready  $article"
+  done
+  tlog "FAILED metadata: ${#failed[@]}"
+  tlog "EXHAUSTED metadata: ${#exhausted[@]}"
+  tlog "RUNNER_ERROR metadata: ${#runner_error[@]}"
+  tlog "already batched: ${#batched[@]}"
+  tlog "already published: ${#published[@]}"
+}
+
+reserve_batch_state() {
+  local batch_id="$1"
+  local branch_name="$2"
+  shift 2
+  local selected_json
+  selected_json="$(printf '%s\n' "$@" | jq -R . | jq -s .)"
+  local ts
+  ts="$(TZ=Asia/Taipei date -Iseconds)"
+  local tmp
+  tmp="$(mktemp)"
+  jq \
+    --arg batchId "$batch_id" \
+    --arg branchName "$branch_name" \
+    --arg updatedAt "$ts" \
+    --argjson selected "$selected_json" '
+      .batches[$batchId] = {
+        batchId: $batchId,
+        branch: $branchName,
+        selectedAt: $updatedAt,
+        entries: $selected
+      }
+      | reduce $selected[] as $article (.;
+          .entries[$article] = {
+            publishState: "batch_selected",
+            batchId: $batchId,
+            updatedAt: $updatedAt
+          }
+        )
+    ' "$PUBLISHER_STATE_FILE" > "$tmp"
+  mv "$tmp" "$PUBLISHER_STATE_FILE"
+}
+
+apply_batch() {
+  local article batch_id branch_name batch_dir
+  mapfile -t selected < <(collect_publishable_passes | head -n "$MAX_BATCH")
+  if [ "${#selected[@]}" -eq 0 ]; then
+    tlog "No publishable PASS artifacts."
+    return 0
+  fi
+
+  batch_id="tribunal-batch-$(TZ=Asia/Taipei date +%Y%m%d-%H%M%S)"
+  branch_name="${BRANCH_NAME:-publisher/$batch_id}"
+  batch_dir="${WORKTREE_PATH:-$ROOT_DIR/.score-loop/publisher/$batch_id}"
+
+  tribunal_fetch_origin_main "$ROOT_DIR" /dev/null || true
+
+  if git show-ref --verify --quiet "refs/heads/$branch_name"; then
+    echo "ERROR: branch already exists locally: $branch_name" >&2
+    exit 1
+  fi
+  mkdir -p "$(dirname "$batch_dir")"
+  git worktree add -b "$branch_name" "$batch_dir" origin/main >/dev/null
+
+  for article in "${selected[@]}"; do
+    while IFS= read -r rel; do
+      [ -n "$rel" ] || continue
+      mkdir -p "$batch_dir/$(dirname "$rel")"
+      cp "$ROOT_DIR/$rel" "$batch_dir/$rel"
+    done < <(post_relpaths_for_article "$article")
+  done
+
+  git -C "$batch_dir" add src/content/posts
+  if git -C "$batch_dir" diff --cached --quiet; then
+    tlog "Selected artifacts produced no diff on origin/main; dropping empty batch."
+    git worktree remove "$batch_dir" --force
+    git branch -D "$branch_name" >/dev/null 2>&1 || true
+    return 0
+  fi
+  git -C "$batch_dir" commit -m "publisher: materialize Tribunal batch $batch_id" >/dev/null
+
+  reserve_batch_state "$batch_id" "$branch_name" "${selected[@]}"
+
+  tlog "batch_id=$batch_id"
+  tlog "branch=$branch_name"
+  tlog "worktree=$batch_dir"
+  for article in "${selected[@]}"; do
+    tlog "  selected $article"
+  done
+
+  if [ "$KEEP_WORKTREE" != "1" ]; then
+    tlog "worktree kept at $batch_dir for inspection"
+  fi
+}
+
+ensure_runtime_files
+
+case "$MODE" in
+  dry-run) render_report ;;
+  apply) apply_batch ;;
+  *) usage; exit 2 ;;
+esac

--- a/scripts/tribunal-quota-loop.sh
+++ b/scripts/tribunal-quota-loop.sh
@@ -945,11 +945,13 @@ while true; do
   EFFECTIVE_WORKERS=$(autoscale_read_limit)
 
   # ── Fetch-only drift check in main repo (workers sync their disposable worktrees) ──
-  git_drift="$(tribunal_fetch_and_report_origin_main "$ROOT_DIR" "$LOG_FILE" "$RUNTIME_GIT_STATE_FILE")"
-  IFS='|' read -r git_fetched git_state git_ahead git_behind git_dirty <<< "$git_drift"
-  if [ "$git_fetched" != "true" ]; then
+  if ! tribunal_fetch_and_report_origin_main "$ROOT_DIR" "$LOG_FILE" "$RUNTIME_GIT_STATE_FILE" >/dev/null; then
     tlog "WARN: origin/main fetch failed; runtime continues with current snapshot."
   fi
+  git_state="$(jq -r '.state // "unknown"' "$RUNTIME_GIT_STATE_FILE" 2>/dev/null || printf 'unknown')"
+  git_ahead="$(jq -r '.ahead // 0' "$RUNTIME_GIT_STATE_FILE" 2>/dev/null || printf '0')"
+  git_behind="$(jq -r '.behind // 0' "$RUNTIME_GIT_STATE_FILE" 2>/dev/null || printf '0')"
+  git_dirty="$(jq -r '.trackedDirty // 0' "$RUNTIME_GIT_STATE_FILE" 2>/dev/null || printf '0')"
   tlog "Git drift: state=$git_state ahead=$git_ahead behind=$git_behind tracked_dirty=$git_dirty"
 
   # ── Find unscored articles ─────────────────────────────────────────────────

--- a/scripts/tribunal-quota-loop.sh
+++ b/scripts/tribunal-quota-loop.sh
@@ -34,7 +34,7 @@ ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$ROOT_DIR"
 
 POSTS_DIR="$ROOT_DIR/src/content/posts"
-PROGRESS_FILE="$ROOT_DIR/scores/tribunal-progress.json"
+PROGRESS_FILE="$(tribunal_progress_file_default "$ROOT_DIR")"
 TRIBUNAL_VERSION=5
 LOG_DIR="$ROOT_DIR/.score-loop/logs"
 LOG_FILE="$LOG_DIR/tribunal-quota-loop-$(date +%Y%m%d-%H%M%S).log"
@@ -88,6 +88,8 @@ tlog() {
 export RC_ROOT_DIR="$ROOT_DIR"
 # shellcheck source=scripts/tribunal-run-control.sh
 source "$SCRIPT_DIR/tribunal-run-control.sh"
+
+RUNTIME_GIT_STATE_FILE="$(tribunal_runtime_git_state_file "$ROOT_DIR")"
 trap 'rc_on_stop_signal TERM' TERM
 trap 'rc_on_stop_signal INT' INT
 
@@ -660,8 +662,8 @@ print(f'# rotated: kept {kept} entries', file=sys.stderr)
 
 # ─── Multi-worker supervisor helpers (Phase 2) ───────────────────────────────
 # Worker worktrees live at ~/clawd/projects/gu-log-worker-<id>. The "main"
-# repo (this script's ROOT_DIR) hosts the shared progress file, claims,
-# locks, and state. When WORKERS=1 we run in ROOT_DIR directly — no worker
+# repo (this script's ROOT_DIR) hosts the ignored runtime ledger, claims,
+# locks, and controller state. When WORKERS=1 we run in ROOT_DIR directly — no worker
 # worktrees, no env overrides — matching the pre-Phase-2 behavior.
 WORKER_IDS=()
 if (( WORKERS > 1 )); then
@@ -748,7 +750,7 @@ spawn_worker() {
     # supervisor; make it explicit again here in case the subshell's env
     # differs).
     export RC_ROOT_DIR="$ROOT_DIR"
-    export PROGRESS_FILE="$ROOT_DIR/scores/tribunal-progress.json"
+    export PROGRESS_FILE="$(tribunal_progress_file_default "$ROOT_DIR")"
     export TRIBUNAL_MAIN_REPO="$ROOT_DIR"
     export TRIBUNAL_SHARED_LOCK_DIR="$ROOT_DIR/.score-loop/locks"
     export TRIBUNAL_WORKER_ID="$id"
@@ -821,9 +823,7 @@ drain_and_exit() {
 # Copied from tribunal-batch-runner.sh (not a shared helper — keep in sync).
 get_unscored_articles() {
   # Ensure progress file exists
-  if [ ! -f "$PROGRESS_FILE" ] || ! jq empty "$PROGRESS_FILE" 2>/dev/null; then
-    echo '{}' > "$PROGRESS_FILE"
-  fi
+  ensure_tribunal_progress_file "$PROGRESS_FILE" "$ROOT_DIR"
 
   # List zh-tw articles (not en-, not demo), sorted newest-first by
   # frontmatter translatedDate (the date we first shipped this post).
@@ -943,9 +943,13 @@ while true; do
   autoscale_check
   EFFECTIVE_WORKERS=$(autoscale_read_limit)
 
-  # ── Git pull in main repo (workers do their own in their worktrees) ──────
-  git pull --rebase --autostash origin main >> "$LOG_FILE" 2>&1 \
-    || { git rebase --abort 2>/dev/null; tlog "WARN: git pull failed, continuing"; }
+  # ── Fetch-only drift check in main repo (workers sync their disposable worktrees) ──
+  git_drift="$(tribunal_fetch_and_report_origin_main "$ROOT_DIR" "$LOG_FILE" "$RUNTIME_GIT_STATE_FILE")"
+  IFS='|' read -r git_fetched git_state git_ahead git_behind git_dirty <<< "$git_drift"
+  if [ "$git_fetched" != "true" ]; then
+    tlog "WARN: origin/main fetch failed; runtime continues with current snapshot."
+  fi
+  tlog "Git drift: state=$git_state ahead=$git_ahead behind=$git_behind tracked_dirty=$git_dirty"
 
   # ── Find unscored articles ─────────────────────────────────────────────────
   mapfile -t ARTICLES < <(get_unscored_articles)

--- a/scripts/tribunal-quota-loop.sh
+++ b/scripts/tribunal-quota-loop.sh
@@ -690,12 +690,13 @@ worker_worktree() {
   fi
 }
 
-# Ensure worker worktrees exist AND are synced with origin/main. Called once
-# at supervisor startup. Without the sync step, worker worktrees keep
-# whichever origin/main snapshot they had at `git worktree add` time, so
-# tribunal fixes merged to main never reach running workers.
+# Ensure worker worktrees exist AND are synced with the supervisor's active
+# code ref. Called once at supervisor startup. Without the sync step, worker
+# worktrees keep whichever snapshot they had at `git worktree add` time, so
+# tribunal fixes in the deployed runtime never reach running workers.
 ensure_worktrees() {
   (( WORKERS == 1 )) && return 0
+  export TRIBUNAL_WORKER_SYNC_REF="${TRIBUNAL_WORKER_SYNC_REF:-HEAD}"
   local id wt
   for id in "${WORKER_IDS[@]}"; do
     wt=$(worker_worktree "$id")
@@ -707,8 +708,8 @@ ensure_worktrees() {
       }
     fi
   done
-  # Fast-forward every worker worktree to whatever main currently is.
-  tlog "Syncing worker worktrees to origin/main…"
+  # Fast-forward every worker worktree to the supervisor's current sync ref.
+  tlog "Syncing worker worktrees to ${TRIBUNAL_WORKER_SYNC_REF}…"
   bash "$SCRIPT_DIR/tribunal-worker-bootstrap.sh" sync >> "$LOG_FILE" 2>&1 || \
     tlog "WARN: worktree sync reported errors (see log)"
 }
@@ -734,11 +735,11 @@ spawn_worker() {
   wt=$(worker_worktree "$id")
   local slug="${article%.mdx}"
 
-  # Sync worker worktree to origin/main before each dispatch. Per-dispatch
-  # cost is one git fetch (~100ms with cached refs) plus a no-op hard reset
-  # if nothing changed; supervisor doesn't need a restart for new tribunal
-  # fixes to reach the next article's worker.
+  # Sync worker worktree to the supervisor's active sync ref before each
+  # dispatch. Per-dispatch cost is one no-op reset when nothing changed; when
+  # the sync ref is origin/main the bootstrap helper also fetches the remote.
   if (( WORKERS > 1 )); then
+    export TRIBUNAL_WORKER_SYNC_REF="${TRIBUNAL_WORKER_SYNC_REF:-HEAD}"
     bash "$SCRIPT_DIR/tribunal-worker-bootstrap.sh" sync "$id" >> "$LOG_FILE" 2>&1 || \
       tlog "  WARN: pre-dispatch sync failed for worker-$id (continuing with current snapshot)"
   fi

--- a/scripts/tribunal-worker-bootstrap.sh
+++ b/scripts/tribunal-worker-bootstrap.sh
@@ -10,7 +10,7 @@
 # Usage:
 #   scripts/tribunal-worker-bootstrap.sh create <id>    # create worktree, pnpm install
 #   scripts/tribunal-worker-bootstrap.sh status         # list all worker worktrees
-#   scripts/tribunal-worker-bootstrap.sh sync [id]      # fast-forward worker(s) to origin/main
+#   scripts/tribunal-worker-bootstrap.sh sync [id]      # fast-forward worker(s) to sync ref
 #   scripts/tribunal-worker-bootstrap.sh remove <id>    # git worktree remove
 #   scripts/tribunal-worker-bootstrap.sh remove-all     # remove every gu-log-worker-*
 #
@@ -18,7 +18,7 @@
 #   - Disk cost is ~500MB per worker (pnpm node_modules per worktree).
 #   - Safe to run create on an id that already exists: prints a warning and
 #     exits 0 so this is idempotent for supervisor startup.
-#   - `sync` MUST be run after every main-branch change to tribunal code or
+#   - `sync` MUST be run after every tribunal-code change on the active sync ref or
 #     workers will continue running the stale snapshot of their worktree.
 #     Supervisor invokes `sync` at startup; also run it manually when you
 #     see new code on main that should reach running workers without a
@@ -29,6 +29,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 MAIN_REPO="$(cd "$SCRIPT_DIR/.." && pwd)"
 WORKER_PARENT="$(dirname "$MAIN_REPO")"   # usually ~/clawd/projects
+SYNC_REF="${TRIBUNAL_WORKER_SYNC_REF:-origin/main}"
 
 usage() {
   grep '^# ' "$0" | sed 's/^# \{0,1\}//'
@@ -54,10 +55,15 @@ cmd_create() {
   fi
 
   cd "$MAIN_REPO"
-  echo "Creating worktree $path at origin/main…"
-  # Fetch first so origin/main is current; bootstrap from a clean main.
-  git fetch origin main
-  git worktree add "$path" origin/main
+  echo "Creating worktree $path at $SYNC_REF…"
+  # Only fetch when the sync ref points at a remote-tracking branch. For
+  # runtime branches we intentionally allow TRIBUNAL_WORKER_SYNC_REF=HEAD so
+  # workers follow the supervisor's currently deployed code, not stale
+  # origin/main.
+  if [[ "$SYNC_REF" == origin/* ]]; then
+    git fetch origin "${SYNC_REF#origin/}"
+  fi
+  git worktree add "$path" "$SYNC_REF"
 
   echo "Running pnpm install in $path (this will take a minute)…"
   cd "$path"
@@ -92,9 +98,11 @@ cmd_status() {
 cmd_sync() {
   local only_id="${1:-}"
   cd "$MAIN_REPO"
-  git fetch origin main >/dev/null 2>&1 || { echo "WARN: git fetch origin main failed" >&2; }
+  if [[ "$SYNC_REF" == origin/* ]]; then
+    git fetch origin "${SYNC_REF#origin/}" >/dev/null 2>&1 || { echo "WARN: git fetch $SYNC_REF failed" >&2; }
+  fi
   local target_sha
-  target_sha=$(git rev-parse origin/main)
+  target_sha=$(git rev-parse "$SYNC_REF")
 
   local dir id before_sha lockfile_changed pkg_changed
   local any=0
@@ -108,7 +116,7 @@ cmd_sync() {
 
     before_sha=$(git -C "$dir" rev-parse HEAD 2>/dev/null || echo "unknown")
     if [ "$before_sha" = "$target_sha" ]; then
-      echo "worker-$id: already at ${target_sha:0:8} (origin/main) — nothing to do"
+      echo "worker-$id: already at ${target_sha:0:8} ($SYNC_REF) — nothing to do"
       continue
     fi
 
@@ -125,7 +133,7 @@ cmd_sync() {
 
     echo "worker-$id: ${before_sha:0:8} -> ${target_sha:0:8}"
     # Reset is safe: worker worktrees are detached-HEAD, ephemeral snapshots
-    # rebuilt from origin/main. Nothing worth preserving lives in them.
+    # rebuilt from the active sync ref. Nothing worth preserving lives in them.
     if ! git -C "$dir" reset --hard "$target_sha" >/dev/null 2>&1; then
       echo "  ERROR: reset failed for worker-$id" >&2
       continue

--- a/scripts/tribunal.sh
+++ b/scripts/tribunal.sh
@@ -147,19 +147,14 @@ if ! flock -n 200; then
 fi
 
 # ─── Progress Tracking ────────────────────────────────────────────────────────
-# Phase 2 (tribunal-safe-parallelism): supervisor runs in the main repo and
-# exports PROGRESS_FILE pointing at the shared progress file there; workers
-# run in isolated worktrees. Without the fallback, this line unconditionally
-# clobbers the export with the WORKTREE's local path, so per-worker
-# init_article_progress / mark_article_* writes land in the wrong file. The
-# main repo's progress.json only refreshes via `git pull`, and whenever that
-# pull warns-and-continues (dirty tree, rebase conflict) the supervisor's
-# get_unscored_articles() keeps re-dispatching articles a worker already
-# marked EXHAUSTED — producing the tight re-dispatch loop that filled the
-# 2 GB cgroup and OOM-killed tribunal-loop.service on 2026-04-24 01:03:59.
-# Honor the exported env so shared flock + shared file + shared commit path
-# all line up.
-PROGRESS_FILE="${PROGRESS_FILE:-$ROOT_DIR/scores/tribunal-progress.json}"
+# Supervisor runs in the main repo and exports PROGRESS_FILE pointing at the
+# ignored runtime ledger under .score-loop/state; workers run in isolated
+# worktrees. Without honoring the export, this line would clobber the shared
+# ledger path with the WORKTREE's local default, so per-worker progress writes
+# land in the wrong place and the supervisor can re-dispatch already-terminal
+# articles. Keep the exported env authoritative so shared flock + shared file
+# coordinates all line up.
+PROGRESS_FILE="${PROGRESS_FILE:-$(tribunal_progress_file_default "$ROOT_DIR")}"
 if [ "$SCORE_ONLY" -eq 1 ]; then
   if [ -n "${TRIBUNAL_SCORE_ONLY_PROGRESS_FILE:-}" ]; then
     PROGRESS_FILE="$TRIBUNAL_SCORE_ONLY_PROGRESS_FILE"
@@ -170,10 +165,7 @@ if [ "$SCORE_ONLY" -eq 1 ]; then
 fi
 
 ensure_progress_file() {
-  mkdir -p "$(dirname "$PROGRESS_FILE")"
-  if [ ! -f "$PROGRESS_FILE" ] || ! jq empty "$PROGRESS_FILE" 2>/dev/null; then
-    printf '{}\n' > "$PROGRESS_FILE"
-  fi
+  ensure_tribunal_progress_file "$PROGRESS_FILE" "$ROOT_DIR"
 }
 
 get_stage_status() {
@@ -890,9 +882,10 @@ PROMPT
 # Phase 2 (tribunal-safe-parallelism):
 #   - Serialized by push_lock so 2 workers don't race while staging/committing.
 #   - Honors TRIBUNAL_MAIN_REPO env var: workers running in their own isolated
-#     worktrees can update the coordinator repo's shared progress file (flock
-#     coordinates the read-modify-write; this function coordinates the local
-#     git commit). Push is opt-in and direct main pushes are refused.
+#     worktrees can update the coordinator repo's shared runtime ledger (flock
+#     coordinates the read-modify-write; this function coordinates target-post
+#     materialization + local git commit). Push is opt-in and direct main pushes
+#     are refused.
 commit_progress() {
   local msg="$1"
   if [ "${TRIBUNAL_NO_COMMIT:-0}" = "1" ]; then
@@ -906,8 +899,8 @@ commit_progress() {
 
     # Workers rewrite posts and write score frontmatter inside their isolated
     # worktree ($ROOT_DIR). Publish those target post artifacts into the main
-    # repo before staging, otherwise PASS commits only contain progress JSON and
-    # production content never changes.
+    # repo before staging, otherwise PASS commits only contain content-free
+    # metadata and production content never changes.
     if [ -n "${POST_FILE:-}" ]; then
       bash "$SCRIPT_DIR/tribunal-publish-worker-changes.sh" "$ROOT_DIR" "$repo_dir" "$POST_FILE" >> "$LOG_FILE" 2>&1 || {
         tlog "ERROR: failed to publish worker post artifacts for $POST_FILE"


### PR DESCRIPTION
## Summary
- move Tribunal runtime progress default to ignored `.score-loop/state/tribunal-progress.json`
- replace daemon/batch runner rebase pulls with fetch-only drift observability
- add runtime git drift state output
- add clean-worktree publisher foundation that materializes PASS artifacts from runtime ledger onto origin/main-based batch branches

## Verification
- bash scripts/tests/test-tribunal-runtime-git-hygiene.sh
- bash scripts/tests/test-tribunal-progress-ledger-migration.sh
- bash scripts/tests/test-tribunal-publisher.sh
- bash scripts/tests/test-tribunal-runner-error-guard.sh
- bash scripts/tests/test-tribunal-pass-artifact-guards.sh

## Notes
- this is implementation groundwork for the tribunal runtime/publisher decoupling spec
- triage/event-driven conflict resolution is not implemented yet
