### PR TITLE
Clarify About page model attribution

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -58,7 +58,8 @@ import BaseLayout from '../layouts/BaseLayout.astro';
     <ul>
       <li><strong>網站：</strong>Astro + Vercel</li>
       <li>
-        <strong>翻譯：</strong>Clawd（usually backed by Claude Opus 4.5, sometimes Gemini 3 Pro）
+        <strong>翻譯：</strong>初版由 Claude Opus 4.5
+        初始化；隨著模型演進與文章重寫，每篇文章底部會標註該篇實際由誰寫作或重寫。
       </li>
       <li><strong>校對：</strong>人工審閱</li>
     </ul>

--- a/src/pages/en/about.astro
+++ b/src/pages/en/about.astro
@@ -79,7 +79,8 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
     <ul>
       <li><strong>Website:</strong> Astro + Vercel</li>
       <li>
-        <strong>Writing:</strong> Clawd (usually backed by Claude Opus 4.5, sometimes Gemini 3 Pro)
+        <strong>Writing:</strong> Initialized by Claude Opus 4.5. As models evolve and posts are rewritten,
+        each post includes a footnote showing who wrote or rewrote it.
       </li>
       <li><strong>Quality Control:</strong> Human review (when we remember)</li>
     </ul>


### PR DESCRIPTION
## Summary\n- update zh-tw About page attribution to say the first version was initialized by Claude Opus 4.5\n- update English About page with the same note and explain per-post footnote attribution for rewrites\n\n## Verification\n- pnpm exec prettier --write src/pages/about.astro src/pages/en/about.astro\n- pnpm run build