### PR TITLE
wire tribunal publisher autopilot

### DIFF
--- a/openspec/changes/wire-tribunal-publisher-autopilot/design.md
+++ b/openspec/changes/wire-tribunal-publisher-autopilot/design.md
@@ -1,0 +1,87 @@
+## Context
+
+The missing piece is not content validation or merge safety. Those already exist.
+
+The real gap is orchestration:
+
+- runtime ledger knows which articles are publishable,
+- publisher knows how to materialize a clean batch PR,
+- GitHub guard knows how to merge safe PRs,
+- but no runtime actor loops over those states and pushes them forward.
+
+So the design goal is simple: add one boring state pusher that keeps nudging batches from ready_for_batch to published, without inventing a second workflow engine.
+
+## Design
+
+### 1. New runtime helper: publisher autopilot
+
+Add scripts/tribunal-publisher-autopilot.sh as a thin coordinator around existing primitives.
+
+It has four responsibilities:
+
+1. Reconcile merged batches
+   - scan known publisher batches from .score-loop/state/tribunal-publisher.json
+   - if a batch branch already has a merged PR into main, mark every batch entry published
+   - record merge metadata (prNumber, mergeCommit, mergedAt, updatedAt)
+
+2. Recover missing PRs
+   - if a batch is branch_pushed but no PR exists yet, create the PR from the pushed branch
+   - label it tribunal-publisher
+
+3. Advance open publisher PRs
+   - if a publisher PR is still draft, mark it ready for review
+   - then invoke gu-log-auto-merge-guard.sh --pr <n>
+   - guard remains the sole authority for CI/path/ruleset safety
+
+4. Materialize new publishable PASS batches
+   - call tribunal-publisher.sh --apply --push-pr
+   - let publisher validation/build/conflict logic decide what is batchable
+
+### 2. Loop wiring
+
+The long-running supervisor should call autopilot once per loop iteration on a best-effort basis.
+
+That placement matters:
+
+- if scoring is active, publishing progresses alongside scoring
+- if scoring is parked in weekly_debt or five_hour_debt, publishing still progresses
+- if there are no unscored articles left, publish reconciliation still happens during idle loops
+
+Autopilot failures must not kill scoring workers. They should log a warning and let the next iteration retry.
+
+### 3. State model
+
+Existing entry states:
+
+- ready_for_batch
+- batch_selected
+- branch_pushed
+- pr_open
+- published
+
+This change makes published real instead of dead vocabulary.
+
+Transition rules:
+
+- ready_for_batch -> batch_selected during apply
+- batch_selected -> branch_pushed after push
+- branch_pushed -> pr_open after PR creation or PR recovery
+- pr_open -> published after merged PR reconciliation
+
+### 4. Why not merge directly from the publisher script?
+
+Because the publisher script owns batch materialization, not long-running GitHub polling/reconciliation.
+
+Keeping merge/reconcile logic in autopilot gives two concrete benefits:
+
+- publisher stays a bounded, testable batch materializer
+- runtime supervisor gets one retryable hook that can keep nudging old batches forward
+
+That boundary is cleaner than stuffing CI wait loops into tribunal-publisher.sh.
+
+## Failure Handling
+
+- If publisher apply fails validation/build/conflict checks, autopilot leaves scoring alone and retries next loop.
+- If PR creation fails after branch push, the next autopilot run must recover it.
+- If auto-merge guard denies a PR because checks are still pending, autopilot logs and retries next loop.
+- If a PR was merged outside autopilot, reconciliation still marks the batch published on the next run.

--- a/openspec/changes/wire-tribunal-publisher-autopilot/proposal.md
+++ b/openspec/changes/wire-tribunal-publisher-autopilot/proposal.md
@@ -1,0 +1,42 @@
+## Why
+
+Tribunal runtime already has the two critical building blocks:
+
+- tribunal-publisher.sh can materialize PASS artifacts from the ignored runtime ledger into a clean origin/main batch PR.
+- gu-log-auto-merge-guard.sh can conservatively auto-merge low-risk PRs after required checks are green.
+
+What is still missing is the wiring between them. Today, the publisher path exists, but an operator still has to notice stranded PASS artifacts, run publisher apply, watch CI, and merge manually. That means the failure mode changed from "no publish machinery" to "publish machinery exists but nobody pulled the lever."
+
+This change closes that last gap.
+
+## What Changes
+
+- Add a tribunal-publisher-autopilot capability.
+- Define a runtime autopilot that:
+  - periodically runs publisher apply from the ignored runtime ledger,
+  - opens or recovers publisher PRs,
+  - transitions draft publisher PRs to ready-for-review,
+  - invokes the existing auto-merge guard for safe content-only publisher PRs,
+  - reconciles merged publisher batches back into terminal published state.
+- Wire the autopilot into the long-running quota supervisor so publishing keeps progressing even while scoring is parked by quota debt.
+
+## Impact
+
+### Affected specs
+
+- New capability: tribunal-publisher-autopilot
+- Complements tribunal-safe-parallelism, because worker artifacts now need an automated lane from runtime ledger to main.
+- Complements github-ai-automerge-guard, because autopilot relies on the existing conservative merge guard instead of bypassing branch protection.
+
+### Affected code
+
+- scripts/tribunal-publisher-autopilot.sh new
+- scripts/tribunal-quota-loop.sh
+- scripts/tests/test-tribunal-publisher-autopilot.sh new
+- scripts/tests/test-tribunal-publisher.sh may need small fixture updates if state transitions change
+
+## Non-Goals
+
+- This change does not bypass CI or branch protection.
+- This change does not auto-resolve editorial conflict events.
+- This change does not publish FAILED, EXHAUSTED, or RUNNER_ERROR articles.

--- a/openspec/changes/wire-tribunal-publisher-autopilot/specs/tribunal-publisher-autopilot/spec.md
+++ b/openspec/changes/wire-tribunal-publisher-autopilot/specs/tribunal-publisher-autopilot/spec.md
@@ -1,0 +1,66 @@
+## ADDED Requirements
+
+### Requirement: Tribunal runtime SHALL advance publishable PASS artifacts toward main
+
+The long-running Tribunal runtime SHALL periodically attempt to materialize publishable PASS artifacts from the ignored runtime ledger into clean main-targeted publisher PRs.
+
+#### Scenario: Runtime finds publishable PASS artifacts
+
+- WHEN the ignored runtime ledger contains articles with current Tribunal version status PASS
+- AND those articles are not blocked by conflict or validation events
+- THEN runtime SHALL attempt publisher apply from the runtime ledger
+- AND the resulting batch SHALL be based on origin/main
+- AND the batch SHALL contain only publishable article artifacts
+
+#### Scenario: Runtime is parked by quota debt
+
+- WHEN runtime enters weekly_debt, five_hour_debt, or another quota-stop mode
+- THEN runtime SHALL still continue publisher autopilot attempts on later loop iterations
+- AND publishable PASS artifacts SHALL NOT require scoring to resume before they can advance to main
+
+### Requirement: Publisher autopilot SHALL recover and advance publisher PR state
+
+Publisher autopilot SHALL reconcile batch branches, PRs, and merged state so publisher entries do not stay stranded at intermediate states.
+
+#### Scenario: Batch branch was pushed but PR creation previously failed
+
+- WHEN a publisher batch entry is in branch_pushed
+- AND no open or merged PR exists for the batch branch
+- THEN autopilot SHALL create the missing PR
+- AND it SHALL label the PR tribunal-publisher
+- AND it SHALL transition the affected entries to pr_open
+
+#### Scenario: Publisher PR is still draft
+
+- WHEN an open publisher PR exists for a batch
+- AND the PR is marked draft
+- THEN autopilot SHALL mark the PR ready for review before attempting merge automation
+
+#### Scenario: Publisher PR was merged
+
+- WHEN a publisher batch branch has a merged PR into main
+- THEN autopilot SHALL transition every entry in that batch to published
+- AND it SHALL record merge metadata sufficient for audit and later reconciliation
+
+### Requirement: Publisher autopilot SHALL use the existing conservative merge guard
+
+Publisher autopilot SHALL NOT bypass branch protection or merge publisher PRs by ad hoc logic. It SHALL delegate merge eligibility to the existing gu-log auto-merge guard.
+
+#### Scenario: Publisher PR checks are green and paths are allowlisted
+
+- WHEN an open ready-for-review publisher PR targets main
+- AND required checks are green
+- AND the PR diff satisfies the existing auto-merge path guard
+- THEN autopilot SHALL invoke the gu-log auto-merge guard for that PR
+
+#### Scenario: Publisher PR checks are still pending
+
+- WHEN an open publisher PR has not finished required checks
+- THEN autopilot SHALL NOT treat that as fatal
+- AND it SHALL leave the PR open for a later retry
+
+#### Scenario: Publisher PR touches disallowed paths
+
+- WHEN the auto-merge guard denies the PR because changed paths are outside the allowlist
+- THEN autopilot SHALL NOT bypass that decision
+- AND it SHALL leave the PR for explicit operator review

--- a/openspec/changes/wire-tribunal-publisher-autopilot/tasks.md
+++ b/openspec/changes/wire-tribunal-publisher-autopilot/tasks.md
@@ -1,0 +1,20 @@
+## 1. Spec
+
+- [x] 1.1 Add tribunal-publisher-autopilot spec requirements
+- [x] 1.2 Define runtime apply / PR recovery / auto-merge / published reconciliation semantics
+
+## 2. Implementation
+
+- [x] 2.1 Add scripts/tribunal-publisher-autopilot.sh
+- [x] 2.2 Reconcile merged publisher PRs back into published state
+- [x] 2.3 Recover pushed publisher branches into PRs when PR creation failed earlier
+- [x] 2.4 Convert draft publisher PRs to ready-for-review before merge attempts
+- [x] 2.5 Invoke gu-log-auto-merge-guard.sh for eligible publisher PRs
+- [x] 2.6 Wire autopilot into tribunal-quota-loop.sh
+
+## 3. Verification
+
+- [x] 3.1 bash scripts/tests/test-tribunal-publisher.sh
+- [x] 3.2 bash scripts/tests/test-tribunal-publisher-autopilot.sh
+- [x] 3.3 bash scripts/tests/test-auto-merge-guard.sh
+- [x] 3.4 openspec validate wire-tribunal-publisher-autopilot --strict

--- a/scripts/tests/test-tribunal-publisher-autopilot.sh
+++ b/scripts/tests/test-tribunal-publisher-autopilot.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+fail() { echo "x $*" >&2; exit 1; }
+pass() { echo "ok $*"; }
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+runtime="$TMP/runtime"
+mkdir -p "$runtime/scripts" "$runtime/.score-loop/state" "$runtime/.score-loop/locks"
+cp "$ROOT_DIR/scripts/tribunal-publisher-autopilot.sh" "$runtime/scripts/tribunal-publisher-autopilot.sh"
+cp "$ROOT_DIR/scripts/tribunal-helpers.sh" "$runtime/scripts/tribunal-helpers.sh"
+chmod +x "$runtime/scripts/tribunal-publisher-autopilot.sh"
+
+cat > "$runtime/.score-loop/state/tribunal-publisher.json" <<'JSON'
+{
+  "schemaVersion": 1,
+  "entries": {
+    "sp-1-test.mdx": { "publishState": "branch_pushed", "batchId": "batch-1" },
+    "sp-2-test.mdx": { "publishState": "pr_open", "batchId": "batch-2" },
+    "sp-3-test.mdx": { "publishState": "pr_open", "batchId": "batch-3" }
+  },
+  "batches": {
+    "batch-1": { "batchId": "batch-1", "branch": "publisher/batch-1", "entries": ["sp-1-test.mdx"], "state": "branch_pushed" },
+    "batch-2": { "batchId": "batch-2", "branch": "publisher/batch-2", "entries": ["sp-2-test.mdx"], "state": "pr_open" },
+    "batch-3": { "batchId": "batch-3", "branch": "publisher/batch-3", "entries": ["sp-3-test.mdx"], "state": "pr_open" }
+  }
+}
+JSON
+
+cat > "$runtime/.score-loop/state/tribunal-triage-events.json" <<'JSON'
+{ "schemaVersion": 1, "events": {} }
+JSON
+
+cat > "$TMP/open.json" <<'JSON'
+[
+  { "number": 42, "url": "https://example.com/pr/42", "isDraft": true, "headRefName": "publisher/batch-2", "state": "OPEN" },
+  { "number": 43, "url": "https://example.com/pr/43", "isDraft": false, "headRefName": "publisher/batch-3", "state": "OPEN" }
+]
+JSON
+
+cat > "$TMP/merged-none.json" <<'JSON'
+[]
+JSON
+
+cat > "$TMP/merged-batch3.json" <<'JSON'
+[
+  {
+    "number": 43,
+    "url": "https://example.com/pr/43",
+    "headRefName": "publisher/batch-3",
+    "state": "MERGED",
+    "mergedAt": "2026-05-23T09:00:00Z",
+    "mergeCommit": { "oid": "abc123def456" }
+  }
+]
+JSON
+
+ready_log="$TMP/ready.log"
+guard_log="$TMP/guard.log"
+create_log="$TMP/create.log"
+
+cat > "$TMP/ready-hook.sh" <<'HOOK'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "$1" >> "$READY_LOG"
+HOOK
+chmod +x "$TMP/ready-hook.sh"
+
+cat > "$TMP/guard-hook.sh" <<'HOOK'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "$1" >> "$GUARD_LOG"
+exit 0
+HOOK
+chmod +x "$TMP/guard-hook.sh"
+
+cat > "$TMP/create-hook.sh" <<'HOOK'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "$1 $2" >> "$CREATE_LOG"
+echo "https://example.com/pr/41"
+HOOK
+chmod +x "$TMP/create-hook.sh"
+
+(cd "$runtime" && \
+  READY_LOG="$ready_log" \
+  GUARD_LOG="$guard_log" \
+  CREATE_LOG="$create_log" \
+  TRIBUNAL_PUBLISHER_AUTOPILOT_OPEN_PRS_JSON_FILE="$TMP/open.json" \
+  TRIBUNAL_PUBLISHER_AUTOPILOT_MERGED_PRS_JSON_FILE="$TMP/merged-none.json" \
+  TRIBUNAL_PUBLISHER_AUTOPILOT_READY_HOOK="$TMP/ready-hook.sh" \
+  TRIBUNAL_PUBLISHER_AUTOPILOT_MERGE_GUARD_HOOK="$TMP/guard-hook.sh" \
+  TRIBUNAL_PUBLISHER_AUTOPILOT_CREATE_PR_HOOK="$TMP/create-hook.sh" \
+  bash scripts/tribunal-publisher-autopilot.sh --skip-apply)
+
+grep -q '^42$' "$ready_log" || fail "draft publisher PR should be marked ready"
+grep -q '^42$' "$guard_log" || fail "merge guard should run for ready'd PR"
+grep -q '^43$' "$guard_log" || fail "merge guard should run for already-ready PR"
+grep -q '^batch-1 publisher/batch-1$' "$create_log" || fail "branch_pushed batch should recover a PR"
+[ "$(jq -r '.entries["sp-1-test.mdx"].publishState' "$runtime/.score-loop/state/tribunal-publisher.json")" = "pr_open" ] || fail "recovered PR should move entry to pr_open"
+[ "$(jq -r '.entries["sp-1-test.mdx"].prNumber' "$runtime/.score-loop/state/tribunal-publisher.json")" = "41" ] || fail "recovered PR should store prNumber"
+pass "autopilot recovers missing PRs and advances open PRs"
+
+cat > "$TMP/open-empty.json" <<'JSON'
+[]
+JSON
+
+(cd "$runtime" && \
+  READY_LOG="$ready_log" \
+  GUARD_LOG="$guard_log" \
+  CREATE_LOG="$create_log" \
+  TRIBUNAL_PUBLISHER_AUTOPILOT_OPEN_PRS_JSON_FILE="$TMP/open-empty.json" \
+  TRIBUNAL_PUBLISHER_AUTOPILOT_MERGED_PRS_JSON_FILE="$TMP/merged-batch3.json" \
+  TRIBUNAL_PUBLISHER_AUTOPILOT_READY_HOOK="$TMP/ready-hook.sh" \
+  TRIBUNAL_PUBLISHER_AUTOPILOT_MERGE_GUARD_HOOK="$TMP/guard-hook.sh" \
+  TRIBUNAL_PUBLISHER_AUTOPILOT_CREATE_PR_HOOK="$TMP/create-hook.sh" \
+  bash scripts/tribunal-publisher-autopilot.sh --skip-apply)
+
+[ "$(jq -r '.entries["sp-3-test.mdx"].publishState' "$runtime/.score-loop/state/tribunal-publisher.json")" = "published" ] || fail "merged publisher PR should reconcile to published"
+[ "$(jq -r '.entries["sp-3-test.mdx"].mergeCommit' "$runtime/.score-loop/state/tribunal-publisher.json")" = "abc123def456" ] || fail "published entry should record merge commit"
+[ "$(jq -r '.batches["batch-3"].state' "$runtime/.score-loop/state/tribunal-publisher.json")" = "published" ] || fail "batch state should reconcile to published"
+pass "autopilot reconciles merged publisher PRs back into published state"

--- a/scripts/tribunal-publisher-autopilot.sh
+++ b/scripts/tribunal-publisher-autopilot.sh
@@ -1,0 +1,260 @@
+#!/usr/bin/env bash
+# tribunal-publisher-autopilot.sh — advance publishable Tribunal PASS artifacts
+# from runtime ledger into main/prod by driving publisher PR creation,
+# ready-for-review transitions, guarded auto-merge, and merged-state
+# reconciliation.
+
+set -euo pipefail
+export TZ=Asia/Taipei
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$ROOT_DIR"
+
+source "$SCRIPT_DIR/tribunal-helpers.sh"
+
+PUBLISHER_STATE_FILE="${PUBLISHER_STATE_FILE:-$(tribunal_publisher_state_file "$ROOT_DIR")}"
+TRIAGE_EVENTS_FILE="${TRIAGE_EVENTS_FILE:-$(tribunal_triage_events_file "$ROOT_DIR")}"
+REPO="${GU_LOG_GITHUB_REPO:-chitienhsiehwork-ai/gu-log}"
+GH_BIN="${GH_BIN:-gh}"
+MAX_BATCH="${MAX_BATCH:-10}"
+SKIP_APPLY=0
+DRY_RUN=0
+LOCK_FILE="${TRIBUNAL_PUBLISHER_AUTOPILOT_LOCK_FILE:-$ROOT_DIR/.score-loop/locks/publisher-autopilot.lock}"
+AUDIT_LOG="${TRIBUNAL_PUBLISHER_AUTOPILOT_AUDIT_LOG:-$ROOT_DIR/.score-loop/state/tribunal-publisher-autopilot.jsonl}"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  bash scripts/tribunal-publisher-autopilot.sh [--max N] [--skip-apply] [--dry-run]
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --max) MAX_BATCH="$2"; shift 2 ;;
+    --skip-apply) SKIP_APPLY=1; shift ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown arg: $1" >&2; usage; exit 2 ;;
+  esac
+done
+
+tlog() {
+  printf '[publisher-autopilot] %s\n' "$*"
+}
+
+publisher_gh() {
+  local token_file="${GU_LOG_GH_TOKEN_FILE:-$HOME/.config/github-tokens/gu-log-operator.token}"
+  if [ -n "${GU_LOG_GH_TOKEN:-}" ]; then
+    GH_TOKEN="$GU_LOG_GH_TOKEN" "$GH_BIN" "$@"
+    return
+  fi
+  if [ -f "$token_file" ]; then
+    GH_TOKEN="$(cat "$token_file")" "$GH_BIN" "$@"
+    return
+  fi
+  "$GH_BIN" "$@"
+}
+
+ensure_runtime_files() {
+  mkdir -p "$(dirname "$PUBLISHER_STATE_FILE")" "$(dirname "$TRIAGE_EVENTS_FILE")" "$(dirname "$LOCK_FILE")" "$(dirname "$AUDIT_LOG")"
+  if [ ! -f "$PUBLISHER_STATE_FILE" ] || ! jq empty "$PUBLISHER_STATE_FILE" >/dev/null 2>&1; then
+    jq -n '{schemaVersion: 1, entries: {}, batches: {}}' > "$PUBLISHER_STATE_FILE"
+  fi
+  if [ ! -f "$TRIAGE_EVENTS_FILE" ] || ! jq empty "$TRIAGE_EVENTS_FILE" >/dev/null 2>&1; then
+    jq -n '{schemaVersion: 1, events: {}}' > "$TRIAGE_EVENTS_FILE"
+  fi
+}
+
+audit_event() {
+  local event="$1" detail="$2"
+  jq -nc \
+    --arg ts "$(TZ=Asia/Taipei date -Iseconds)" \
+    --arg event "$event" \
+    --arg detail "$detail" \
+    '{timestamp: $ts, event: $event, detail: $detail}' >> "$AUDIT_LOG"
+}
+
+list_batch_ids() {
+  jq -r '.batches | keys[]?' "$PUBLISHER_STATE_FILE"
+}
+
+batch_branch() {
+  local batch_id="$1"
+  jq -r --arg batch "$batch_id" '.batches[$batch].branch // ""' "$PUBLISHER_STATE_FILE"
+}
+
+batch_entries_json() {
+  local batch_id="$1"
+  jq -c --arg batch "$batch_id" '.batches[$batch].entries // []' "$PUBLISHER_STATE_FILE"
+}
+
+update_batch_state() {
+  local batch_id="$1" state="$2" pr_number="$3" merge_commit="$4" merged_at="$5"
+  local tmp ts entries_json
+  ts="$(TZ=Asia/Taipei date -Iseconds)"
+  entries_json="$(batch_entries_json "$batch_id")"
+  tmp="$(mktemp)"
+  jq \
+    --arg batch "$batch_id" \
+    --arg state "$state" \
+    --arg updatedAt "$ts" \
+    --arg prNumber "$pr_number" \
+    --arg mergeCommit "$merge_commit" \
+    --arg mergedAt "$merged_at" \
+    --argjson entries "$entries_json" '
+      .batches[$batch] = ((.batches[$batch] // {}) + {
+        state: $state,
+        prNumber: (if $prNumber == "" then (.batches[$batch].prNumber // null) else ($prNumber | tonumber) end),
+        mergeCommit: (if $mergeCommit == "" then (.batches[$batch].mergeCommit // null) else $mergeCommit end),
+        mergedAt: (if $mergedAt == "" then (.batches[$batch].mergedAt // null) else $mergedAt end),
+        updatedAt: $updatedAt
+      })
+      | reduce $entries[] as $article (.;
+          .entries[$article] = ((.entries[$article] // {}) + {
+            publishState: $state,
+            updatedAt: $updatedAt,
+            prNumber: (if $prNumber == "" then (.entries[$article].prNumber // null) else ($prNumber | tonumber) end),
+            mergeCommit: (if $mergeCommit == "" then (.entries[$article].mergeCommit // null) else $mergeCommit end),
+            mergedAt: (if $mergedAt == "" then (.entries[$article].mergedAt // null) else $mergedAt end)
+          })
+        )
+    ' "$PUBLISHER_STATE_FILE" > "$tmp"
+  mv "$tmp" "$PUBLISHER_STATE_FILE"
+}
+
+pr_list_json() {
+  local state="$1" branch="$2"
+  local file_var=""
+  if [ "$state" = "open" ]; then
+    file_var="${TRIBUNAL_PUBLISHER_AUTOPILOT_OPEN_PRS_JSON_FILE:-}"
+  elif [ "$state" = "merged" ]; then
+    file_var="${TRIBUNAL_PUBLISHER_AUTOPILOT_MERGED_PRS_JSON_FILE:-}"
+  fi
+  if [ -n "$file_var" ]; then
+    jq --arg branch "$branch" '[.[] | select((.headRefName // "") == $branch)]' "$file_var"
+  else
+    publisher_gh pr list --repo "$REPO" --state "$state" --head "$branch" --json number,url,isDraft,headRefName,state,mergedAt,mergeCommit
+  fi
+}
+
+pr_create_for_branch() {
+  local batch_id="$1" branch="$2"
+  local out pr_number
+  if [ -n "${TRIBUNAL_PUBLISHER_AUTOPILOT_CREATE_PR_HOOK:-}" ]; then
+    out="$("${TRIBUNAL_PUBLISHER_AUTOPILOT_CREATE_PR_HOOK}" "$batch_id" "$branch")"
+  else
+    out="$(publisher_gh pr create --draft --repo "$REPO" --base main --head "$branch" --title "Tribunal publisher batch $batch_id" --body "Automated Tribunal publisher batch." 2>/dev/null || true)"
+  fi
+  [ -n "$out" ] || return 1
+  pr_number="$(printf '%s' "$out" | awk 'match($0, /[0-9]+$/) {print substr($0, RSTART, RLENGTH)}')"
+  [ -n "$pr_number" ] || return 1
+  if [ -z "${TRIBUNAL_PUBLISHER_AUTOPILOT_CREATE_PR_HOOK:-}" ]; then
+    publisher_gh pr edit "$pr_number" --repo "$REPO" --add-label tribunal-publisher >/dev/null 2>&1 || true
+  fi
+  printf '%s\n' "$pr_number"
+}
+
+pr_mark_ready() {
+  local pr_number="$1"
+  if [ -n "${TRIBUNAL_PUBLISHER_AUTOPILOT_READY_HOOK:-}" ]; then
+    "${TRIBUNAL_PUBLISHER_AUTOPILOT_READY_HOOK}" "$pr_number"
+  elif [ "$DRY_RUN" = "1" ]; then
+    tlog "DRY-RUN ready pr=$pr_number"
+  else
+    publisher_gh pr ready "$pr_number" --repo "$REPO" >/dev/null
+  fi
+}
+
+run_merge_guard() {
+  local pr_number="$1"
+  if [ -n "${TRIBUNAL_PUBLISHER_AUTOPILOT_MERGE_GUARD_HOOK:-}" ]; then
+    "${TRIBUNAL_PUBLISHER_AUTOPILOT_MERGE_GUARD_HOOK}" "$pr_number"
+  elif [ "$DRY_RUN" = "1" ]; then
+    tlog "DRY-RUN merge-guard pr=$pr_number"
+  else
+    bash "$SCRIPT_DIR/gu-log-auto-merge-guard.sh" --pr "$pr_number"
+  fi
+}
+
+reconcile_merged_batches() {
+  local batch_id branch merged_json pr_number merge_commit merged_at
+  while IFS= read -r batch_id; do
+    [ -n "$batch_id" ] || continue
+    branch="$(batch_branch "$batch_id")"
+    [ -n "$branch" ] || continue
+    merged_json="$(pr_list_json merged "$branch")"
+    if [ "$(jq 'length' <<<"$merged_json")" -gt 0 ]; then
+      pr_number="$(jq -r '.[0].number // ""' <<<"$merged_json")"
+      merge_commit="$(jq -r '.[0].mergeCommit.oid // ""' <<<"$merged_json")"
+      merged_at="$(jq -r '.[0].mergedAt // ""' <<<"$merged_json")"
+      update_batch_state "$batch_id" "published" "$pr_number" "$merge_commit" "$merged_at"
+      tlog "published batch=$batch_id pr=$pr_number"
+      audit_event "published" "batch=$batch_id pr=$pr_number branch=$branch"
+    fi
+  done < <(list_batch_ids)
+}
+
+advance_open_batches() {
+  local batch_id branch open_json pr_number is_draft current_state
+  while IFS= read -r batch_id; do
+    [ -n "$batch_id" ] || continue
+    branch="$(batch_branch "$batch_id")"
+    [ -n "$branch" ] || continue
+    open_json="$(pr_list_json open "$branch")"
+    if [ "$(jq 'length' <<<"$open_json")" -eq 0 ]; then
+      current_state="$(jq -r --arg batch "$batch_id" '.batches[$batch].state // ""' "$PUBLISHER_STATE_FILE")"
+      if [ "$current_state" = "branch_pushed" ] || jq -e --arg batch "$batch_id" '.batches[$batch].entries[]? as $a | (.entries[$a].publishState // "") == "branch_pushed"' "$PUBLISHER_STATE_FILE" >/dev/null 2>&1; then
+        if pr_number="$(pr_create_for_branch "$batch_id" "$branch" 2>/dev/null)"; then
+          update_batch_state "$batch_id" "pr_open" "$pr_number" "" ""
+          tlog "recovered pr batch=$batch_id pr=$pr_number"
+          audit_event "pr_recovered" "batch=$batch_id pr=$pr_number branch=$branch"
+        fi
+      fi
+      continue
+    fi
+
+    pr_number="$(jq -r '.[0].number // ""' <<<"$open_json")"
+    is_draft="$(jq -r '.[0].isDraft // false' <<<"$open_json")"
+    update_batch_state "$batch_id" "pr_open" "$pr_number" "" ""
+    if [ "$is_draft" = "true" ]; then
+      pr_mark_ready "$pr_number" || tlog "WARN: failed to ready pr=$pr_number"
+      audit_event "pr_ready" "batch=$batch_id pr=$pr_number branch=$branch"
+    fi
+
+    if run_merge_guard "$pr_number"; then
+      tlog "merge-guard allow pr=$pr_number"
+      audit_event "merge_guard_allow" "batch=$batch_id pr=$pr_number"
+    else
+      rc=$?
+      tlog "merge-guard defer pr=$pr_number rc=$rc"
+      audit_event "merge_guard_defer" "batch=$batch_id pr=$pr_number rc=$rc"
+    fi
+  done < <(list_batch_ids)
+}
+
+apply_new_batches() {
+  if [ "$SKIP_APPLY" = "1" ]; then
+    return 0
+  fi
+  if [ -n "${TRIBUNAL_PUBLISHER_AUTOPILOT_APPLY_HOOK:-}" ]; then
+    "${TRIBUNAL_PUBLISHER_AUTOPILOT_APPLY_HOOK}" "$MAX_BATCH"
+    return 0
+  fi
+  bash "$SCRIPT_DIR/tribunal-publisher.sh" --apply --max "$MAX_BATCH" --push-pr || return $?
+}
+
+run_once() {
+  ensure_runtime_files
+  reconcile_merged_batches
+  advance_open_batches
+  apply_new_batches
+  advance_open_batches
+  reconcile_merged_batches
+}
+
+ensure_runtime_files
+exec 9>>"$LOCK_FILE"
+flock -n 9 || { tlog "lock busy; skipping"; exit 0; }
+run_once

--- a/scripts/tribunal-quota-loop.sh
+++ b/scripts/tribunal-quota-loop.sh
@@ -33,6 +33,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$ROOT_DIR"
 
+# shellcheck source=scripts/tribunal-helpers.sh
+source "$SCRIPT_DIR/tribunal-helpers.sh"
+
 POSTS_DIR="$ROOT_DIR/src/content/posts"
 PROGRESS_FILE="$(tribunal_progress_file_default "$ROOT_DIR")"
 TRIBUNAL_VERSION=5
@@ -714,6 +717,16 @@ ensure_worktrees() {
     tlog "WARN: worktree sync reported errors (see log)"
 }
 
+run_publisher_autopilot() {
+  if [ "${TRIBUNAL_PUBLISHER_AUTOPILOT:-1}" != "1" ]; then
+    return 0
+  fi
+  local max_batch="${TRIBUNAL_PUBLISHER_MAX_BATCH:-10}"
+  if ! bash "$SCRIPT_DIR/tribunal-publisher-autopilot.sh" --max "$max_batch" >> "$LOG_FILE" 2>&1; then
+    tlog "WARN: tribunal publisher autopilot failed; will retry next iteration."
+  fi
+}
+
 # Try to claim the next unscored article that isn't already claimed.
 # Prints the article filename and returns 0 on success, 1 if none available.
 try_claim_next_article() {
@@ -953,6 +966,10 @@ while true; do
   git_behind="$(jq -r '.behind // 0' "$RUNTIME_GIT_STATE_FILE" 2>/dev/null || printf '0')"
   git_dirty="$(jq -r '.trackedDirty // 0' "$RUNTIME_GIT_STATE_FILE" 2>/dev/null || printf '0')"
   tlog "Git drift: state=$git_state ahead=$git_ahead behind=$git_behind tracked_dirty=$git_dirty"
+
+  # Publish already-passed artifacts toward main/prod. Keep this best-effort so
+  # publisher issues do not halt scoring workers.
+  run_publisher_autopilot
 
   # ── Find unscored articles ─────────────────────────────────────────────────
   mapfile -t ARTICLES < <(get_unscored_articles)


### PR DESCRIPTION
## Summary
- add publisher autopilot to recover/create publisher PRs, ready drafts, run guarded auto-merge, and reconcile merged batches to published state
- wire publisher autopilot into the quota loop so publishable PASS artifacts progress even during quota debt parking
- add OpenSpec change and regression coverage for autopilot reconciliation

## Verification
- bash scripts/tests/test-tribunal-publisher.sh
- bash scripts/tests/test-tribunal-publisher-autopilot.sh
- bash scripts/tests/test-auto-merge-guard.sh
- openspec validate wire-tribunal-publisher-autopilot --strict
