### PR TITLE
tribunal: move clarity to fresh eyes

### DIFF
--- a/.claude/agents/fact-checker.md
+++ b/.claude/agents/fact-checker.md
@@ -1,5 +1,5 @@
 ---
-description: "Fact Checker — first Tribunal v5 judge for gu-log posts. Checks factual accuracy, source faithfulness, logical consistency, Source Boundary, and Commentary Separation."
+description: "Fact Checker — first Tribunal v6 judge for gu-log posts. Checks factual accuracy, source faithfulness, logical consistency, Source Boundary, and Commentary Separation."
 # Tracks latest Opus: fact-checking benefits from newest reasoning, and voice
 # doesn't matter (no prose output). Writer/scorer are separately pinned to 4.6.
 model: opus
@@ -12,7 +12,7 @@ tools:
   - WebFetch
 ---
 
-You are a strict, independent **Tribunal v5 Fact Checker** for gu-log blog posts.
+You are a strict, independent **Tribunal v6 Fact Checker** for gu-log blog posts.
 Your job is to evaluate FACTUAL ACCURACY and the source/commentary boundary.
 You have ZERO context from the parent conversation. No bias.
 
@@ -25,7 +25,7 @@ Read the post file provided in the task prompt. Pay attention to:
 
 For SP/CP posts, if possible, fetch the `sourceUrl` to compare against the translation.
 
-## Tribunal v5 Source Boundary Rule
+## Tribunal v6 Source Boundary Rule
 
 For SP posts, the reader already sees `原文出處：` on the page and understands the body is derived from the source. The SP body should therefore NOT use meta framing such as:
 - 「原作者說」
@@ -186,5 +186,5 @@ Rules:
 - `judge` = `"factCheck"` (fixed)
 - `dimensions` = each dimension 0-10 integer
 - `score` = `floor(sum of all dimensions / 5)` — you calculate this
-- `verdict` = `"PASS"` only if the v5 pass bar above passes, else `"FAIL"` (advisory only)
+- `verdict` = `"PASS"` only if the v6 pass bar above passes, else `"FAIL"` (advisory only)
 - `reasons` = one sentence per dimension, cite specific examples from the post

--- a/.claude/agents/fresh-eyes.md
+++ b/.claude/agents/fresh-eyes.md
@@ -1,5 +1,5 @@
 ---
-description: "Fresh Eyes — fast first-impression reader. Reads the post as a complete stranger with zero blog context. Catches things the specialized judges miss: confusing structure, unclear jargon, boring stretches, cringe moments. Quick and blunt."
+description: "Fresh Eyes — fast first-impression reader. Reads the post as a complete stranger with zero blog context. Catches things the specialized judges miss: confusing structure, unclear jargon, weak speaker attribution, boring stretches, cringe moments. Quick and blunt."
 model: claude-opus-4-7
 tools:
   - Read
@@ -12,7 +12,7 @@ You are a developer with **~3 months of experience**. You're smart but extremely
 
 ## Your Job
 
-Read the post and give your honest, gut-level reaction. Score TWO things:
+Read the post and give your honest, gut-level reaction. Score THREE things:
 
 ### 1. readability (0-10)
 Can you follow this without getting lost?
@@ -31,6 +31,15 @@ Would you finish reading? Would you share it?
 - **6** = Finished but wouldn't revisit. Fine.
 - **4** = Skimmed the second half. Meh.
 - **2** = Closed tab after 3 paragraphs.
+
+### 3. clarity (0-10)
+Can you tell who is speaking and what each sentence is pointing at?
+
+- **10** = Speaker attribution stays obvious. No fuzzy referents, no half-translated wording drag.
+- **8** = Mostly clear. Maybe one sentence you re-read for "wait, who means what?"
+- **6** = Understandable, but a few fuzzy 我/你/這個/那個 shortcuts or muddy wording slow you down.
+- **4** = Repeated ambiguity. You keep stopping to resolve who said what.
+- **2** = Too muddy. Reader loses the thread.
 
 ## What to Flag
 
@@ -51,7 +60,7 @@ Would you finish reading? Would you share it?
 
 ## Scoring
 
-Composite = floor(average of readability and firstImpression).
+Composite = floor(average of readability, firstImpression, and clarity).
 Pass bar: composite ≥ 8 (advisory — orchestrator code enforces final verdict)
 
 ## Output
@@ -66,13 +75,15 @@ Then print a SHORT (3-5 lines) blunt summary. No politeness.
   "judge": "freshEyes",
   "dimensions": {
     "readability": 8,
-    "firstImpression": 8
+    "firstImpression": 8,
+    "clarity": 8
   },
   "score": 8,
   "verdict": "PASS",
   "reasons": {
     "readability": "Flows well, one confusing paragraph about token limits in the middle.",
-    "firstImpression": "Interesting hook, would probably share if the topic came up."
+    "firstImpression": "Interesting hook, would probably share if the topic came up.",
+    "clarity": "I can track who is speaking without rereading."
   }
 }
 ```
@@ -80,6 +91,6 @@ Then print a SHORT (3-5 lines) blunt summary. No politeness.
 Rules:
 - `judge` = `"freshEyes"` (fixed)
 - `dimensions` = each dimension 0-10 integer
-- `score` = `floor(sum of readability + firstImpression / 2)` — you calculate this
+- `score` = `floor(sum of readability + firstImpression + clarity / 3)` — you calculate this
 - `verdict` = `"PASS"` if score ≥ 8, else `"FAIL"` (advisory only)
 - `reasons` = one sentence per dimension, gut reaction, cite specific moments

--- a/.claude/agents/tribunal-writer.md
+++ b/.claude/agents/tribunal-writer.md
@@ -47,10 +47,10 @@ For each failing dimension, the fix is different:
 | Fact Checker | commentarySeparation | Move Clawd/gu-log opinions, interpretation, jokes, and source-meta commentary out of SP body and into `<ClawdNote>` |
 | Fresh Eyes | readability | Simplify jargon; break up confusing paragraphs; add transitions |
 | Fresh Eyes | firstImpression | Strengthen hook; tighten boring sections; improve ending |
+| Fresh Eyes | clarity | Replace fuzzy referents; fix speaker attribution; remove half-translated wording that muddies reading |
 | Vibe | persona | Add life analogies; inject oral feel; increase 吐槽 density; fix motivational-poster ending |
 | Vibe | clawdNote | Convert explain-only notes to opinion-first notes; add Clawd's own stance; add meta-commentary |
 | Vibe | vibe | Fix bullet-dump ending; add narrative arc; tighten boring stretches |
-| Vibe | clarity | Replace 你/我 in body text with specific names; clarify speaker attribution |
 | Vibe | narrative | Add emotional arc; create section pivots; add punch ending; break linear structure |
 
 ### Rules for rewriting

--- a/.claude/agents/vibe-opus-scorer.md
+++ b/.claude/agents/vibe-opus-scorer.md
@@ -1,5 +1,5 @@
 ---
-description: "Vibe Scorer — independent, harsh quality scorer for gu-log posts. Scores on 5 dimensions (Persona/ClawdNote/Vibe/Clarity/Narrative). Pass bar: composite ≥ 8 AND at least one dimension ≥ 9 AND no dimension < 8. Zero context from parent conversation. Use this to evaluate post quality without bias."
+description: "Vibe Scorer — independent, harsh quality scorer for gu-log posts. Scores on 4 dimensions (Persona/ClawdNote/Vibe/Narrative). Pass bar: composite ≥ 8 AND at least one dimension ≥ 9 AND no dimension < 8. Zero context from parent conversation. Use this to evaluate post quality without bias."
 # PINNED: claude-opus-4-6[1m]. Maintainer has explicitly rejected Opus 4.7's
 # vibe-scoring calibration — 4.7 inflates scores and misses decorative-persona
 # traps that 4.6 catches. Do NOT bump to "opus" alias or 4.7 without owner
@@ -25,7 +25,7 @@ Read these files to calibrate before scoring anything:
 
 Then read the ENTIRE post file provided in the task prompt. Every line.
 
-## Five Scoring Dimensions (each 0-10)
+## Four Scoring Dimensions (each 0-10)
 
 ### 1. persona — 李宏毅教授 (LHY) 風格
 Does it read like a passionate professor explaining things? Or like a news article / press release?
@@ -43,13 +43,7 @@ Would you share this with a friend? Read on phone for fun?
 - Vibe killers: bullet-dump ending, template structure, motivational-poster closing
 - **Sentence Signal Rule:** every sentence must be informative or intriguing. Sentences that only repeat source metadata, throat-clear, summarize what the reader already knows from frontmatter/source attribution, or add no curiosity are vibe killers.
 
-### 4. clarity — Pronoun Clarity / Voice Attribution / 晶晶體
-Does every sentence make it obvious who is speaking?
-- Body text 你/我 = bad. ClawdNote/ShroomDogNote/blockquote = OK (exempted).
-- zh-tw posts: **晶晶體 enforcement is hard rule, not taste**. The English allowlist is `src/data/glossary.json` plus proper nouns (product/people/place/benchmark/model-variant names), code identifiers, direct quoted English (inside 「」 or ""), and universally-understood acronyms (API, SDK, CLI, PM, CEO, ML, LLM, UI, UX, RL). **ANY OTHER English word in body or ClawdNote = 晶晶體**. Examples that MUST be flagged: `framing`, `hedge`, `takeaway`, `inbox`, `launch`, `generalist`, `letter`, `newsletter`, `model` (when used as 「模型」), `bottleneck` (when natural is 「卡關 / 瓶頸」), `release`, `incentive`, `essay`, `narrative`, `recap`, `stack`, `target`, `lab`, `weights` (standalone — but `Open Weights` glossary term OK), `cover`, `superlative`, `instantly`, `async`, `remote` (when 「遠端」 fits), `feature` (when 「功能」 fits), `coding` (when 「寫程式」 fits), `engineer` (when 「工程師」 fits). Score with no mercy: presence of even 5 unjustified English words across 200 lines drops clarity to ≤ 7.
-- EN posts: focus on referent clarity — reader always knows who "I"/"you" refers to
-
-### 5. narrative — Narrative Structure / Rhythm / Emotional Arc
+### 4. narrative — Narrative Structure / Rhythm / Emotional Arc
 Does the post have genuine narrative structure, or is it a linear report with decorative persona?
 - **10** = 情緒起伏明確，每個 section 節奏不同，結尾 callback 開頭，讀完有「靠，這句要記住」的感覺
 - **9** = 有起伏有節奏，結尾有收 punch，個別段落可再加強
@@ -79,7 +73,7 @@ Does the post have genuine narrative structure, or is it a linear report with de
 - Motivational-poster closing → vibe -2
 - ClawdNote = pure definition → clawdNote -2
 - SP-158 decorative persona pattern → persona cap 5, narrative cap 5
-- **晶晶體 (any non-allowlist English in zh-tw body or ClawdNote)** → clarity -3 AND vibe -4. Severity scales: 1-3 instances = -3 clarity / -4 vibe; 4-10 instances = clarity capped at 6, vibe capped at 6; 10+ instances = clarity capped at 5, vibe capped at 5, persona capped at 6 (because LHY would never let this past). This is **not stylistic preference** — it's repository policy. If a non-allowlist English word genuinely needs to stay, apply `GU-LOG_WRITER_PROMPT.md`'s glossary creation standard: ordinary English should become natural zh-tw; canonical/reusable terms that lose meaning when translated can become glossary entries; borderline accepted-English boundary decisions must be discussed with ShroomDog.
+- **晶晶體 (any non-allowlist English in zh-tw body or ClawdNote)** still damages reader flow. Fresh Eyes owns the explicit clarity score now, but Vibe should still treat decorative English mixing as a vibe penalty when it makes the prose feel fake or half-translated.
 
 ## Protocol
 
@@ -92,12 +86,12 @@ Does the post have genuine narrative structure, or is it a linear report with de
 7. Check Sentence Signal — scan opening and representative body paragraphs. Does every sentence either inform or intrigue? Flag source-metadata repetition and throat-clearing.
 8. Score each dimension independently (0-10)
 9. Write 1-2 sentence justification per dimension — cite specific lines/quotes
-10. Calculate composite: floor(avg of all 5 dims)
+10. Calculate composite: floor(avg of all 4 dims)
 11. Check pass bar: composite ≥ 8 AND at least one dim ≥ 9 AND no dim < 8
 
 ## Scoring
 
-Composite = floor(average of all 5 dimensions).
+Composite = floor(average of all 4 dimensions).
 Pass bar: composite ≥ 8 AND at least one dimension ≥ 9 AND no dimension < 8
 (advisory — orchestrator code enforces final verdict)
 
@@ -116,7 +110,6 @@ Pass bar: composite ≥ 8 AND at least one dimension ≥ 9 AND no dimension < 8
     "persona": 9,
     "clawdNote": 8,
     "vibe": 8,
-    "clarity": 9,
     "narrative": 8
   },
   "score": 8,
@@ -125,7 +118,6 @@ Pass bar: composite ≥ 8 AND at least one dimension ≥ 9 AND no dimension < 8
     "persona": "LHY feel strong; convenience store analogy lands perfectly.",
     "clawdNote": "Half of notes have clear opinions (agrees/disagrees with source).",
     "vibe": "Good read, one bullet-heavy section drags.",
-    "clarity": "Body text keeps subjects named; no pronoun ambiguity.",
     "narrative": "Section 3 pivot creates genuine surprise; ending callbacks opening."
   }
 }
@@ -139,11 +131,11 @@ Pass bar: composite ≥ 8 AND at least one dimension ≥ 9 AND no dimension < 8
 
 **Required top-level keys (exactly 5):** `judge`, `dimensions`, `score`, `verdict`, `reasons`
 
-**Required dimension keys (exactly 5):** `persona`, `clawdNote`, `vibe`, `clarity`, `narrative`
+**Required dimension keys (exactly 4):** `persona`, `clawdNote`, `vibe`, `narrative`
 
 Rules:
 - `judge` = `"vibe"` (fixed string, always)
-- `dimensions` = object with exactly 5 keys above, each an integer 0-10
-- `score` = integer, `floor(sum of all 5 dimensions / 5)` — you calculate this
+- `dimensions` = object with exactly 4 keys above, each an integer 0-10
+- `score` = integer, `floor(sum of all 4 dimensions / 4)` — you calculate this
 - `verdict` = `"PASS"` if score ≥ 8 AND max(dims) ≥ 9 AND min(dims) ≥ 8, else `"FAIL"` (advisory only)
 - `reasons` = object with exactly 5 keys above, each a one-sentence string citing specific content

--- a/.claude/commands/vibe-score.md
+++ b/.claude/commands/vibe-score.md
@@ -1,5 +1,5 @@
 ---
-description: Score a gu-log post with the Vibe Opus scorer (5 dimensions, tribunal schema)
+description: Score a gu-log post with the Vibe Opus scorer (4 dimensions, tribunal schema)
 ---
 
 You are an independent, harsh quality reviewer for gu-log blog posts. Score the given post honestly — never inflate.
@@ -12,13 +12,12 @@ Read these files to calibrate before scoring:
 
 Then read the ENTIRE post file: `src/content/posts/$ARGUMENTS`. Every line.
 
-## Five Scoring Dimensions (0-10 each)
+## Four Scoring Dimensions (0-10 each)
 
 1. **persona** — 李宏毅 teaching feel? Life analogies, oral voice, harsh on tech but kind to people?
 2. **clawdNote** — Opinionated, 吐槽-filled, personality? Or Wikipedia footnotes?
 3. **vibe** — Would you share this with a friend? Can you read it on your phone without swiping away?
-4. **clarity** — Pronoun clarity / voice attribution. Body text 你/我 = bad; ClawdNote/blockquote exempt.
-5. **narrative** — Real narrative arc with rhythm and emotional peaks? Or a linear report with decorative persona?
+4. **narrative** — Real narrative arc with rhythm and emotional peaks? Or a linear report with decorative persona?
 
 ## Scoring Anchors
 - **10** = CP-85 (AI Vampire) — storytelling you can't stop
@@ -38,7 +37,7 @@ Then read the ENTIRE post file: `src/content/posts/$ARGUMENTS`. Every line.
 
 ## Composite & Pass Bar
 
-- `score` = `floor(average of all 5 dimensions)`
+- `score` = `floor(average of all 4 dimensions)`
 - Pass = `score ≥ 8` AND `max(dimensions) ≥ 9` AND `min(dimensions) ≥ 8`
 - Otherwise Fail
 
@@ -53,7 +52,6 @@ Write the result to `/tmp/vibe-score-<ticketId>.json` using EXACTLY this structu
     "persona": 9,
     "clawdNote": 8,
     "vibe": 8,
-    "clarity": 9,
     "narrative": 8
   },
   "score": 8,
@@ -62,20 +60,19 @@ Write the result to `/tmp/vibe-score-<ticketId>.json` using EXACTLY this structu
     "persona": "LHY feel strong; convenience-store analogy lands perfectly.",
     "clawdNote": "Half of notes have clear opinions (agrees/disagrees with source).",
     "vibe": "Good read overall, one bullet-heavy section drags a bit.",
-    "clarity": "Body text keeps subjects named; no pronoun ambiguity.",
     "narrative": "Section 3 pivot creates real surprise; ending callbacks opening."
   }
 }
 ```
 
 **Required top-level keys (exactly 5):** `judge`, `dimensions`, `score`, `verdict`, `reasons`.
-**Required dimension keys (exactly 5):** `persona`, `clawdNote`, `vibe`, `clarity`, `narrative`.
+**Required dimension keys (exactly 4):** `persona`, `clawdNote`, `vibe`, `narrative`.
 **Forbidden fields:** `ticketId`, `file`, `scores`, `meetBar`, `topIssues`, `issues`, `recommendations`.
 
 Rules:
 - `judge` = `"vibe"` (fixed string)
-- `dimensions` = object with exactly the 5 keys, each integer 0-10
-- `score` = integer, `floor(sum of all 5 dims / 5)`
+- `dimensions` = object with exactly the 4 keys, each integer 0-10
+- `score` = integer, `floor(sum of all 4 dims / 4)`
 - `verdict` = `"PASS"` if score ≥ 8 AND max(dims) ≥ 9 AND min(dims) ≥ 8, else `"FAIL"`
 - `reasons` = object with exactly the 5 keys, each a one-sentence string citing specific content
 

--- a/scripts/frontmatter-scores.mjs
+++ b/scripts/frontmatter-scores.mjs
@@ -38,7 +38,7 @@ import process from 'node:process';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const VALID_JUDGES = ['librarian', 'factCheck', 'freshEyes', 'vibe'];
-const CURRENT_TRIBUNAL_VERSION = 5;
+const CURRENT_TRIBUNAL_VERSION = 6;
 
 const __isCli =
   import.meta.url === pathToFileURL(process.argv[1] ?? '').href ||
@@ -297,8 +297,8 @@ function opWrite() {
     delete scores.vibe.clarity;
   }
 
-  // New tribunal writes are v5: factCheck runs first and includes
-  // Source Boundary / Commentary Separation dimensions.
+  // New tribunal writes are v6: factCheck-first pipeline retained, while
+  // clarity moves from Vibe to Fresh Eyes.
   scores.tribunalVersion = CURRENT_TRIBUNAL_VERSION;
 
   let newFm = removeScoresBlock(parts.fmText);

--- a/scripts/frontmatter-scores.mjs
+++ b/scripts/frontmatter-scores.mjs
@@ -200,8 +200,8 @@ function writeFrontmatter(filePath, fmText, body) {
 const JUDGE_DIMS = {
   librarian: ['glossary', 'crossRef', 'sourceAlign', 'attribution'],
   factCheck: ['accuracy', 'fidelity', 'consistency', 'sourceBoundary', 'commentarySeparation'],
-  freshEyes: ['readability', 'firstImpression'],
-  vibe: ['persona', 'clawdNote', 'vibe', 'clarity', 'narrative'],
+  freshEyes: ['readability', 'firstImpression', 'clarity'],
+  vibe: ['persona', 'clawdNote', 'vibe', 'narrative'],
 };
 
 // ─── Operations ───────────────────────────────────────────────────────────
@@ -227,6 +227,9 @@ function opGet() {
   const dimensions = {};
   for (const dim of dims) {
     if (entry[dim] != null) dimensions[dim] = entry[dim];
+  }
+  if (judge === 'freshEyes' && dimensions.clarity == null && scores.vibe?.clarity != null) {
+    dimensions.clarity = scores.vibe.clarity;
   }
 
   const output = {
@@ -290,6 +293,9 @@ function opWrite() {
   if (scoreData.model) entry.model = scoreData.model;
 
   scores[judge] = entry;
+  if (judge === 'freshEyes' && scores.vibe && typeof scores.vibe === 'object') {
+    delete scores.vibe.clarity;
+  }
 
   // New tribunal writes are v5: factCheck runs first and includes
   // Source Boundary / Commentary Separation dimensions.

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -72,8 +72,8 @@ echo ""
 
 # ─── Step 0.1: Score gate — staged posts must have vibe scores ────
 # Only checks zh-tw primary posts (not en- translations).
-# Minimum: scores.vibe block with persona, clawdNote, vibe, clarity,
-# narrative (tribunal v2 format — scores.ralph was the v1 shape and
+# Minimum: scores.vibe block with persona, clawdNote, vibe, narrative
+# (tribunal v2 format — scores.ralph was the v1 shape and
 # has been superseded; src/content/config.ts schema only declares
 # scores.vibe / librarian / factCheck / freshEyes).
 #
@@ -215,9 +215,9 @@ else
             continue
         fi
 
-        # Check scores.vibe block with the 5 tribunal v2 dimensions.
+        # Check scores.vibe block with the 4 active tribunal dimensions.
         # Matches both "^  vibe:" (nested under scores) and inline value
-        # styles; requires persona/clawdNote/vibe/clarity/narrative to
+        # styles; requires persona/clawdNote/vibe/narrative to
         # appear within the block's first ~8 lines.
         if ! grep -q "^  vibe:" "$FULL_PATH" 2>/dev/null; then
             BASENAME=$(basename "$file")
@@ -230,11 +230,10 @@ else
             HAS_PERSONA=$(printf '%s\n' "$BLOCK" | grep -c "persona:" 2>/dev/null || echo 0)
             HAS_CLAWD=$(printf '%s\n' "$BLOCK" | grep -c "clawdNote:" 2>/dev/null || echo 0)
             HAS_VIBE=$(printf '%s\n' "$BLOCK" | grep -c "vibe:" 2>/dev/null || echo 0)
-            HAS_CLARITY=$(printf '%s\n' "$BLOCK" | grep -c "clarity:" 2>/dev/null || echo 0)
             HAS_NARRATIVE=$(printf '%s\n' "$BLOCK" | grep -c "narrative:" 2>/dev/null || echo 0)
-            if [ "$HAS_PERSONA" -eq 0 ] || [ "$HAS_CLAWD" -eq 0 ] || [ "$HAS_VIBE" -lt 2 ] || [ "$HAS_CLARITY" -eq 0 ] || [ "$HAS_NARRATIVE" -eq 0 ]; then
+            if [ "$HAS_PERSONA" -eq 0 ] || [ "$HAS_CLAWD" -eq 0 ] || [ "$HAS_VIBE" -lt 2 ] || [ "$HAS_NARRATIVE" -eq 0 ]; then
                 BASENAME=$(basename "$file")
-                SCORE_MISSING="$SCORE_MISSING  ⚠️  $BASENAME — scores.vibe incomplete (need persona, clawdNote, vibe, clarity, narrative)\n"
+                SCORE_MISSING="$SCORE_MISSING  ⚠️  $BASENAME — scores.vibe incomplete (need persona, clawdNote, vibe, narrative)\n"
             fi
         fi
     done

--- a/scripts/score-helpers.sh
+++ b/scripts/score-helpers.sh
@@ -287,12 +287,12 @@ validate_judge_score_json() {
     freshEyes|fresh-eyes)
       _validate_dim readability     || return 1
       _validate_dim firstImpression || return 1
+      _validate_dim clarity         || return 1
       ;;
     vibe|vibe-opus-scorer)
       _validate_dim persona    || return 1
       _validate_dim clawdNote  || return 1
       _validate_dim vibe       || return 1
-      _validate_dim clarity    || return 1
       _validate_dim narrative  || return 1
       ;;
     *)

--- a/scripts/tests/test-frontmatter-scores-fresheyes-clarity-fallback.sh
+++ b/scripts/tests/test-frontmatter-scores-fresheyes-clarity-fallback.sh
@@ -16,7 +16,7 @@ sourceUrl: "https://example.com"
 summary: "x"
 lang: "zh-tw"
 scores:
-  tribunalVersion: 5
+  tribunalVersion: 6
   freshEyes:
     readability: 8
     firstImpression: 9

--- a/scripts/tests/test-frontmatter-scores-fresheyes-clarity-fallback.sh
+++ b/scripts/tests/test-frontmatter-scores-fresheyes-clarity-fallback.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+post="$TMP_DIR/post.mdx"
+cat > "$post" <<'EOF'
+---
+title: "Test"
+originalDate: "2026-05-23"
+translatedDate: "2026-05-23"
+source: "x"
+sourceUrl: "https://example.com"
+summary: "x"
+lang: "zh-tw"
+scores:
+  tribunalVersion: 5
+  freshEyes:
+    readability: 8
+    firstImpression: 9
+    score: 8
+    date: "2026-05-23"
+    model: "gpt-5.5"
+  vibe:
+    persona: 8
+    clawdNote: 8
+    vibe: 8
+    clarity: 7
+    narrative: 8
+    score: 7
+    date: "2026-05-23"
+    model: "gpt-5.5"
+---
+body
+EOF
+
+got="$(node "$ROOT_DIR/scripts/frontmatter-scores.mjs" get "$post" freshEyes)"
+if [[ "$got" != *'"clarity":7'* ]]; then
+  echo "expected legacy vibe.clarity to be exposed via freshEyes get"
+  echo "$got"
+  exit 1
+fi
+
+echo "PASS: freshEyes get falls back to legacy vibe.clarity"

--- a/scripts/tests/test-frontmatter-scores-v5.sh
+++ b/scripts/tests/test-frontmatter-scores-v5.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# test-frontmatter-scores-v5.sh — regression tests for Tribunal v5 factCheck
+# test-frontmatter-scores-v5.sh — regression tests for Tribunal v6 factCheck
 # dimensions and frontmatter versioning.
 
 set -euo pipefail
@@ -41,7 +41,7 @@ score_json='{
 
 node "$ROOT_DIR/scripts/frontmatter-scores.mjs" write "$post" factCheck "$score_json"
 
-grep -q 'tribunalVersion: 5' "$post" || fail "frontmatter write did not set tribunalVersion: 5"
+grep -q 'tribunalVersion: 6' "$post" || fail "frontmatter write did not set tribunalVersion: 6"
 grep -q 'sourceBoundary: 8' "$post" || fail "sourceBoundary was not written"
 grep -q 'commentarySeparation: 9' "$post" || fail "commentarySeparation was not written"
 
@@ -51,14 +51,14 @@ const data = JSON.parse(process.argv[1]);
 if (data.dimensions.sourceBoundary !== 8) process.exit(1);
 if (data.dimensions.commentarySeparation !== 9) process.exit(2);
 if (data.score !== 8) process.exit(3);
-' "$roundtrip" || fail "frontmatter get did not roundtrip v5 factCheck dimensions"
-pass "frontmatter-scores writes and reads Tribunal v5 factCheck dimensions"
+' "$roundtrip" || fail "frontmatter get did not roundtrip v6 factCheck dimensions"
+pass "frontmatter-scores writes and reads Tribunal v6 factCheck dimensions"
 
 score_file="$TMP/fact-score.json"
 printf '%s\n' "$score_json" > "$score_file"
 source "$ROOT_DIR/scripts/score-helpers.sh"
-validate_judge_score_json fact-checker "$score_file" || fail "v5 factCheck score JSON did not validate"
-pass "score helper validates Tribunal v5 factCheck JSON"
+validate_judge_score_json fact-checker "$score_file" || fail "v6 factCheck score JSON did not validate"
+pass "score helper validates Tribunal v6 factCheck JSON"
 
 missing_file="$TMP/fact-score-missing.json"
 cat > "$missing_file" <<'JSON'
@@ -74,6 +74,6 @@ cat > "$missing_file" <<'JSON'
 }
 JSON
 if validate_judge_score_json fact-checker "$missing_file"; then
-  fail "v5 factCheck validation accepted JSON without boundary dimensions"
+  fail "v6 factCheck validation accepted JSON without boundary dimensions"
 fi
-pass "score helper rejects pre-v5 factCheck JSON"
+pass "score helper rejects pre-v6 factCheck JSON"

--- a/scripts/tests/test-tribunal-openai-quota-controller.sh
+++ b/scripts/tests/test-tribunal-openai-quota-controller.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Static/no-token regression tests for Tribunal v5 OpenAI-aware burn-rate pacing.
+# Static/no-token regression tests for Tribunal v6 OpenAI-aware burn-rate pacing.
 
 set -euo pipefail
 

--- a/scripts/tests/test-tribunal-pass-artifact-guards.sh
+++ b/scripts/tests/test-tribunal-pass-artifact-guards.sh
@@ -28,7 +28,7 @@ title: Test
 lang: zh-tw
 translatedDate: 2026-04-29
 scores:
-  tribunalVersion: 5
+  tribunalVersion: 6
 ---
 
 Original body.
@@ -40,7 +40,7 @@ title: Test EN
 lang: en
 translatedDate: 2026-04-29
 scores:
-  tribunalVersion: 5
+  tribunalVersion: 6
 ---
 
 Original EN body.
@@ -86,7 +86,7 @@ git -C "$repo2" add scores/tribunal-progress.json src/content/posts/cp-999-test.
 bash "$ASSERT" "$repo2" cp-999-test.mdx --staged
 pass "postcondition accepts staged PASS with target artifacts"
 
-# 3. New staged PASS postcondition must reject pre-v5 score frontmatter.
+# 3. New staged PASS postcondition must reject pre-v6 score frontmatter.
 repo2b="$TMP/postcondition-v3-reject"
 setup_repo "$repo2b"
 python3 - <<PY
@@ -95,20 +95,20 @@ import json
 repo=Path('$repo2b')
 for name in ['cp-999-test.mdx', 'en-cp-999-test.mdx']:
     p = repo/'src/content/posts'/name
-    p.write_text(p.read_text().replace('tribunalVersion: 5', 'tribunalVersion: 3').replace('Original', 'Rewritten'))
+    p.write_text(p.read_text().replace('tribunalVersion: 6', 'tribunalVersion: 3').replace('Original', 'Rewritten'))
 p=repo/'scores/tribunal-progress.json'
-p.write_text(json.dumps({'cp-999-test.mdx': {'status': 'PASS', 'tribunalVersion': 5}}, indent=2) + '\n')
+p.write_text(json.dumps({'cp-999-test.mdx': {'status': 'PASS', 'tribunalVersion': 6}}, indent=2) + '\n')
 PY
 git -C "$repo2b" add scores/tribunal-progress.json src/content/posts/cp-999-test.mdx src/content/posts/en-cp-999-test.mdx
 if bash "$ASSERT" "$repo2b" cp-999-test.mdx --staged >/tmp/guard-v3-out 2>&1; then
   cat /tmp/guard-v3-out >&2
-  fail "postcondition accepted pre-v5 score frontmatter for a new PASS"
+  fail "postcondition accepted pre-v6 score frontmatter for a new PASS"
 fi
-if ! grep -q 'tribunalVersion >= 5' /tmp/guard-v3-out; then
+if ! grep -q 'tribunalVersion >= 6' /tmp/guard-v3-out; then
   cat /tmp/guard-v3-out >&2
-  fail "pre-v5 rejection did not explain required tribunal version"
+  fail "pre-v6 rejection did not explain required tribunal version"
 fi
-pass "postcondition rejects pre-v5 staged PASS score frontmatter"
+pass "postcondition rejects pre-v6 staged PASS score frontmatter"
 
 # 4. Audit must fail on historical progress-only Tribunal PASS commits.
 repo3="$TMP/audit"

--- a/scripts/tests/test-tribunal-publish-worker-changes.sh
+++ b/scripts/tests/test-tribunal-publish-worker-changes.sh
@@ -61,7 +61,7 @@ title: Original
 lang: zh-tw
 translatedDate: 2026-04-28
 scores:
-  tribunalVersion: 5
+  tribunalVersion: 6
   vibe:
     score: 8
 ---
@@ -75,7 +75,7 @@ ticketId: CP-999
 lang: en
 translatedDate: 2026-04-28
 scores:
-  tribunalVersion: 5
+  tribunalVersion: 6
   vibe:
     score: 8
 ---
@@ -89,7 +89,7 @@ grep -q 'Rewritten body with Tribunal changes' "$main/src/content/posts/cp-999-t
   || fail "zh post rewrite was not copied from worker to main"
 grep -q 'Rewritten EN body with Tribunal changes' "$main/src/content/posts/en-cp-999-test.mdx" \
   || fail "en post rewrite was not copied from worker to main"
-grep -q 'tribunalVersion: 5' "$main/src/content/posts/cp-999-test.mdx" \
+grep -q 'tribunalVersion: 6' "$main/src/content/posts/cp-999-test.mdx" \
   || fail "score frontmatter was not copied to main"
 
 git -C "$main" add src/content/posts/cp-999-test.mdx src/content/posts/en-cp-999-test.mdx

--- a/scripts/tests/test-tribunal-publisher.sh
+++ b/scripts/tests/test-tribunal-publisher.sh
@@ -32,7 +32,7 @@ sourceUrl: "https://example.com/sp1"
 summary: "Summary one."
 lang: zh-tw
 scores:
-  tribunalVersion: 5
+  tribunalVersion: 6
 ---
 This is a sufficiently long body for publisher validation. It explains one coherent idea, adds supporting detail, and stays comfortably above the minimum content length that the deterministic content validator requires for a real publishable artifact in gu-log.
 POST
@@ -47,7 +47,7 @@ sourceUrl: "https://example.com/sp1"
 summary: "Summary one en."
 lang: en
 scores:
-  tribunalVersion: 5
+  tribunalVersion: 6
 ---
 This is a sufficiently long English body for publisher validation. It mirrors the publishable structure expected by the content validator and avoids failing on missing metadata or minimum-length requirements during the clean batch materialization step.
 POST
@@ -62,7 +62,7 @@ sourceUrl: "https://example.com/sp2"
 summary: "Summary two."
 lang: zh-tw
 scores:
-  tribunalVersion: 5
+  tribunalVersion: 6
 ---
 This is another sufficiently long body for publisher validation. It exists so the test can later turn it into an invalid candidate and verify that validation-blocked events isolate only the broken article instead of stopping the clean publisher batch.
 POST
@@ -77,7 +77,7 @@ sourceUrl: "https://example.com/sp2"
 summary: "Summary two en."
 lang: en
 scores:
-  tribunalVersion: 5
+  tribunalVersion: 6
 ---
 This is another sufficiently long English body for publisher validation. It gives the test a clean bilingual pair so the batch publisher can materialize both files and still isolate the broken candidate later when the zh file is intentionally damaged.
 POST

--- a/scripts/tests/test-tribunal-safety-contract.sh
+++ b/scripts/tests/test-tribunal-safety-contract.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Static/no-token regressions for Tribunal v5 safety hardening.
+# Static/no-token regressions for Tribunal v6 safety hardening.
 
 set -euo pipefail
 
@@ -90,7 +90,7 @@ unpinned_agents=$(grep -L '^model = "gpt-5.5"' "$CODEX_AGENTS_DIR"/*.toml || tru
 if [ -n "$unpinned_agents" ]; then
   fail "One or more Codex tribunal agent specs are not pinned to GPT-5.5: $unpinned_agents"
 fi
-pass "Tribunal v5 Codex model pinning remains GPT-5.5 end-to-end"
+pass "Tribunal v6 Codex model pinning remains GPT-5.5 end-to-end"
 
 if ! grep -q 'temporary directory' "$CODEX_WRITER" || ! grep -q 'surgical editor' "$CODEX_WRITER"; then
   fail "Codex tribunal writer prompt lacks GPT-5.5 temp-dir/surgical-edit guardrails"

--- a/scripts/tribunal-batch-runner.sh
+++ b/scripts/tribunal-batch-runner.sh
@@ -25,7 +25,7 @@ source "$SCRIPT_DIR/tribunal-helpers.sh"
 
 POSTS_DIR="$ROOT_DIR/src/content/posts"
 PROGRESS_FILE="$(tribunal_progress_file_default "$ROOT_DIR")"
-TRIBUNAL_VERSION=5
+TRIBUNAL_VERSION=6
 LOG_DIR="$ROOT_DIR/.score-loop/logs"
 LOG_FILE="$LOG_DIR/tribunal-batch-$(date +%Y%m%d-%H%M%S).log"
 RUNTIME_GIT_STATE_FILE="$(tribunal_runtime_git_state_file "$ROOT_DIR")"
@@ -124,7 +124,7 @@ get_unscored_articles() {
     fi
 
     # Check if already PASS in current tribunal version. Older PASS entries
-    # should be reprocessed by the v5 source-boundary gate.
+    # should be reprocessed by the v6 score schema / source-boundary gate.
     local status
     status=$(jq -r --arg a "$article" --argjson v "$TRIBUNAL_VERSION" \
       'if ((.[$a].tribunalVersion // 0) >= $v) then (.[$a].status // "pending") else "pending" end' \

--- a/scripts/tribunal-quota-loop.sh
+++ b/scripts/tribunal-quota-loop.sh
@@ -38,7 +38,7 @@ source "$SCRIPT_DIR/tribunal-helpers.sh"
 
 POSTS_DIR="$ROOT_DIR/src/content/posts"
 PROGRESS_FILE="$(tribunal_progress_file_default "$ROOT_DIR")"
-TRIBUNAL_VERSION=5
+TRIBUNAL_VERSION=6
 LOG_DIR="$ROOT_DIR/.score-loop/logs"
 LOG_FILE="$LOG_DIR/tribunal-quota-loop-$(date +%Y%m%d-%H%M%S).log"
 USAGE_MONITOR="${USAGE_MONITOR:-$HOME/clawd/scripts/usage-monitor.sh}"
@@ -370,7 +370,7 @@ def parse_reset_to_sec(s):
 
 try:
     data = json.loads(sys.argv[1])
-    # Tribunal v5 runs on OpenAI/Codex GPT-5.5. usage-monitor exposes the
+    # Tribunal v6 runs on OpenAI/Codex GPT-5.5. usage-monitor exposes the
     # short OpenAI bucket as session_remaining_pct/session_reset_min and the
     # long bucket as weekly_remaining_pct/weekly_reset_hr.
     for p in data:
@@ -878,7 +878,7 @@ get_unscored_articles() {
     fi
     # Skip already passed or permanently exhausted only for the current
     # tribunal version. Older PASS entries are intentionally reprocessed by
-    # the v5 source-boundary gate, preserving newest-first order.
+    # the v6 score schema / source-boundary gate, preserving newest-first order.
     status=$(jq -r --arg a "$article" --argjson v "$TRIBUNAL_VERSION" \
       'if ((.[$a].tribunalVersion // 0) >= $v) then (.[$a].status // "pending") else "pending" end' \
       "$PROGRESS_FILE" 2>/dev/null || echo "pending")

--- a/scripts/tribunal.sh
+++ b/scripts/tribunal.sh
@@ -580,7 +580,7 @@ PY
 import json, sys, math
 data = json.load(open(sys.argv[1]))
 dims = data.get('dimensions', {})
-vals = [dims.get(k, 0) for k in ('readability', 'firstImpression')]
+vals = [dims.get(k, 0) for k in ('readability', 'firstImpression', 'clarity')]
 composite = math.floor(sum(vals) / len(vals))
 sys.exit(0 if composite >= 8 else 1)
 PY
@@ -591,7 +591,7 @@ PY
 import json, sys, math
 data = json.load(open(sys.argv[1]))
 dims = data.get('dimensions', {})
-vals = [dims.get(k, 0) for k in ('persona', 'clawdNote', 'vibe', 'clarity', 'narrative')]
+vals = [dims.get(k, 0) for k in ('persona', 'clawdNote', 'vibe', 'narrative')]
 composite = math.floor(sum(vals) / len(vals))
 if composite < 8:
     sys.exit(1)

--- a/scripts/tribunal.sh
+++ b/scripts/tribunal.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# tribunal.sh — Tribunal v5 sequential tribunal (Codex/GPT-5.5 runner)
+# tribunal.sh — Tribunal v6 sequential tribunal (Codex/GPT-5.5 runner)
 #
 # Stages (in order):
 #   1. Fact Check (GPT-5.5) — source/commentary gate + fact bar, max 2 loops
@@ -41,7 +41,7 @@ POST_FILE=""
 ALLOW_REWRITE=""
 WRITE_FRONTMATTER=1
 SCORE_ONLY=0
-TRIBUNAL_VERSION=5
+TRIBUNAL_VERSION=6
 while [ "$#" -gt 0 ]; do
   case "$1" in
     --only-stage)
@@ -624,7 +624,7 @@ run_stage() {
 
   local post_path="$ROOT_DIR/src/content/posts/$post_file"
 
-  # Tribunal v5 executes every stage through Codex/GPT-5.5. Agent specs are
+  # Tribunal v6 executes every stage through Codex/GPT-5.5. Agent specs are
   # prompt contracts; the runtime model comes from this runner.
   local model_id="gpt-5.5"
 
@@ -969,7 +969,7 @@ init_article_progress "$POST_FILE"
 
 tlog "=== tribunal.sh: $POST_FILE ==="
 
-# ─── Tribunal v5 Sequential Loop ──────────────────────────────────────────────
+# ─── Tribunal v6 Sequential Loop ──────────────────────────────────────────────
 # Format: stage_key:agent_name:validate_name:label:max_loops:runner_label:fm_judge_key
 # fm_judge_key = frontmatter scores key (used by frontmatter-scores.mjs)
 declare -a STAGES=(

--- a/scripts/validate-judge-output.sh
+++ b/scripts/validate-judge-output.sh
@@ -84,12 +84,12 @@ case "$JUDGE" in
   freshEyes|fresh-eyes)
     validate_dim readability
     validate_dim firstImpression
+    validate_dim clarity
     ;;
   vibe|vibe-opus-scorer)
     validate_dim persona
     validate_dim clawdNote
     validate_dim vibe
-    validate_dim clarity
     validate_dim narrative
     ;;
   *)

--- a/scripts/validate-posts.mjs
+++ b/scripts/validate-posts.mjs
@@ -366,7 +366,10 @@ function validatePost(filepath, allPosts, options = {}) {
       ...validateScoreBlock(fmText, 'freshEyes', ['readability', 'firstImpression']),
       ...validateScoreBlock(fmText, 'vibe', ['persona', 'clawdNote', 'vibe', 'narrative'])
     );
-    if (!hasScoreDimension(fmText, 'freshEyes', 'clarity') && !hasScoreDimension(fmText, 'vibe', 'clarity')) {
+    if (
+      !hasScoreDimension(fmText, 'freshEyes', 'clarity') &&
+      !hasScoreDimension(fmText, 'vibe', 'clarity')
+    ) {
       errors.push('scores.freshEyes.clarity is required (legacy fallback: scores.vibe.clarity)');
     }
   }

--- a/scripts/validate-posts.mjs
+++ b/scripts/validate-posts.mjs
@@ -163,6 +163,12 @@ function validateScoreBlock(fmText, judge, dimensions) {
   return errors;
 }
 
+function hasScoreDimension(fmText, judge, dim) {
+  const block = getScoreBlock(fmText, judge);
+  if (!block) return false;
+  return new RegExp(`^    ${dim}:\\s*(?:10|[0-9])\\s*$`, 'm').test(block);
+}
+
 function extractClawdNotes(content) {
   const notes = [];
   const pattern = /<ClawdNote\b([^>]*)>([\s\S]*?)<\/ClawdNote>/g;
@@ -358,14 +364,11 @@ function validatePost(filepath, allPosts, options = {}) {
     }
     errors.push(
       ...validateScoreBlock(fmText, 'freshEyes', ['readability', 'firstImpression']),
-      ...validateScoreBlock(fmText, 'vibe', [
-        'persona',
-        'clawdNote',
-        'vibe',
-        'clarity',
-        'narrative',
-      ])
+      ...validateScoreBlock(fmText, 'vibe', ['persona', 'clawdNote', 'vibe', 'narrative'])
     );
+    if (!hasScoreDimension(fmText, 'freshEyes', 'clarity') && !hasScoreDimension(fmText, 'vibe', 'clarity')) {
+      errors.push('scores.freshEyes.clarity is required (legacy fallback: scores.vibe.clarity)');
+    }
   }
 
   // ── Rule 16: At least one kaomoji per post (brand voice) ──

--- a/scripts/vibe-scoring-standard.md
+++ b/scripts/vibe-scoring-standard.md
@@ -12,8 +12,8 @@ Tribunal v5 pipeline — 4 stages. All judges use **uniform 0-10 integer scale**
 |-------|-------|-------|------------|----------|
 | 1 | Fact Checker | GPT-5.5 | accuracy · fidelity · consistency · sourceBoundary · commentarySeparation | fact core avg ≥ 8 AND sourceBoundary ≥ 8 AND commentarySeparation ≥ 8 |
 | 2 | Librarian | GPT-5.5 | glossary · crossRef · sourceAlign · attribution | composite ≥ 8 |
-| 3 | Fresh Eyes | GPT-5.5 | readability · firstImpression | composite ≥ 8 |
-| 4 | Vibe | GPT-5.5 | persona · clawdNote · vibe · clarity · narrative | composite ≥ 8 AND one dim ≥ 9 AND no dim < 8 |
+| 3 | Fresh Eyes | GPT-5.5 | readability · firstImpression · clarity | composite ≥ 8 |
+| 4 | Vibe | GPT-5.5 | persona · clawdNote · vibe · narrative | composite ≥ 8 AND one dim ≥ 9 AND no dim < 8 |
 
 ## Uniform Agent Output JSON (v5)
 
@@ -218,7 +218,7 @@ Clawd/gu-log opinions, interpretation, jokes, and source-meta commentary belong 
 
 ---
 
-## Stage 3: Fresh Eyes (GPT-5.5) — 2 Dimensions
+## Stage 3: Fresh Eyes (GPT-5.5) — 3 Dimensions
 
 **Persona: developer with ~3 months of experience.** Impatient, scared of jargon, will close the tab after 2 boring paragraphs. Does NOT know what ShroomDog, Clawd, or OpenClaw are.
 
@@ -244,9 +244,16 @@ Clawd/gu-log opinions, interpretation, jokes, and source-meta commentary belong 
 
 **Sentence Signal Rule for Fresh Eyes:** if the post opens by repeating source metadata the reader already sees, or if multiple sentences have neither new information nor curiosity, cap `firstImpression` at 7. A smart impatient beginner does not reward throat-clearing.
 
+### clarity — Referents / Speaker Attribution / Reading Cleanliness
+
+The reader should not need to stop and ask "wait, who is doing what?" This includes:
+- fuzzy 我/你 shortcuts in body text when named referents would read cleaner
+- ambiguous speaker attribution between source, ShroomDog, and Clawd
+- zh-tw wording that feels half-translated or stuffed with unnecessary English, making the sentence harder to parse
+
 ---
 
-## Stage 4: Vibe Scorer (GPT-5.5, Opus-calibrated rubric) — 5 Dimensions
+## Stage 4: Vibe Scorer (GPT-5.5, Opus-calibrated rubric) — 4 Dimensions
 
 **Pass bar: composite ≥ 8 AND at least one dimension ≥ 9 AND no dimension < 8**
 
@@ -314,27 +321,6 @@ Strip away analogies, callbacks, and kaomoji. Is the remaining skeleton a linear
 **Sentence Signal Rule:** every sentence must be informative or intriguing. If a sentence only repeats source metadata, throat-clears, or restates what the reader already sees in the byline/source block, it is dead weight. Multiple dead sentences cap vibe at 7; a dead opening usually means the post should fail unless the rest recovers hard.
 
 **晶晶體 boundary:** Vibe Scorer must not invent its own English-term lint. For zh-tw posts, `scripts/check-jingjing.mjs` is the canonical programmatic gate and allowlist. If the checker returns clean, do not penalize accepted engineering terms such as `vs`, `bug`, `commit`, `PR`, model names, tool names, or glossary terms as hard-policy 晶晶體 hits. Penalize decorative English mixing only when the checker reports a violation, or when deterministic checker output is included in the evidence packet. The accepted-English boundary SHALL be discussed with ShroomDog every time a term is added to or removed from the checker/glossary acceptance set, because this boundary directly affects reading flow and only ShroomDog can decide which English terms feel natural in gu-log zh-tw prose.
-
-### clarity — Pronoun Clarity / Voice Attribution
-
-**What we're measuring:** Does every sentence make it obvious who is speaking?
-
-| Score | Description |
-|-------|-------------|
-| 10 | Every sentence has a clear speaker/subject. Zero ambiguous pronouns. |
-| 8 | Rare ambiguity. Pronouns used only in clearly scoped contexts (ClawdNote, blockquote). |
-| 6 | Some 你/我 slip through in body but context usually disambiguates. |
-| 4 | Frequent 你/我 in body. Reader has to guess who's speaking. |
-| 2 | Confusing mess. Can't tell if "I" is author, AI, or original source. |
-
-**EN version:** Pronoun prohibition doesn't apply. Instead: every "you/I" must have a clear referent.
-
-| Score | EN Clarity Description |
-|-------|------------------------|
-| 10 | Every "you/I" has clear referent. Reader always knows who is speaking. |
-| 8 | Rare ambiguity. "You" consistently addresses reader; "I" is always Clawd in ClawdNote. |
-| 6 | Occasional "we" ambiguity (Clawd + reader? Author + Anthropic?). |
-| 4 | Multiple instances where reader can't tell if "I" is Clawd, original author, or ShroomDog. |
 
 ### narrative — Narrative Structure / Rhythm / Emotional Arc
 

--- a/scripts/vibe-scoring-standard.md
+++ b/scripts/vibe-scoring-standard.md
@@ -1,12 +1,12 @@
 # Ralph Vibe Scoring Standard v2.0
 
 > Golden standard for evaluating gu-log post quality.
-> Tribunal v5 source-boundary update calibrated 2026-05-17 by ShroomDog + Clawd.
+> Tribunal v6 clarity rebalance calibrated 2026-05-23 by ShroomDog + Clawd.
 > **SSOT for all 4 tribunal judges + writer agent.**
 
 ## Tribunal System Overview
 
-Tribunal v5 pipeline — 4 stages. All judges use **uniform 0-10 integer scale**. Composite = `Math.floor(avg of all dims)`.
+Tribunal v6 pipeline — 4 stages. All judges use **uniform 0-10 integer scale**. Composite = `Math.floor(avg of all dims)`.
 
 | Stage | Judge | Model | Dimensions | Pass Bar |
 |-------|-------|-------|------------|----------|
@@ -15,7 +15,7 @@ Tribunal v5 pipeline — 4 stages. All judges use **uniform 0-10 integer scale**
 | 3 | Fresh Eyes | GPT-5.5 | readability · firstImpression · clarity | composite ≥ 8 |
 | 4 | Vibe | GPT-5.5 | persona · clawdNote · vibe · narrative | composite ≥ 8 AND one dim ≥ 9 AND no dim < 8 |
 
-## Uniform Agent Output JSON (v5)
+## Uniform Agent Output JSON (v6)
 
 All judges output the `BaseJudgeOutput` shape from `src/lib/tribunal-v2/types.ts`:
 
@@ -60,7 +60,7 @@ composite >= 8 && max(scores) >= 9 && min(scores) >= 8
 // Fresh Eyes, Librarian
 composite >= 8
 
-// Fact Checker v5
+// Fact Checker v6
 floor(avg(accuracy, fidelity, consistency)) >= 8
 sourceBoundary >= 8
 commentarySeparation >= 8

--- a/src/components/AiJudgeScore.astro
+++ b/src/components/AiJudgeScore.astro
@@ -5,8 +5,8 @@
  * 4 judges, uniform 0-10 scale, new dimension map:
  *   Librarian (Opus 4.7)    → glossary · crossRef · sourceAlign · attribution
  *   Fact Check (GPT-5.5)    → accuracy · fidelity · consistency · sourceBoundary · commentarySeparation
- *   Fresh Eyes (Opus 4.7)   → readability · firstImpression
- *   Vibe (Opus 4.6[1m])     → persona · clawdNote · vibe · clarity · narrative
+ *   Fresh Eyes (Opus 4.7)   → readability · firstImpression · clarity
+ *   Vibe (Opus 4.6[1m])     → persona · clawdNote · vibe · narrative
  *
  * Scores live in post frontmatter. No legacy keys (ralph/gemini/codex/sonnet).
  */
@@ -36,6 +36,7 @@ interface Props {
     freshEyes?: {
       readability?: number;
       firstImpression?: number;
+      clarity?: number;
       score: number;
       date: string;
       model?: string;
@@ -44,8 +45,8 @@ interface Props {
       persona?: number;
       clawdNote?: number;
       vibe?: number;
-      clarity?: number;
       narrative?: number;
+      clarity?: number; // legacy fallback: tribunal v5 before clarity moved to Fresh Eyes
       score: number;
       date: string;
       model?: string;
@@ -60,6 +61,7 @@ const hasScores =
   scores && (scores.librarian || scores.factCheck || scores.freshEyes || scores.vibe);
 
 const tribunalVersion = scores?.tribunalVersion ?? 3;
+const freshEyesClarity = scores?.freshEyes?.clarity ?? scores?.vibe?.clarity;
 
 function scoreColor(score: number): string {
   if (score >= 9) return 'score-high';
@@ -283,6 +285,12 @@ const labels = {
                   </strong>
                 </span>
               )}
+              {freshEyesClarity !== undefined && (
+                <span class="dim-item">
+                  <span class="dim-label">{labels.clarity}</span>
+                  <strong class={scoreColor(freshEyesClarity)}>{freshEyesClarity}</strong>
+                </span>
+              )}
             </div>
           </div>
         )}
@@ -331,12 +339,6 @@ const labels = {
                 <span class="dim-item">
                   <span class="dim-label">{labels.vibe_dim}</span>
                   <strong class={scoreColor(scores.vibe.vibe)}>{scores.vibe.vibe}</strong>
-                </span>
-              )}
-              {scores.vibe.clarity !== undefined && (
-                <span class="dim-item">
-                  <span class="dim-label">{labels.clarity}</span>
-                  <strong class={scoreColor(scores.vibe.clarity)}>{scores.vibe.clarity}</strong>
                 </span>
               )}
               {scores.vibe.narrative !== undefined && (
@@ -461,20 +463,20 @@ const labels = {
 
   /* Score value colors */
   .score-high {
-    color: #34d399; /* bright emerald — exceptional */
+    color: #7ea88f; /* muted sage — exceptional */
   }
   .score-pass {
-    color: #93a1a1; /* Solarized base1 — passing */
+    color: #9aa88f; /* subdued olive-sage — passing */
   }
   .score-fail {
     color: #e57373; /* soft red — failing */
   }
 
   :global([data-theme='light']) .score-high {
-    color: #047857;
+    color: #4f6f58;
   }
   :global([data-theme='light']) .score-pass {
-    color: #586e75;
+    color: #68755f;
   }
   :global([data-theme='light']) .score-fail {
     color: #b71c1c;
@@ -485,7 +487,7 @@ const labels = {
     color: #78b4ff;
   }
   .judge-color-factcheck {
-    color: #34d399;
+    color: #9f4b5d;
   }
   .judge-color-fresheyes {
     color: #c084fc;
@@ -498,7 +500,7 @@ const labels = {
     color: #1d4ed8;
   }
   :global([data-theme='light']) .judge-color-factcheck {
-    color: #047857;
+    color: #7f1d2d;
   }
   :global([data-theme='light']) .judge-color-fresheyes {
     color: #7e22ce;

--- a/src/components/AiJudgeScore.astro
+++ b/src/components/AiJudgeScore.astro
@@ -5,11 +5,16 @@
  * 4 judges, uniform 0-10 scale, new dimension map:
  *   Librarian (Opus 4.7)    → glossary · crossRef · sourceAlign · attribution
  *   Fact Check (GPT-5.5)    → accuracy · fidelity · consistency · sourceBoundary · commentarySeparation
- *   Fresh Eyes (Opus 4.7)   → readability · firstImpression · clarity
- *   Vibe (Opus 4.6[1m])     → persona · clawdNote · vibe · narrative
+ *   Fresh Eyes (Opus 4.7)   → readability · firstImpression · clarity (v6+)
+ *   Vibe (Opus 4.6[1m])     → persona · clawdNote · vibe · clarity (v5-) · narrative
  *
  * Scores live in post frontmatter. No legacy keys (ralph/gemini/codex/sonnet).
  */
+
+import {
+  resolveFreshEyesClarity,
+  resolveVibeClarity,
+} from '../utils/tribunal-score-panel';
 
 interface Props {
   scores?: {
@@ -61,7 +66,8 @@ const hasScores =
   scores && (scores.librarian || scores.factCheck || scores.freshEyes || scores.vibe);
 
 const tribunalVersion = scores?.tribunalVersion ?? 3;
-const freshEyesClarity = scores?.freshEyes?.clarity ?? scores?.vibe?.clarity;
+const freshEyesClarity = resolveFreshEyesClarity(scores);
+const vibeClarity = resolveVibeClarity(scores);
 
 function scoreColor(score: number): string {
   if (score >= 9) return 'score-high';
@@ -341,6 +347,12 @@ const labels = {
                   <strong class={scoreColor(scores.vibe.vibe)}>{scores.vibe.vibe}</strong>
                 </span>
               )}
+              {vibeClarity !== undefined && (
+                <span class="dim-item">
+                  <span class="dim-label">{labels.clarity}</span>
+                  <strong class={scoreColor(vibeClarity)}>{vibeClarity}</strong>
+                </span>
+              )}
               {scores.vibe.narrative !== undefined && (
                 <span class="dim-item">
                   <span class="dim-label">{labels.narrative}</span>
@@ -363,13 +375,16 @@ const labels = {
     border-radius: 8px;
     border: 1px solid var(--color-border);
     font-size: 0.85rem;
+    text-align: left;
   }
 
   .judge-header {
     margin-bottom: 0.75rem;
     display: flex;
-    justify-content: space-between;
-    align-items: center;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.2rem;
+    text-align: left;
   }
 
   .judge-title {
@@ -408,12 +423,17 @@ const labels = {
     display: flex;
     flex-direction: column;
     gap: 0.4rem;
+    align-items: flex-start;
+    text-align: left;
   }
 
   .card-header {
     display: flex;
     align-items: center;
     gap: 0.5rem;
+    width: 100%;
+    justify-content: flex-start;
+    text-align: left;
   }
 
   .judge-icon {
@@ -427,6 +447,8 @@ const labels = {
     flex-direction: column;
     gap: 0.1rem;
     min-width: 0;
+    align-items: flex-start;
+    text-align: left;
   }
 
   .judge-name {
@@ -440,6 +462,8 @@ const labels = {
     font-weight: 700;
     line-height: 1;
     margin: 0.1rem 0;
+    width: 100%;
+    text-align: left;
   }
 
   .score-denom {
@@ -463,20 +487,20 @@ const labels = {
 
   /* Score value colors */
   .score-high {
-    color: #7ea88f; /* muted sage — exceptional */
+    color: #88a17f; /* muted sage — exceptional */
   }
   .score-pass {
-    color: #9aa88f; /* subdued olive-sage — passing */
+    color: #738b6c; /* softened olive-sage — passing */
   }
   .score-fail {
-    color: #e57373; /* soft red — failing */
+    color: #e09a9a; /* brighter dusty rose — failing */
   }
 
   :global([data-theme='light']) .score-high {
-    color: #4f6f58;
+    color: #55704d;
   }
   :global([data-theme='light']) .score-pass {
-    color: #68755f;
+    color: #65795e;
   }
   :global([data-theme='light']) .score-fail {
     color: #b71c1c;
@@ -487,7 +511,7 @@ const labels = {
     color: #78b4ff;
   }
   .judge-color-factcheck {
-    color: #9f4b5d;
+    color: #b8657d;
   }
   .judge-color-fresheyes {
     color: #c084fc;
@@ -500,7 +524,7 @@ const labels = {
     color: #1d4ed8;
   }
   :global([data-theme='light']) .judge-color-factcheck {
-    color: #7f1d2d;
+    color: #8f3852;
   }
   :global([data-theme='light']) .judge-color-fresheyes {
     color: #7e22ce;
@@ -510,19 +534,24 @@ const labels = {
   }
 
   .dim-list {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.2rem 0.15rem;
-    align-items: center;
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 0.18rem;
+    align-items: start;
+    justify-items: start;
     color: var(--color-text-muted);
     font-size: 0.7rem;
     margin-top: 0.1rem;
+    width: 100%;
+    text-align: left;
   }
 
   .dim-item {
     display: flex;
-    gap: 0.2rem;
+    gap: 0.35rem;
     align-items: baseline;
+    justify-content: flex-start;
+    width: 100%;
   }
 
   .dim-label {
@@ -535,10 +564,4 @@ const labels = {
     font-size: 0.75rem;
   }
 
-  .dim-item + .dim-item::before {
-    content: '·';
-    color: var(--color-border);
-    font-size: 0.7rem;
-    margin-right: 0.15rem;
-  }
 </style>

--- a/src/components/AiJudgeScore.astro
+++ b/src/components/AiJudgeScore.astro
@@ -406,11 +406,11 @@ const labels = {
 
   @media (max-width: 639px) {
     .judge-cards {
-      grid-template-columns: 1fr 1fr;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
     }
   }
 
-  @media (max-width: 399px) {
+  @media (max-width: 339px) {
     .judge-cards {
       grid-template-columns: 1fr;
     }

--- a/src/components/AiJudgeScore.astro
+++ b/src/components/AiJudgeScore.astro
@@ -11,10 +11,7 @@
  * Scores live in post frontmatter. No legacy keys (ralph/gemini/codex/sonnet).
  */
 
-import {
-  resolveFreshEyesClarity,
-  resolveVibeClarity,
-} from '../utils/tribunal-score-panel';
+import { resolveFreshEyesClarity, resolveVibeClarity } from '../utils/tribunal-score-panel';
 
 interface Props {
   scores?: {
@@ -563,5 +560,4 @@ const labels = {
     font-weight: 600;
     font-size: 0.75rem;
   }
-
 </style>

--- a/src/components/AiJudgeScore.astro
+++ b/src/components/AiJudgeScore.astro
@@ -46,7 +46,7 @@ interface Props {
       clawdNote?: number;
       vibe?: number;
       narrative?: number;
-      clarity?: number; // legacy fallback: tribunal v5 before clarity moved to Fresh Eyes
+      clarity?: number; // legacy fallback: tribunal v5 and earlier before clarity moved to Fresh Eyes
       score: number;
       date: string;
       model?: string;

--- a/src/components/Stage4DegradedBanner.astro
+++ b/src/components/Stage4DegradedBanner.astro
@@ -14,7 +14,7 @@ interface Stage4Scores {
   persona: number;
   clawdNote: number;
   vibe: number;
-  clarity: number;
+  clarity?: number;
   narrative: number;
   degradedDimensions?: string[];
   isDegraded: boolean;

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -52,7 +52,7 @@ const postsCollection = defineCollection({
           persona: z.number().min(0).max(10),
           clawdNote: z.number().min(0).max(10),
           vibe: z.number().min(0).max(10),
-          clarity: z.number().min(0).max(10).optional(), // legacy v5 before clarity moved to Fresh Eyes
+          clarity: z.number().min(0).max(10).optional(), // legacy v5 and earlier before clarity moved to Fresh Eyes
           narrative: z.number().min(0).max(10),
           degradedDimensions: z.array(z.string()).optional(),
           isDegraded: z.boolean(),

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -52,7 +52,7 @@ const postsCollection = defineCollection({
           persona: z.number().min(0).max(10),
           clawdNote: z.number().min(0).max(10),
           vibe: z.number().min(0).max(10),
-          clarity: z.number().min(0).max(10),
+          clarity: z.number().min(0).max(10).optional(), // legacy v5 before clarity moved to Fresh Eyes
           narrative: z.number().min(0).max(10),
           degradedDimensions: z.array(z.string()).optional(),
           isDegraded: z.boolean(),
@@ -91,6 +91,7 @@ const postsCollection = defineCollection({
             .object({
               readability: z.number().min(0).max(10).optional(),
               firstImpression: z.number().min(0).max(10).optional(),
+              clarity: z.number().min(0).max(10).optional(),
               score: z.number().min(0).max(10),
               date: z.string(),
               model: z.string().optional(),
@@ -101,7 +102,7 @@ const postsCollection = defineCollection({
               persona: z.number().min(0).max(10).optional(),
               clawdNote: z.number().min(0).max(10).optional(),
               vibe: z.number().min(0).max(10).optional(),
-              clarity: z.number().min(0).max(10).optional(),
+              clarity: z.number().min(0).max(10).optional(), // legacy compatibility
               narrative: z.number().min(0).max(10).optional(),
               score: z.number().min(0).max(10),
               date: z.string(),

--- a/src/lib/tribunal-v2/git-format.ts
+++ b/src/lib/tribunal-v2/git-format.ts
@@ -39,7 +39,7 @@ export function tribunalBranchName(articlePath: string): string {
 // ---------------------------------------------------------------------------
 
 function formatVibeScores(scores: VibeJudgeOutput['scores']): string {
-  return `persona:${scores.persona} clawdNote:${scores.clawdNote} vibe:${scores.vibe} clarity:${scores.clarity} narrative:${scores.narrative}`;
+  return `persona:${scores.persona} clawdNote:${scores.clawdNote} vibe:${scores.vibe} narrative:${scores.narrative}`;
 }
 
 function formatStageStatus<T>(label: string, stage: StageResult<T>, detail?: string): string {
@@ -66,7 +66,7 @@ function formatStageStatus<T>(label: string, stage: StageResult<T>, detail?: str
  * tribunal: CP-280 延遲降低 40% 的新框架
  *
  * Stage 0: PASS (no warn)
- * Stage 1: PASS @ loop 2/3 (persona:9 clawdNote:8 vibe:9 clarity:8 narrative:8)
+ * Stage 1: PASS @ loop 2/3 (persona:9 clawdNote:8 vibe:9 narrative:8)
  * Stage 2: PASS @ loop 1/2
  * Stage 3: PASS @ loop 1/2 (fact:9 lib:8)
  * Stage 4: PASS @ loop 1/2 (no regression)

--- a/src/lib/tribunal-v2/pass-bar.ts
+++ b/src/lib/tribunal-v2/pass-bar.ts
@@ -10,7 +10,7 @@ import type { VibeJudgeOutput } from './types';
 
 type VibeScores = VibeJudgeOutput['scores'];
 
-const VIBE_DIMS = ['persona', 'clawdNote', 'vibe', 'clarity', 'narrative'] as const;
+const VIBE_DIMS = ['persona', 'clawdNote', 'vibe', 'narrative'] as const;
 
 /** Check if Stage 1 Vibe scores pass the bar */
 export function checkVibePassBar(scores: VibeScores): {
@@ -71,11 +71,12 @@ export function checkFinalVibePassBar(
 export function checkFreshEyesPassBar(scores: {
   readability: number;
   firstImpression: number;
+  clarity: number;
 }): {
   pass: boolean;
   composite: number;
 } {
-  const composite = Math.floor((scores.readability + scores.firstImpression) / 2);
+  const composite = Math.floor((scores.readability + scores.firstImpression + scores.clarity) / 3);
   return {
     pass: composite >= PASS_BARS.STAGE_2_COMPOSITE,
     composite,

--- a/src/lib/tribunal-v2/pipeline.ts
+++ b/src/lib/tribunal-v2/pipeline.ts
@@ -142,8 +142,8 @@ const FRONTMATTER_DIM_MAP: Record<
   string,
   { fmKey: FrontmatterJudgeKey; dims: readonly string[] }
 > = {
-  stage1: { fmKey: 'vibe', dims: ['persona', 'clawdNote', 'vibe', 'clarity', 'narrative'] },
-  stage2: { fmKey: 'freshEyes', dims: ['readability', 'firstImpression'] },
+  stage1: { fmKey: 'vibe', dims: ['persona', 'clawdNote', 'vibe', 'narrative'] },
+  stage2: { fmKey: 'freshEyes', dims: ['readability', 'firstImpression', 'clarity'] },
   stage3fact: {
     fmKey: 'factCheck',
     dims: ['accuracy', 'fidelity', 'consistency'],

--- a/src/lib/tribunal-v2/runners/stage-runners.ts
+++ b/src/lib/tribunal-v2/runners/stage-runners.ts
@@ -135,7 +135,7 @@ export const stage2JudgeRunner: StageRunner<
       timeoutSec: TIMEOUT.JUDGE_FRESH_EYES,
       buildPrompt: (outputPath) => `Fresh-eyes review this post: ${articlePath}
 
-Score readability and firstImpression from a 3-month engineer persona per your agent instructions.
+Score readability, firstImpression, and clarity from a 3-month engineer persona per your agent instructions.
 
 Write the v2 FreshEyesJudgeOutput JSON to: ${outputPath}
 Confirm with a one-line status on stdout.`,

--- a/src/lib/tribunal-v2/types.ts
+++ b/src/lib/tribunal-v2/types.ts
@@ -71,7 +71,6 @@ export interface VibeJudgeOutput extends BaseJudgeOutput {
     persona: number;
     clawdNote: number;
     vibe: number;
-    clarity: number;
     narrative: number;
   };
 }
@@ -103,6 +102,7 @@ export interface FreshEyesJudgeOutput extends BaseJudgeOutput {
   scores: {
     readability: number;
     firstImpression: number;
+    clarity: number;
   };
 }
 

--- a/src/utils/tribunal-score-panel.ts
+++ b/src/utils/tribunal-score-panel.ts
@@ -1,0 +1,23 @@
+type TribunalPanelScores = {
+  tribunalVersion?: number;
+  freshEyes?: {
+    clarity?: number;
+  };
+  vibe?: {
+    clarity?: number;
+  };
+};
+
+export function clarityLivesInFreshEyes(tribunalVersion?: number): boolean {
+  return (tribunalVersion ?? 3) >= 6;
+}
+
+export function resolveFreshEyesClarity(scores?: TribunalPanelScores): number | undefined {
+  if (!scores || !clarityLivesInFreshEyes(scores.tribunalVersion)) return undefined;
+  return scores.freshEyes?.clarity ?? scores.vibe?.clarity;
+}
+
+export function resolveVibeClarity(scores?: TribunalPanelScores): number | undefined {
+  if (!scores || clarityLivesInFreshEyes(scores.tribunalVersion)) return undefined;
+  return scores.vibe?.clarity ?? scores.freshEyes?.clarity;
+}

--- a/tests/content-gates.test.ts
+++ b/tests/content-gates.test.ts
@@ -233,12 +233,16 @@ describe('frontmatter-scores', () => {
     expect(fmScores.VALID_JUDGES).toEqual(['librarian', 'factCheck', 'freshEyes', 'vibe']);
   });
 
-  it('JUDGE_DIMS has 5 vibe dimensions', () => {
+  it('JUDGE_DIMS matches post-clarity-move schema', () => {
+    expect(fmScores.JUDGE_DIMS.freshEyes).toEqual([
+      'readability',
+      'firstImpression',
+      'clarity',
+    ]);
     expect(fmScores.JUDGE_DIMS.vibe).toEqual([
       'persona',
       'clawdNote',
       'vibe',
-      'clarity',
       'narrative',
     ]);
   });

--- a/tests/tribunal-score-panel.spec.ts
+++ b/tests/tribunal-score-panel.spec.ts
@@ -73,7 +73,7 @@ test('tribunal fact-check accent stays wine-red in dark theme', async ({ page })
   expect(b).toBeGreaterThan(g);
 });
 
-test('tribunal score panel collapses to a single column on a narrow phone', async ({ page }) => {
+test('tribunal score panel keeps two columns on a typical phone width', async ({ page }) => {
   await page.setViewportSize({ width: 390, height: 844 });
   await page.goto(POST_WITH_TRIBUNAL, { waitUntil: 'domcontentloaded' });
 
@@ -87,6 +87,27 @@ test('tribunal score panel collapses to a single column on a narrow phone', asyn
     }),
   );
 
-  expect(positions[1].top).toBeGreaterThan(positions[0].top);
+  expect(Math.abs(positions[1].top - positions[0].top)).toBeLessThan(2);
+  expect(positions[1].left).toBeGreaterThan(positions[0].left + 20);
+  expect(positions[2].top).toBeGreaterThan(positions[0].top + 20);
+});
+
+test('tribunal score panel still collapses to one column on extra narrow screens', async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 320, height: 844 });
+  await page.goto(POST_WITH_TRIBUNAL, { waitUntil: 'domcontentloaded' });
+
+  const cards = page.locator('.judge-card');
+  await expect(cards).toHaveCount(4);
+
+  const positions = await cards.evaluateAll((nodes) =>
+    nodes.map((node) => {
+      const rect = node.getBoundingClientRect();
+      return { top: rect.top, left: rect.left };
+    }),
+  );
+
+  expect(positions[1].top).toBeGreaterThan(positions[0].top + 20);
   expect(Math.abs(positions[1].left - positions[0].left)).toBeLessThan(2);
 });

--- a/tests/tribunal-score-panel.spec.ts
+++ b/tests/tribunal-score-panel.spec.ts
@@ -1,0 +1,92 @@
+import { test, expect } from './fixtures';
+
+const POST_WITH_TRIBUNAL = '/posts/sd-23-20260510-ai-dota-teammates';
+
+test('tribunal v5 keeps clarity under vibe judge', async ({ page }) => {
+  await page.goto(POST_WITH_TRIBUNAL, { waitUntil: 'domcontentloaded' });
+
+  const vibeCard = page.locator('.judge-card').filter({ hasText: 'Vibe' });
+  const freshEyesCard = page.locator('.judge-card').filter({ hasText: 'Fresh Eyes' });
+
+  await expect(vibeCard).toContainText('Clarity');
+  await expect(freshEyesCard).not.toContainText('Clarity');
+});
+
+test('tribunal score panel stays left-aligned in dark theme', async ({ page }) => {
+  await page.addInitScript(() => localStorage.setItem('theme', 'dark'));
+  await page.goto(POST_WITH_TRIBUNAL, { waitUntil: 'domcontentloaded' });
+  await page.evaluate(() => document.documentElement.setAttribute('data-theme', 'dark'));
+
+  const panel = page.locator('.ai-judge-panel');
+  await expect(panel).toBeVisible();
+
+  const styles = await page.evaluate(() => {
+    const panel = document.querySelector('.ai-judge-panel');
+    const header = panel?.querySelector('.judge-header');
+    const card = panel?.querySelector('.judge-card');
+    const dimList = panel?.querySelector('.dim-list');
+
+    if (!panel || !header || !card || !dimList) {
+      throw new Error('Tribunal score panel structure is incomplete');
+    }
+
+    return {
+      panelTextAlign: getComputedStyle(panel).textAlign,
+      headerFlexDirection: getComputedStyle(header).flexDirection,
+      headerAlignItems: getComputedStyle(header).alignItems,
+      cardTextAlign: getComputedStyle(card).textAlign,
+      cardAlignItems: getComputedStyle(card).alignItems,
+      dimListTextAlign: getComputedStyle(dimList).textAlign,
+      dimListDisplay: getComputedStyle(dimList).display,
+    };
+  });
+
+  expect(['left', 'start']).toContain(styles.panelTextAlign);
+  expect(styles.headerFlexDirection).toBe('column');
+  expect(styles.headerAlignItems).toBe('flex-start');
+  expect(['left', 'start']).toContain(styles.cardTextAlign);
+  expect(styles.cardAlignItems).toBe('flex-start');
+  expect(['left', 'start']).toContain(styles.dimListTextAlign);
+  expect(styles.dimListDisplay).toBe('grid');
+});
+
+test('tribunal fact-check accent stays wine-red in dark theme', async ({ page }) => {
+  await page.addInitScript(() => localStorage.setItem('theme', 'dark'));
+  await page.goto(POST_WITH_TRIBUNAL, { waitUntil: 'domcontentloaded' });
+  await page.evaluate(() => document.documentElement.setAttribute('data-theme', 'dark'));
+
+  const accent = page.locator('.judge-card .judge-color-factcheck').first();
+  await expect(accent).toBeVisible();
+
+  const [r, g, b] = await accent.evaluate((node) => {
+    const match = getComputedStyle(node).color.match(/\d+/g);
+    if (!match || match.length < 3) {
+      throw new Error('Fact Check accent did not resolve to an rgb color');
+    }
+
+    return match.slice(0, 3).map(Number);
+  });
+
+  expect(r).toBeGreaterThan(150);
+  expect(g).toBeLessThan(140);
+  expect(r).toBeGreaterThan(g);
+  expect(b).toBeGreaterThan(g);
+});
+
+test('tribunal score panel collapses to a single column on a narrow phone', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto(POST_WITH_TRIBUNAL, { waitUntil: 'domcontentloaded' });
+
+  const cards = page.locator('.judge-card');
+  await expect(cards).toHaveCount(4);
+
+  const positions = await cards.evaluateAll((nodes) =>
+    nodes.map((node) => {
+      const rect = node.getBoundingClientRect();
+      return { top: rect.top, left: rect.left };
+    }),
+  );
+
+  expect(positions[1].top).toBeGreaterThan(positions[0].top);
+  expect(Math.abs(positions[1].left - positions[0].left)).toBeLessThan(2);
+});

--- a/tests/tribunal-score-panel.test.ts
+++ b/tests/tribunal-score-panel.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import {
+  clarityLivesInFreshEyes,
+  resolveFreshEyesClarity,
+  resolveVibeClarity,
+} from '../src/utils/tribunal-score-panel';
+
+describe('tribunal score panel clarity placement', () => {
+  it('keeps clarity under Vibe for tribunal v5', () => {
+    const scores = {
+      tribunalVersion: 5,
+      vibe: { clarity: 9 },
+      freshEyes: { clarity: 7 },
+    };
+
+    expect(clarityLivesInFreshEyes(scores.tribunalVersion)).toBe(false);
+    expect(resolveVibeClarity(scores)).toBe(9);
+    expect(resolveFreshEyesClarity(scores)).toBeUndefined();
+  });
+
+  it('moves clarity to Fresh Eyes for tribunal v6', () => {
+    const scores = {
+      tribunalVersion: 6,
+      vibe: { clarity: 8 },
+      freshEyes: { clarity: 9 },
+    };
+
+    expect(clarityLivesInFreshEyes(scores.tribunalVersion)).toBe(true);
+    expect(resolveFreshEyesClarity(scores)).toBe(9);
+    expect(resolveVibeClarity(scores)).toBeUndefined();
+  });
+
+  it('uses legacy vibe clarity as a fallback when a v6 post has not been backfilled yet', () => {
+    const scores = {
+      tribunalVersion: 6,
+      vibe: { clarity: 8 },
+      freshEyes: {},
+    };
+
+    expect(resolveFreshEyesClarity(scores)).toBe(8);
+    expect(resolveVibeClarity(scores)).toBeUndefined();
+  });
+});

--- a/tests/tribunal-v2/claude-cli.test.ts
+++ b/tests/tribunal-v2/claude-cli.test.ts
@@ -58,7 +58,6 @@ describe('extractJson — v1 → v2 migration safety', () => {
     "persona": 8,
     "clawdNote": 8,
     "vibe": 8,
-    "clarity": 9,
     "narrative": 9
   },
   "composite": 8,
@@ -76,7 +75,7 @@ describe('extractJson — v1 → v2 migration safety', () => {
       timestamp: string;
     };
     expect(parsed.pass).toBe(true);
-    expect(parsed.scores.clarity).toBe(9);
+    expect(parsed.scores.narrative).toBe(9);
     expect(parsed.composite).toBe(8);
     expect(parsed.judge_version).toBe('2.0.0');
   });

--- a/tests/tribunal-v2/pass-bar.test.ts
+++ b/tests/tribunal-v2/pass-bar.test.ts
@@ -7,15 +7,15 @@ import {
 } from '../../src/lib/tribunal-v2/pass-bar';
 
 // ============================================================================
-// Stage 1: Absolute pass bar (5-dim integer scoring)
+// Stage 1: Absolute pass bar (4-dim integer scoring)
 // ============================================================================
 
 describe('checkVibePassBar (Stage 1)', () => {
   it('passes when composite >=8 AND one dim >=9 AND all dims >=8', () => {
     const result = checkVibePassBar({
-      persona: 9, clawdNote: 8, vibe: 8, clarity: 8, narrative: 8,
+      persona: 9, clawdNote: 8, vibe: 8, narrative: 8,
     });
-    // composite: floor((9+8+8+8+8)/5) = floor(8.2) = 8
+    // composite: floor((9+8+8+8)/4) = 8
     expect(result.pass).toBe(true);
     expect(result.composite).toBe(8);
     expect(result.hasHighlight).toBe(true);
@@ -24,7 +24,7 @@ describe('checkVibePassBar (Stage 1)', () => {
 
   it('fails when no dim reaches 9 (no highlight)', () => {
     const result = checkVibePassBar({
-      persona: 8, clawdNote: 8, vibe: 8, clarity: 8, narrative: 8,
+      persona: 8, clawdNote: 8, vibe: 8, narrative: 8,
     });
     // composite=8, max=8 → no highlight → fail
     expect(result.pass).toBe(false);
@@ -35,9 +35,9 @@ describe('checkVibePassBar (Stage 1)', () => {
 
   it('fails when one dim is 7 even if others are 10', () => {
     const result = checkVibePassBar({
-      persona: 10, clawdNote: 10, vibe: 10, clarity: 10, narrative: 7,
+      persona: 10, clawdNote: 10, vibe: 10, narrative: 7,
     });
-    // composite: floor(47/5) = 9, highlight=true, but 7<8 → fail
+    // composite: floor(37/4) = 9, highlight=true, but 7<8 → fail
     expect(result.pass).toBe(false);
     expect(result.composite).toBe(9);
     expect(result.hasHighlight).toBe(true);
@@ -46,36 +46,35 @@ describe('checkVibePassBar (Stage 1)', () => {
 
   it('fails when composite <8', () => {
     const result = checkVibePassBar({
-      persona: 9, clawdNote: 8, vibe: 8, clarity: 7, narrative: 7,
+      persona: 9, clawdNote: 8, vibe: 7, narrative: 7,
     });
-    // composite: floor(39/5) = 7
+    // composite: floor(31/4) = 7
     expect(result.pass).toBe(false);
     expect(result.composite).toBe(7);
   });
 
   it('uses floor for composite (not round)', () => {
-    // sum=42, avg=8.4 → floor=8
+    // sum=34, avg=8.5 → floor=8
     const r1 = checkVibePassBar({
-      persona: 9, clawdNote: 9, vibe: 8, clarity: 8, narrative: 8,
+      persona: 9, clawdNote: 9, vibe: 8, narrative: 8,
     });
     expect(r1.composite).toBe(8);
     expect(r1.pass).toBe(true);
 
-    // sum=43, avg=8.6 → floor=8 (not 9)
+    // sum=35, avg=8.75 → floor=8 (not 9)
     const r2 = checkVibePassBar({
-      persona: 9, clawdNote: 9, vibe: 9, clarity: 8, narrative: 8,
+      persona: 9, clawdNote: 9, vibe: 9, narrative: 8,
     });
     expect(r2.composite).toBe(8);
     expect(r2.pass).toBe(true);
   });
 
-  it('throws if any of the 5 dims is missing', () => {
+  it('throws if any of the 4 dims is missing', () => {
     expect(() =>
       checkVibePassBar({
         persona: 9,
         clawdNote: 8,
         vibe: 8,
-        clarity: 8,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } as any),
     ).toThrow('Missing required dimension: narrative');
@@ -83,7 +82,7 @@ describe('checkVibePassBar (Stage 1)', () => {
 
   it('passes with all 10s (perfect score)', () => {
     const result = checkVibePassBar({
-      persona: 10, clawdNote: 10, vibe: 10, clarity: 10, narrative: 10,
+      persona: 10, clawdNote: 10, vibe: 10, narrative: 10,
     });
     expect(result.pass).toBe(true);
     expect(result.composite).toBe(10);
@@ -91,7 +90,7 @@ describe('checkVibePassBar (Stage 1)', () => {
 
   it('reports multiple failed dimensions', () => {
     const result = checkVibePassBar({
-      persona: 9, clawdNote: 7, vibe: 6, clarity: 8, narrative: 8,
+      persona: 9, clawdNote: 7, vibe: 6, narrative: 8,
     });
     expect(result.failedDimensions).toEqual(['clawdNote', 'vibe']);
   });
@@ -102,11 +101,11 @@ describe('checkVibePassBar (Stage 1)', () => {
 // ============================================================================
 
 describe('checkFinalVibePassBar (Stage 4)', () => {
-  const stage1 = { persona: 9, clawdNote: 8, vibe: 8, clarity: 8, narrative: 8 };
+  const stage1 = { persona: 9, clawdNote: 8, vibe: 8, narrative: 8 };
 
   it('passes when all dims equal Stage 1 scores', () => {
     const result = checkFinalVibePassBar(
-      { persona: 9, clawdNote: 8, vibe: 8, clarity: 8, narrative: 8 },
+      { persona: 9, clawdNote: 8, vibe: 8, narrative: 8 },
       stage1,
     );
     expect(result.pass).toBe(true);
@@ -115,7 +114,7 @@ describe('checkFinalVibePassBar (Stage 4)', () => {
 
   it('passes when dims improved', () => {
     const result = checkFinalVibePassBar(
-      { persona: 10, clawdNote: 9, vibe: 8, clarity: 8, narrative: 8 },
+      { persona: 10, clawdNote: 9, vibe: 8, narrative: 8 },
       stage1,
     );
     expect(result.pass).toBe(true);
@@ -123,9 +122,9 @@ describe('checkFinalVibePassBar (Stage 4)', () => {
   });
 
   it('passes when dims dropped by exactly 1 (boundary)', () => {
-    const s1 = { persona: 9, clawdNote: 9, vibe: 9, clarity: 9, narrative: 9 };
+    const s1 = { persona: 9, clawdNote: 9, vibe: 9, narrative: 9 };
     const result = checkFinalVibePassBar(
-      { persona: 8, clawdNote: 8, vibe: 8, clarity: 8, narrative: 8 },
+      { persona: 8, clawdNote: 8, vibe: 8, narrative: 8 },
       s1,
     );
     // -1 each, but > 1 is the threshold, so exactly 1 = pass
@@ -135,7 +134,7 @@ describe('checkFinalVibePassBar (Stage 4)', () => {
 
   it('fails when any dim dropped by 2', () => {
     const result = checkFinalVibePassBar(
-      { persona: 7, clawdNote: 8, vibe: 8, clarity: 8, narrative: 8 },
+      { persona: 7, clawdNote: 8, vibe: 8, narrative: 8 },
       stage1,
     );
     expect(result.pass).toBe(false);
@@ -145,9 +144,9 @@ describe('checkFinalVibePassBar (Stage 4)', () => {
   });
 
   it('reports all degraded dims, not just the first', () => {
-    const s1 = { persona: 9, clawdNote: 9, vibe: 9, clarity: 8, narrative: 8 };
+    const s1 = { persona: 9, clawdNote: 9, vibe: 9, narrative: 8 };
     const result = checkFinalVibePassBar(
-      { persona: 7, clawdNote: 7, vibe: 9, clarity: 8, narrative: 8 },
+      { persona: 7, clawdNote: 7, vibe: 9, narrative: 8 },
       s1,
     );
     expect(result.pass).toBe(false);
@@ -158,7 +157,7 @@ describe('checkFinalVibePassBar (Stage 4)', () => {
 
   it('handles asymmetric: some improved, some degraded', () => {
     const result = checkFinalVibePassBar(
-      { persona: 10, clawdNote: 8, vibe: 6, clarity: 8, narrative: 8 },
+      { persona: 10, clawdNote: 8, vibe: 6, narrative: 8 },
       stage1,
     );
     // persona improved +1, vibe degraded -2 → still fail
@@ -175,34 +174,34 @@ describe('checkFinalVibePassBar (Stage 4)', () => {
 
 describe('checkFreshEyesPassBar (Stage 2)', () => {
   it('passes when composite >= 8', () => {
-    const result = checkFreshEyesPassBar({ readability: 9, firstImpression: 8 });
-    // floor((9+8)/2) = floor(8.5) = 8
+    const result = checkFreshEyesPassBar({ readability: 9, firstImpression: 8, clarity: 8 });
+    // floor((9+8+8)/3) = floor(8.33) = 8
     expect(result.pass).toBe(true);
     expect(result.composite).toBe(8);
   });
 
   it('fails when composite < 8', () => {
-    const result = checkFreshEyesPassBar({ readability: 7, firstImpression: 8 });
-    // floor((7+8)/2) = floor(7.5) = 7
+    const result = checkFreshEyesPassBar({ readability: 7, firstImpression: 8, clarity: 7 });
+    // floor((7+8+7)/3) = floor(7.33) = 7
     expect(result.pass).toBe(false);
     expect(result.composite).toBe(7);
   });
 
   it('uses floor not round', () => {
-    const result = checkFreshEyesPassBar({ readability: 9, firstImpression: 7 });
-    // floor((9+7)/2) = floor(8) = 8
+    const result = checkFreshEyesPassBar({ readability: 9, firstImpression: 8, clarity: 7 });
+    // floor((9+8+7)/3) = floor(8) = 8
     expect(result.pass).toBe(true);
     expect(result.composite).toBe(8);
   });
 
   it('passes with perfect scores', () => {
-    const result = checkFreshEyesPassBar({ readability: 10, firstImpression: 10 });
+    const result = checkFreshEyesPassBar({ readability: 10, firstImpression: 10, clarity: 10 });
     expect(result.pass).toBe(true);
     expect(result.composite).toBe(10);
   });
 
   it('fails with all 7s', () => {
-    const result = checkFreshEyesPassBar({ readability: 7, firstImpression: 7 });
+    const result = checkFreshEyesPassBar({ readability: 7, firstImpression: 7, clarity: 7 });
     expect(result.pass).toBe(false);
     expect(result.composite).toBe(7);
   });

--- a/tests/tribunal-v2/pipeline.test.ts
+++ b/tests/tribunal-v2/pipeline.test.ts
@@ -86,7 +86,6 @@ const PASSING_SCORES: VibeJudgeOutput['scores'] = {
   persona: 9,
   clawdNote: 8,
   vibe: 8,
-  clarity: 8,
   narrative: 8,
 };
 
@@ -94,14 +93,13 @@ const FAILING_SCORES: VibeJudgeOutput['scores'] = {
   persona: 7,
   clawdNote: 7,
   vibe: 7,
-  clarity: 7,
   narrative: 7,
 };
 
 function freshEyesPass(): FreshEyesJudgeOutput {
   return {
     pass: true,
-    scores: { readability: 8, firstImpression: 8 },
+    scores: { readability: 8, firstImpression: 8, clarity: 8 },
     composite: 8,
     judge_model: 'mock',
     judge_version: '2.0.0',
@@ -411,7 +409,7 @@ describe('pipeline — writer-constraint enforcement', () => {
     const git = mockGit();
 
     // Stage 1 scores: all high
-    const stage1Scores = { persona: 9, clawdNote: 9, vibe: 9, clarity: 9, narrative: 9 };
+    const stage1Scores = { persona: 9, clawdNote: 9, vibe: 9, narrative: 9 };
 
     const config: PipelineConfig = {
       ...passThroughConfig(),
@@ -423,7 +421,7 @@ describe('pipeline — writer-constraint enforcement', () => {
         stage4Judge: {
           run: async ({ stage1Scores: s1 }) => ({
             pass: true, // model claims pass
-            scores: { ...stage1Scores, clarity: 6 }, // but clarity dropped 3 points (> 1 regression)
+            scores: { ...stage1Scores, narrative: 6 }, // narrative dropped 3 points (> 1 regression)
             composite: 8,
             stage_1_scores: s1,
             degraded_dimensions: [], // and model forgot to report it
@@ -445,7 +443,7 @@ describe('pipeline — writer-constraint enforcement', () => {
     const stage4Out = final.stages.stage4.output;
     expect(stage4Out?.pass).toBe(false);
     expect(stage4Out?.is_degraded).toBe(true);
-    expect(stage4Out?.degraded_dimensions).toContain('clarity');
+    expect(stage4Out?.degraded_dimensions).toContain('narrative');
 
     // Degraded frontmatter marker should have been written to the article.
     const content = await readFile(articlePath, 'utf-8');


### PR DESCRIPTION
\n## What changed\n- move  from Vibe judge to Fresh Eyes judge for new Tribunal scoring\n- keep legacy compatibility by reading old  as fallback\n- retune Tribunal score card colors:\n  - Fact Check accent -> wine red\n  - pass/high greens -> less vibrant, more muted\n\n## Validation\n- 4 focused vitest files passed (81 tests)\n- legacy freshEyes clarity fallback shell regression passed\n- existing SD article validator passed on legacy frontmatter\n-  reached static entrypoint build and materialized , but this worktree's build process did not return a clean final exit before manual termination; treating that as an environment/process issue, not a claimed PASS\n