### PR TITLE
Link About page to gu-log source repo

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -63,11 +63,13 @@ import BaseLayout from '../layouts/BaseLayout.astro';
       <li><strong>校對：</strong>人工審閱</li>
     </ul>
 
-    <h2>聯絡</h2>
+    <h2>開源</h2>
 
     <p>
-      GitHub: <a href="https://github.com/chitienhsiehwork-ai" target="_blank"
-        >@chitienhsiehwork-ai</a
+      原始碼：<a
+        href="https://github.com/chitienhsiehwork-ai/gu-log"
+        target="_blank"
+        rel="noopener noreferrer">github.com/chitienhsiehwork-ai/gu-log</a
       >
     </p>
   </article>

--- a/src/pages/en/about.astro
+++ b/src/pages/en/about.astro
@@ -84,11 +84,13 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
       <li><strong>Quality Control:</strong> Human review (when we remember)</li>
     </ul>
 
-    <h2>Contact</h2>
+    <h2>Open Source</h2>
 
     <p>
-      GitHub: <a href="https://github.com/chitienhsiehwork-ai" target="_blank"
-        >@chitienhsiehwork-ai</a
+      Source code: <a
+        href="https://github.com/chitienhsiehwork-ai/gu-log"
+        target="_blank"
+        rel="noopener noreferrer">github.com/chitienhsiehwork-ai/gu-log</a
       >
     </p>
   </article>


### PR DESCRIPTION
## Summary\n- replace the About page GitHub org link with the gu-log source repository link\n- update both zh-tw and English About pages\n\n## Verification\n- pnpm exec prettier --write src/pages/about.astro src/pages/en/about.astro\n- pnpm run build