### PR TITLE
tools(sp-pipeline): lower Codex writing reasoning effort

### DIFF
--- a/tools/sp-pipeline/internal/llm/codex.go
+++ b/tools/sp-pipeline/internal/llm/codex.go
@@ -19,6 +19,11 @@ type CodexProvider struct {
 	ReasoningEffort string
 }
 
+// NewCodexGPT55Low returns a CodexProvider wired to GPT-5.5 low.
+func NewCodexGPT55Low() *CodexProvider {
+	return &CodexProvider{ModelName: "gpt-5.5", ReasoningEffort: "low"}
+}
+
 // NewCodexGPT55Medium returns a CodexProvider wired to GPT-5.5 medium.
 func NewCodexGPT55Medium() *CodexProvider {
 	return &CodexProvider{ModelName: "gpt-5.5", ReasoningEffort: "medium"}

--- a/tools/sp-pipeline/internal/llm/codex_test.go
+++ b/tools/sp-pipeline/internal/llm/codex_test.go
@@ -85,10 +85,14 @@ printf 'codex-ok\n' > "$out"
 }
 
 func TestDefaultChainsAreCodexGPT55Only(t *testing.T) {
-	for name, chain := range map[string][]Provider{
-		"writing": DefaultWritingChain(),
-		"probe":   DefaultProbeChain(),
+	for name, tc := range map[string]struct {
+		chain  []Provider
+		effort string
+	}{
+		"writing": {chain: DefaultWritingChain(), effort: "low"},
+		"probe":   {chain: DefaultProbeChain(), effort: "medium"},
 	} {
+		chain := tc.chain
 		if len(chain) != 1 {
 			t.Fatalf("%s chain length = %d, want 1", name, len(chain))
 		}
@@ -97,6 +101,13 @@ func TestDefaultChainsAreCodexGPT55Only(t *testing.T) {
 		}
 		if chain[0].Model() != ModelGPT55 {
 			t.Fatalf("%s model = %q, want %q", name, chain[0].Model(), ModelGPT55)
+		}
+		codex, ok := chain[0].(*CodexProvider)
+		if !ok {
+			t.Fatalf("%s provider type = %T, want *CodexProvider", name, chain[0])
+		}
+		if got := codex.reasoningEffort(); got != tc.effort {
+			t.Fatalf("%s effort = %q, want %q", name, got, tc.effort)
 		}
 	}
 }

--- a/tools/sp-pipeline/internal/llm/defaults.go
+++ b/tools/sp-pipeline/internal/llm/defaults.go
@@ -1,17 +1,17 @@
 package llm
 
 // DefaultWritingChain returns the provider ordering used for article writing
-// and review/refine steps. Codex GPT-5.5 medium is the only default provider:
+// and review/refine steps. Codex GPT-5.5 low is the only default provider:
 // Anthropic and Gemini subscriptions are not assumed to exist on the Clawd VM.
 func DefaultWritingChain() []Provider {
 	return []Provider{
-		NewCodexGPT55Medium(),
+		NewCodexGPT55Low(),
 	}
 }
 
 // DefaultProbeChain returns the providers the doctor subcommand should ping.
-// Keep this aligned with the production default chain so doctor does not fail
-// or warn on intentionally unavailable Claude/Gemini subscriptions.
+// Keep this on the same model as production while using medium effort for a
+// slightly more conservative canary; doctor should not ping Claude/Gemini.
 func DefaultProbeChain() []Provider {
 	return []Provider{
 		NewCodexGPT55Medium(),


### PR DESCRIPTION
## Summary
- Keep sp-pipeline on Codex GPT-5.5
- Lower the writing/review/refine default chain to model_reasoning_effort=low
- Keep doctor/probe on GPT-5.5 medium for a conservative canary

## Test Plan
- cd tools/sp-pipeline && go test ./internal/llm ./internal/dedup ./cmd/sp-pipeline
- git diff --check on touched files