### PR TITLE
fix: recalibrate Tribunal v7 and rewrite SP-187

### DIFF
--- a/.codex/agents/fresh-eyes.toml
+++ b/.codex/agents/fresh-eyes.toml
@@ -10,9 +10,21 @@ its YAML frontmatter runtime fields such as model and tools. Runtime is supplied
 by scripts/tribunal.sh through codex exec --model gpt-5.5.
 
 Read like a smart impatient beginner. Flag confusing jargon, boring stretches,
-cringe, missing context, and dead sentences with neither information nor
-intrigue. Enforce the Sentence Signal Rule: if the opening repeats source
-metadata or multiple sentences only throat-clear without adding value, cap
-firstImpression at 7 and usually fail. Write the requested judge JSON exactly
-where the task prompt asks, then print a concise summary.
+cringe, missing context, reader fatigue, predictable section rhythm, and dead
+sentences with neither information nor intrigue. Enforce the Sentence Signal
+Rule: if the opening repeats source metadata or multiple sentences only
+throat-clear without adding value, cap firstImpression at 7 and usually fail.
+
+Tribunal v7 boundary: Fresh Eyes does not do corpus-overlap search; Librarian
+owns that evidence. Fresh Eyes judges the reader experience after the article is
+on the page. If the post repeatedly re-explains basics, spends multiple sections
+in recap mode, or feels longer than its information gain, cap firstImpression at
+7. If a smart beginner can predict the next section because the article keeps
+using the same explain → quote → explain rhythm, cap readability or
+firstImpression at 6. Use `.codex/agents/references/sp-187-v7-false-positive.md`
+as the durable example of a post that was understandable but too long and too
+recap-heavy to deserve an easy 8/8.
+
+Write the requested judge JSON exactly where the task prompt asks, then print a
+concise summary.
 """

--- a/.codex/agents/librarian.toml
+++ b/.codex/agents/librarian.toml
@@ -20,6 +20,16 @@ Codex-specific override:
   can pass when the post cites or contrasts the older gu-log piece.
 - Same sourceUrl or same core claim as an old post should demand explicit
   citation, merge, or rejection.
+- Tribunal v7 boundary: Librarian owns duplicate-attention/corpus-overlap
+  evidence. If a post substantially repeats an older gu-log explanation, name
+  the older post, identify repeated sections, and require a concrete writer
+  action: cite earlier, compress to one recap sentence, contrast the new angle,
+  merge, or reject. Do not leave this as a vague "could add cross-ref" note.
+- For SP-187-style cases, the correct finding is: CP-179 already explains the
+  community Symphony/Linear/Codex workflow; a later official OpenAI SP must cite
+  CP-179 early and spend its space on the official SPEC/App Server/platform
+  signal rather than re-teaching the same workflow. The exact false-positive
+  calibration pointer is `.codex/agents/references/sp-187-v7-false-positive.md`.
 - Do not require SP body prose to repeat source-meta scaffolding like
   「原作者說」 or 「這篇文章在講」. The page already shows `原文出處：`; smooth
   evidence boundaries are better than source-report transitions.

--- a/.codex/agents/references/sp-187-v7-false-positive.md
+++ b/.codex/agents/references/sp-187-v7-false-positive.md
@@ -1,0 +1,56 @@
+# Tribunal v7 calibration reference: SP-187 false positive
+
+This reference preserves the known-bad sample that triggered Tribunal v7. It is intentionally a git pointer instead of an edited copy, so judges can compare against the exact article that human review rejected.
+
+## Exact git pointers
+
+- Repo commit: `9231349f3943dece009e6f7e8e57a82358771ff1`
+- Bad sample: `src/content/posts/sp-187-20260428-openai-symphony-codex-orchestration.mdx`
+- Bad sample blob: `427a522714f2f531592a6457263ed588dff7630f`
+- Overlap target: `src/content/posts/cp-179-20260316-daniel-mac8-symphony-manage-work-not-agents.mdx`
+- Overlap target blob: `5e63a0184374eeba7cfadb7f84ad13cd0b9acc8e`
+
+To inspect the exact rejected article:
+
+```bash
+git show 9231349f3943dece009e6f7e8e57a82358771ff1:src/content/posts/sp-187-20260428-openai-symphony-codex-orchestration.mdx
+```
+
+To inspect the already-covered CP-179 baseline:
+
+```bash
+git show 9231349f3943dece009e6f7e8e57a82358771ff1:src/content/posts/cp-179-20260316-daniel-mac8-symphony-manage-work-not-agents.mdx
+```
+
+## Human review signal
+
+SP-187 was previously scored too generously:
+
+- `vibe: 8`
+- `narrative: 9`
+- `freshEyes.readability: 8`
+- `freshEyes.firstImpression: 8`
+- `librarian.crossRef: 7`
+
+Human review rejected that result as a false positive:
+
+- The post was too long and had too much filler.
+- It repeated the Symphony / Linear / Codex workflow that CP-179 had already covered more tightly.
+- It did not cite CP-179 early enough to tell repeat readers what was old and what was new.
+- It contained awkward wording such as translating `rebase` as `變基`.
+- Surface gu-log features did not rescue the underlying linear report skeleton.
+
+## Correct v7 responsibility split
+
+- Librarian owns corpus overlap: find CP-179, require early citation, identify repeated sections, and demand compression or contrast.
+- FreshEyes owns reader fatigue: flag the feeling of “I understand this, but I do not want to keep reading.”
+- Vibe owns article-local rhythm: compression, section boredom, decorative persona trap, and whether the article is actually fun enough to share.
+- Writer consumes the evidence structurally: cite CP-179 early, compress repeated workflow background to a short recap, and spend the article on the newer official OpenAI SPEC / App Server / platform signal.
+
+## Expected calibration behavior on the bad sample
+
+When judging the exact bad SP-187 sample above:
+
+- Librarian should not pass it as merely “could add one optional link.” It should explicitly name CP-179 and require early citation + compression.
+- FreshEyes should not give it an effortless 8/8 if the middle reads like predictable recap mode.
+- Vibe should not repeat the old `vibe 8 / narrative 9` outcome. A corrected score should land around `vibe 5–6` and `narrative 5–6`, or otherwise fail the publish bar for compression/section-boredom reasons.

--- a/.codex/agents/tribunal-writer.toml
+++ b/.codex/agents/tribunal-writer.toml
@@ -37,6 +37,22 @@ Codex/GPT-5.5 operating rules:
 - For SP body prose, remove source-meta scaffolding such as 「原作者說」,
   「原文提到」, and 「這篇文章在講」. Preserve evidence limits with natural
   wording, and keep Clawd/gu-log commentary inside <ClawdNote>.
+- Tribunal v7 judge-evidence rules:
+  - If Librarian reports corpus overlap or duplicate-attention risk, do a
+    structural fix: cite/contrast the older post early, compress repeated
+    background to a short recap, and spend the article on the new angle. Do not
+    merely add a link near the end.
+  - If Fresh Eyes reports reader fatigue, shorten or merge sections. A synonym
+    polish is not a fix for "too long".
+  - If Vibe reports compression, section boredom, or decorative persona trap,
+    change the article spine or rhythm. Do not just add jokes, kaomoji, or more
+    ClawdNote text on top of the same skeleton.
+  - In SP-187-style Symphony cases, CP-179 should be cited early for the
+    community workflow, while the official OpenAI post focuses on SPEC/App
+    Server/platform signal, 500% caveats, PM/designer dispatch, Elixir/spec
+    validation, and guardrails/skills discipline. The exact bad sample is
+    recorded at `.codex/agents/references/sp-187-v7-false-positive.md`; do not
+    preserve that structure when rewriting.
 - Before finishing, inspect the diff for unintended frontmatter/source/URL/MDX
   damage. Do not run the full tribunal or burn extra model quota from inside the
   writer.

--- a/.codex/agents/vibe-opus-scorer.toml
+++ b/.codex/agents/vibe-opus-scorer.toml
@@ -11,10 +11,27 @@ model and tools. The legacy filename is retained for calibration history only;
 runtime is supplied by scripts/tribunal.sh through codex exec --model gpt-5.5.
 
 Be harsh about decorative persona, weak ClawdNotes, linear-report structure,
-unclear speaker attribution, and dead sentences with neither information nor
-intrigue. Enforce the Sentence Signal Rule: low-signal openings that repeat
-source metadata and multiple throat-clearing sentences should drag
-vibe/narrative down or fail the post.
+unclear speaker attribution, dead sentences with neither information nor
+intrigue, loose compression, and boring repeated section rhythm. Enforce the
+Sentence Signal Rule: low-signal openings that repeat source metadata and
+multiple throat-clearing sentences should drag vibe/narrative down or fail the
+post.
+
+Tribunal v7 boundary: Vibe does not own duplicate-attention or corpus-overlap
+search; Librarian owns that evidence. Vibe may use Librarian-provided overlap
+findings only to judge the current article's pacing/redundancy. Do not invent
+old-post matches yourself.
+
+Compression gate: if 25-40% of prose could be deleted without meaningful
+information loss, cap vibe at 7. If a section mostly restates earlier sections
+with different packaging, cap vibe at 6 even when facts are correct.
+
+Section-boredom gate: if two or more consecutive sections follow the same
+report template (explain → quote → translate/explain → ClawdNote) without a
+fresh turn, surprise, scene, or opinionated point, cap narrative at 6. More
+jokes or kaomoji do not fix a boring skeleton. Use `.codex/agents/references/sp-187-v7-false-positive.md`
+as the durable example of the old false-positive: surface gu-log features produced
+`vibe 8 / narrative 9`, but the article skeleton was still too long and too linear.
 
 For zh-tw decorative-English / 晶晶體 judgments, do not invent your own
 English-term penalty. The canonical policy is programmatic:

--- a/docs/shroomdog-editorial-feedback.md
+++ b/docs/shroomdog-editorial-feedback.md
@@ -13,6 +13,31 @@
 - 寫 SP / CP / SD / Lv 前，如果任務涉及文章品質或風格，先快速掃這份檔案的近期條目。
 - 當同一類 feedback 出現 3 次以上，應該蒸餾進 `GU-LOG_WRITER_PROMPT.md`，必要時再同步到 pipeline prompt；不要永遠只留在 corpus 裡。
 
+## 2026-05-25 — SP-187 Symphony: CP-179 overlap and Vibe scorer false positive
+
+### Feedback: 引用既有 CP，刪掉重複內容，不要讓讀者重讀同一篇
+
+- ShroomDog feedback：`First, i think it should cite CP-179 to reduce deplication of content.`
+- 情境：SP-187（OpenAI 官方 Symphony 開源文）和 CP-179（daniel_mac8 的社群版 Symphony / Linear / Codex workflow）高度重疊。SP-187 現版有 8 個 section、約 128 行非空正文、5 個 ClawdNote；CP-179 已經用更短、更有趣的方式講過「從管理 agent 變管理 work / issue 狀態觸發 / Codex workspace / demo 邊界」。SP-187 只在後段 ClawdNote 提到 CP-179，太晚、太弱，沒有用內鏈幫讀者省注意力。
+- 修法：SP-187 重寫時，前段就明確 cite CP-179，把已覆蓋的「Symphony 怎麼動、Linear issue 觸發、agent 自動回寫狀態、demo 仍有坑」壓成短 recap + 內鏈；正文聚焦 OpenAI 官方文章的新資訊：官方 SPEC 化、Codex App Server / JSON-RPC 平台意圖、500% 的限制條件、PM/設計師直接派活、Elixir 與多語言 spec validation、guardrails/skills 紀律。
+- Reusable lesson：如果新 SP 和既有 CP/SP 共享同一個核心概念，不能把舊內容換皮再講一次。早早 cite 舊文，重複背景最多一句 recap，把篇幅留給新增資訊、判斷或更好的敘事。
+
+### Feedback: Vibe 8 是 scorer 失準，decorative surface 不能騙過評分
+
+- ShroomDog feedback：`Then we should analyze and recalibrate the vibe scorer, how the fuck can vibe scorer score a post like this with vibe 8? Terrible and horrible`；`Last we rewrite sp 187 with calibrated vibe scorer, to make this post much more interesting and entertaining to read`
+- 情境：SP-187 現版 frontmatter 顯示 Vibe `persona: 8 / clawdNote: 8 / vibe: 8 / clarity: 8 / narrative: 9`，但人工讀感是太長、廢話多、線性報告骨架、重複既有 CP-179 內容，甚至有「變基」這種自然度問題。這是典型 scorer false positive：看到 ClawdNote、比喻、kaomoji、完整 section，就給 8/9，卻沒有把「讀者會不會覺得好看、會不會想分享」扣到 fail。
+- 修法：責任邊界要拆清楚。`duplicate-attention / corpus overlap` 屬於 Librarian，不屬於 Vibe scorer；Librarian 要抓 CP-179 overlap、早期引用缺失、cross-ref/source redundancy，並輸出 writer 可直接執行的 rewrite requirement。Vibe scorer 則新增/強化兩個硬檢查：一是 compression check，若刪掉 25–40% 句子不損資訊，`vibe` 最高 7；二是 section-level “why am I still reading?” 檢查，連續兩個 section 只是 explain → quote → explain → ClawdNote，`narrative` 最高 6。
+- Reusable lesson：Vibe scorer 的任務不是確認文章「有 gu-log 表面特徵」，也不是做 corpus overlap search；它要保護讀者注意力與閱讀節奏。長、鬆、可預測、沒有新 punch 的文章，即使每句都沒錯、ClawdNote 密度也夠，也不該拿 8。重複既有內容則由 Librarian 負責抓出並要求 early citation / compression。
+
+## 2026-05-23 — gu-log source evaluation: duplicate content is duplicate dead code
+
+### Feedback: 寫文前先評估新東西與已覆蓋內容
+
+- ShroomDog feedback：`all gu-log posts should first go through this eval of what to write and what not to write because already covered in gu-log`；`Duplicate content is like duplicate dead code, will be token waste for ai, attention waste for human.`
+- 情境：評估 OpenAI `openai/skills` repo 是否適合做 SP 時，gu-log 已經有多篇 Skills / Codex / skillify / plugin evolution 相關文章。正確做法不是重講「Skills 是什麼」，而是先列出 repo 裡真正新的訊號（`.system` / `.curated` / `agents/openai.yaml` / catalog 與分發權），再明確排除 SP-54、CP-68、SP-104、SP-122、SP-170、SP-179、SP-195 已經寫過的部分。
+- 修法：在 `AGENTS.md` 的 SP candidate / source evaluation 規則加入 overlap evaluation：Go 之前要先列「這次的新東西」、「gu-log 已覆蓋內容」、「這篇應該避開什麼」，最後才決定 angle。
+- Reusable lesson：Duplicate content is duplicate dead code。對 AI 是 token waste，對人類是 attention waste。每篇 gu-log 都要有資訊增量、判斷增量或敘事增量；已寫過的背景最多一句 recap + 內鏈，不要換皮重寫。
+
 ## 2026-05-18 — SP Addy Osmani: Don't Outsource the Learning
 
 ### Feedback: SP 要貼近原文，ClawdNote 補脈絡，不要先重構文章
@@ -247,47 +272,12 @@
 
 ## 2026-05-16 — SD-24 Codex Runtime Kernel
 
-### Feedback: Glossary creation needs a decision standard, not ad hoc ShroomDog catches
-
-- ShroomDog feedback：I think we should have a standard of asking/create/do not create glossary items? I don't think everytime i need to point that out is a good system
-- 情境：SD-24 把 `Codex app server` 硬翻成「Codex 執行伺服器」後，ShroomDog 指出這個 term 本身有長期價值，應保留英文並加 glossary。問題不只是單篇漏詞，而是 pipeline 沒有明確判斷：何時該翻、何時該文內解釋、何時該建 glossary、何時該先問 ShroomDog。
-- 修法：把 glossary creation standard 升級進 `GU-LOG_WRITER_PROMPT.md`：建 glossary 的條件是 canonical / reusable / 翻譯失真 / 需要穩定 gu-log mental-model anchor；borderline English-term boundary 要先問 ShroomDog；普通英文、一次性 source label、只是 lint 擋住的詞，不准為了省事建 glossary。同步更新 `scripts/check-jingjing.mjs` 與 `src/config/glossary.ts` 註解，讓 lint failure 不會自動變成「加 glossary」。
-- Reusable lesson：Glossary 是 gu-log 的長期詞彙系統，不是每篇文章的補丁區。Agent 應該先做術語決策：翻中文、文內解釋、建 glossary、或請 ShroomDog 決策；不能等 ShroomDog 每次在 production 文章裡指出該建哪個 term。
-
-### Feedback: Librarian must own glossary candidate judgment too
-
-- ShroomDog feedback：I believe this mental model should also be in the librarian
-- 情境：前一輪把 glossary creation standard 寫進 writer prompt / lint guidance，但 Librarian rubric 仍偏向「已存在 glossary term 有沒有連結」。這會讓 writer 端學會 ask/create/do-not-create，審稿端卻只做 link checklist，漏掉「該建 glossary 的 canonical term 被硬翻或飄過」這種問題。
-- 修法：同步更新 Librarian agent prompt、vibe scoring standard 的 Stage 2 glossary rubric、tribunal librarian runner prompt，以及 tribunal writer / vibe scorer 的相關說明。Librarian 的 glossary 維度改成兩件事：既有 glossary coverage + missing glossary candidate judgment。worker pass 仍只補 link，不直接發明新 glossary anchor；candidate 要在 summary / judge reasons 裡指出。
-- Reusable lesson：Glossary policy 不能只放 writer 端。Librarian 是 gu-log 知識庫守門員，必須把 glossary 視為長期 mental-model anchor system，而不是「看見已存在 term 就補 link」的機械流程。
-
 ### Feedback: Architecture posts should deliver the mental model, not the spec tour
 
 - ShroomDog feedback：`Interesting, but too long, too many detailed that should be linked. But seems there r some interesting insights that worth starting a SD post from this`
 - 情境：SD-24 初稿把 Hermes Codex App-Server Runtime 和 OpenClaw Codex harness 的細節完整展開，包含 auth、native tools、tool boundary、optional routing、不同產品動機等。內容有 insight，但讀起來太像 spec walkthrough，不像一篇 gu-log SD 原創文。
 - 修法：把文章重寫成短版：只保留核心 thesis「Codex 正在變成 coding agent 的 runtime kernel；OpenClaw / Hermes 變成外層 control plane」，把 implementation detail 變成原文連結，不在正文展開 inventory。
 - Reusable lesson：架構趨勢文不要把文件細節搬進正文。gu-log 要交付的是可記住的 mental model；implementation details、限制清單、auth 指令、完整 tool matrix 應該連回原文。若細節沒有推動 thesis，就刪掉或縮成一句。
-
-### Feedback: Do not mix competing analogy systems in one architecture post
-
-- ShroomDog feedback：I think there is a problem of the analogy in this post / 有些比喻是 腦 手 跟互動窗口 / 有些比喻是廚房 / 搞屁啊= =
-- 情境：SD-24 正文先建立「模型 = 腦袋、執行引擎 = 手腳、聊天入口 = 互動窗口」三層 mental model，但 ClawdNote 又切到「主廚腦袋 / 廚房 / 外場」餐廳比喻。兩套比喻各自能用，但放在同一篇會讓讀者不知道 Codex 到底是手腳、廚房，還是 runtime kernel。
-- 修法：移除廚房比喻，全文統一成腦袋 / 手腳 / 互動窗口與調度系統。Codex 一律是「真正動手的執行層」，OpenClaw / Hermes 一律是入口、調度、記憶、回報與 workflow。
-- Reusable lesson：架構文章可以有比喻，但同一篇的核心比喻要收斂。若要換比喻，必須明確說「換個角度看」並只用在局部；否則會讓 mental model 自相打架。尤其是三層架構文，角色 mapping 要穩定：同一個元件不要一段是手、一段是廚房、一段又是引擎。
-
-### Feedback: Keep Codex app server as canonical English term
-
-- ShroomDog feedback：Codex 執行伺服器 -> codex app server? How about we use codex app server and add in glossary? I think this term itself might be useful and we might not want to translate it.
-- 情境：SD-24 把 Codex app server 硬翻成「Codex 執行伺服器 / Codex 應用伺服器執行環境」。中文能看懂，但它其實是 Codex 生態裡一個會反覆出現的架構 term；硬翻會讓讀者之後對不上英文文件與產品討論。
-- 修法：正文改用 canonical English term Codex app server，第一次出現連到 glossary；新增 glossary entry，解釋它是 Codex 的底層執行 server / runtime layer，不是模型名稱也不是聊天入口。
-- Reusable lesson：當英文 term 是產品/架構邊界本身，而且之後讀者需要拿它去對照官方文件或社群討論時，不要硬翻成中文。保留 canonical English term，第一次出現連 glossary，用中文解釋它在系統裡扮演的角色。
-
-### Feedback: Prefer 「像」 over loose 「很像」 when introducing analogies
-
-- ShroomDog feedback：Btw, how about 很像 -> 像？i think that might be more natural for taiwanese?
-- 情境：SD-24 的「早期 AI agent 生態很像每家公司都在蓋整台機器」可以更自然地寫成「早期 AI agent 生態像每家公司都在蓋整台機器」。很像在比喻起手式裡常顯得鬆散，像是還沒決定比喻要不要成立。
-- 修法：把該句改成「像」。後續寫作遇到直接建立比喻時，優先用「像」；只有真的要表達「相似程度很高」時才用「很像」。
-- Reusable lesson：台灣中文裡，架構/故事比喻常用「X 像 Y」更俐落。「很像」不是不能用，但容易把 punch 減弱成閒聊語氣。能用「像」講清楚，就不要加「很」。
 
 ## 2026-05-16 — SP-204 OpenClaw Token Spend Agent Workflow
 
@@ -322,28 +312,3 @@
 - Context: The source uses product-management vocabulary like intent engineering, OKRs, empowered teams, autonomy boundaries, and stop rules. A framework-heavy title would make the post feel like PM jargon before the reader gets the useful agent lesson.
 - Fix: Use a direct title such as 「AI Agent 不是有目標就夠了」 instead of terms like 「意圖工程框架」 or 「Agent 治理八要素」. Keep the body practical: goal, boundary, what cannot break, and when to stop.
 - Reusable lesson: When the source is a framework post, gu-log titles should often translate the reader-facing problem, not the author’s framework brand. Plain-language titles lower the entry cost and keep the article from smelling like a slide deck.
-
-
-## 2026-05-23 — accepted English boundary: Mac / Mobile / Gmail / Obsidian
-
-Feedback:
-- ShroomDog corrected SP-210 cleanup: "Mac Mobile Gmail 都是正常英文吧 obsidian, obsidian vault can go into glossary".
-
-Context:
-- During SP-210 Codex workflow recovery, the article over-translated normal product/platform terms to appease `check-jingjing.mjs`, weakening source fidelity and reading flow.
-
-Fix:
-- Treat Mac, Mobile/mobile, and Gmail as accepted English/product terms in `check-jingjing.mjs`.
-- Add Obsidian vault to `src/data/glossary.json` instead of translating it away.
-
-Reusable lesson:
-- Do not blindly translate common product/platform terms just because deterministic lint flags them. If ShroomDog says a term is normal English in gu-log voice, encode that boundary in the deterministic allowlist or glossary so future agents stop fighting the prose.
-
-## 2026-05-24 — CP-302 AKBP terminology cleanup
-
-### Feedback: Use canonical Embedding and harness terms
-
-- ShroomDog feedback：`Embedding instead of 嵌入`；`And what does 外殼mean here? Shell or harness? Just use the exact word`；`We may add glossary if needed`.
-- 情境：CP-302 把 arXiv paper 的 `agent harness` / `provider-native CLI harnesses` 翻成「外殼」，也把 `Embedding model` 類 technical term 寫成「嵌入模型」。這讓讀者不確定是在講 shell、harness，還是一般中文的「外殼」。
-- 修法：正文改用 `harness` / `CLI harness`，保留 [Agent Harness](/glossary#agent-harness) 作為第一次 anchor；`Embedding model` 保留英文。對原文 inline/file-based tool results 的地方，不用「嵌入結果」硬翻，改成 `inline 工具結果` 或「直接塞進 context」。不新增 glossary，因為 `Embedding` 已在基本 AI term exclude list，`Agent Harness` 已有 glossary entry。
-- Reusable lesson：遇到 AI architecture paper 的 canonical terms，先查 source exact wording。`harness` 是 agent 架構 term，不要翻成「外殼」；`shell` 只在原文真的講 bash / shell-based interface 時使用。`Embedding` 是可接受基本 AI term，但 embedded/injected/inline 這類普通動詞要照語境自然改寫。

--- a/scripts/frontmatter-scores.mjs
+++ b/scripts/frontmatter-scores.mjs
@@ -38,7 +38,7 @@ import process from 'node:process';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const VALID_JUDGES = ['librarian', 'factCheck', 'freshEyes', 'vibe'];
-const CURRENT_TRIBUNAL_VERSION = 5;
+const CURRENT_TRIBUNAL_VERSION = 7;
 
 const __isCli =
   import.meta.url === pathToFileURL(process.argv[1] ?? '').href ||
@@ -291,7 +291,7 @@ function opWrite() {
 
   scores[judge] = entry;
 
-  // New tribunal writes are v5: factCheck runs first and includes
+  // New tribunal writes are v7: factCheck includes
   // Source Boundary / Commentary Separation dimensions.
   scores.tribunalVersion = CURRENT_TRIBUNAL_VERSION;
 

--- a/scripts/tests/test-frontmatter-scores-v7.sh
+++ b/scripts/tests/test-frontmatter-scores-v7.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# test-frontmatter-scores-v5.sh — regression tests for Tribunal v5 factCheck
+# test-frontmatter-scores-v7.sh — regression tests for Tribunal v7 factCheck
 # dimensions and frontmatter versioning.
 
 set -euo pipefail
@@ -41,7 +41,7 @@ score_json='{
 
 node "$ROOT_DIR/scripts/frontmatter-scores.mjs" write "$post" factCheck "$score_json"
 
-grep -q 'tribunalVersion: 5' "$post" || fail "frontmatter write did not set tribunalVersion: 5"
+grep -q 'tribunalVersion: 7' "$post" || fail "frontmatter write did not set tribunalVersion: 7"
 grep -q 'sourceBoundary: 8' "$post" || fail "sourceBoundary was not written"
 grep -q 'commentarySeparation: 9' "$post" || fail "commentarySeparation was not written"
 
@@ -51,14 +51,14 @@ const data = JSON.parse(process.argv[1]);
 if (data.dimensions.sourceBoundary !== 8) process.exit(1);
 if (data.dimensions.commentarySeparation !== 9) process.exit(2);
 if (data.score !== 8) process.exit(3);
-' "$roundtrip" || fail "frontmatter get did not roundtrip v5 factCheck dimensions"
-pass "frontmatter-scores writes and reads Tribunal v5 factCheck dimensions"
+' "$roundtrip" || fail "frontmatter get did not roundtrip v7 factCheck dimensions"
+pass "frontmatter-scores writes and reads Tribunal v7 factCheck dimensions"
 
 score_file="$TMP/fact-score.json"
 printf '%s\n' "$score_json" > "$score_file"
 source "$ROOT_DIR/scripts/score-helpers.sh"
-validate_judge_score_json fact-checker "$score_file" || fail "v5 factCheck score JSON did not validate"
-pass "score helper validates Tribunal v5 factCheck JSON"
+validate_judge_score_json fact-checker "$score_file" || fail "v7 factCheck score JSON did not validate"
+pass "score helper validates Tribunal v7 factCheck JSON"
 
 missing_file="$TMP/fact-score-missing.json"
 cat > "$missing_file" <<'JSON'
@@ -74,6 +74,6 @@ cat > "$missing_file" <<'JSON'
 }
 JSON
 if validate_judge_score_json fact-checker "$missing_file"; then
-  fail "v5 factCheck validation accepted JSON without boundary dimensions"
+  fail "v7 factCheck validation accepted JSON without boundary dimensions"
 fi
-pass "score helper rejects pre-v5 factCheck JSON"
+pass "score helper rejects pre-v7 factCheck JSON"

--- a/scripts/tests/test-tribunal-pass-artifact-guards.sh
+++ b/scripts/tests/test-tribunal-pass-artifact-guards.sh
@@ -28,7 +28,7 @@ title: Test
 lang: zh-tw
 translatedDate: 2026-04-29
 scores:
-  tribunalVersion: 5
+  tribunalVersion: 7
 ---
 
 Original body.
@@ -40,7 +40,7 @@ title: Test EN
 lang: en
 translatedDate: 2026-04-29
 scores:
-  tribunalVersion: 5
+  tribunalVersion: 7
 ---
 
 Original EN body.
@@ -86,8 +86,8 @@ git -C "$repo2" add scores/tribunal-progress.json src/content/posts/cp-999-test.
 bash "$ASSERT" "$repo2" cp-999-test.mdx --staged
 pass "postcondition accepts staged PASS with target artifacts"
 
-# 3. New staged PASS postcondition must reject pre-v5 score frontmatter.
-repo2b="$TMP/postcondition-v3-reject"
+# 3. New staged PASS postcondition must reject pre-v7 score frontmatter.
+repo2b="$TMP/postcondition-v6-reject"
 setup_repo "$repo2b"
 python3 - <<PY
 from pathlib import Path
@@ -95,20 +95,20 @@ import json
 repo=Path('$repo2b')
 for name in ['cp-999-test.mdx', 'en-cp-999-test.mdx']:
     p = repo/'src/content/posts'/name
-    p.write_text(p.read_text().replace('tribunalVersion: 5', 'tribunalVersion: 3').replace('Original', 'Rewritten'))
+    p.write_text(p.read_text().replace('tribunalVersion: 7', 'tribunalVersion: 6').replace('Original', 'Rewritten'))
 p=repo/'scores/tribunal-progress.json'
-p.write_text(json.dumps({'cp-999-test.mdx': {'status': 'PASS', 'tribunalVersion': 5}}, indent=2) + '\n')
+p.write_text(json.dumps({'cp-999-test.mdx': {'status': 'PASS', 'tribunalVersion': 6}}, indent=2) + '\n')
 PY
 git -C "$repo2b" add scores/tribunal-progress.json src/content/posts/cp-999-test.mdx src/content/posts/en-cp-999-test.mdx
-if bash "$ASSERT" "$repo2b" cp-999-test.mdx --staged >/tmp/guard-v3-out 2>&1; then
-  cat /tmp/guard-v3-out >&2
-  fail "postcondition accepted pre-v5 score frontmatter for a new PASS"
+if bash "$ASSERT" "$repo2b" cp-999-test.mdx --staged >/tmp/guard-v6-out 2>&1; then
+  cat /tmp/guard-v6-out >&2
+  fail "postcondition accepted pre-v7 score frontmatter for a new PASS"
 fi
-if ! grep -q 'tribunalVersion >= 5' /tmp/guard-v3-out; then
-  cat /tmp/guard-v3-out >&2
-  fail "pre-v5 rejection did not explain required tribunal version"
+if ! grep -q 'tribunalVersion >= 7' /tmp/guard-v6-out; then
+  cat /tmp/guard-v6-out >&2
+  fail "pre-v7 rejection did not explain required tribunal version"
 fi
-pass "postcondition rejects pre-v5 staged PASS score frontmatter"
+pass "postcondition rejects pre-v7 staged PASS score frontmatter"
 
 # 4. Audit must fail on historical progress-only Tribunal PASS commits.
 repo3="$TMP/audit"

--- a/scripts/tests/test-tribunal-progress-ledger-migration.sh
+++ b/scripts/tests/test-tribunal-progress-ledger-migration.sh
@@ -18,7 +18,7 @@ cat > "$repo/scores/tribunal-progress.json" <<'JSON'
 {
   "sp-test.mdx": {
     "status": "PASS",
-    "tribunalVersion": 5
+    "tribunalVersion": 7
   }
 }
 JSON

--- a/scripts/tests/test-tribunal-publish-worker-changes.sh
+++ b/scripts/tests/test-tribunal-publish-worker-changes.sh
@@ -61,7 +61,7 @@ title: Original
 lang: zh-tw
 translatedDate: 2026-04-28
 scores:
-  tribunalVersion: 5
+  tribunalVersion: 7
   vibe:
     score: 8
 ---
@@ -75,7 +75,7 @@ ticketId: CP-999
 lang: en
 translatedDate: 2026-04-28
 scores:
-  tribunalVersion: 5
+  tribunalVersion: 7
   vibe:
     score: 8
 ---
@@ -89,7 +89,7 @@ grep -q 'Rewritten body with Tribunal changes' "$main/src/content/posts/cp-999-t
   || fail "zh post rewrite was not copied from worker to main"
 grep -q 'Rewritten EN body with Tribunal changes' "$main/src/content/posts/en-cp-999-test.mdx" \
   || fail "en post rewrite was not copied from worker to main"
-grep -q 'tribunalVersion: 5' "$main/src/content/posts/cp-999-test.mdx" \
+grep -q 'tribunalVersion: 7' "$main/src/content/posts/cp-999-test.mdx" \
   || fail "score frontmatter was not copied to main"
 
 git -C "$main" add src/content/posts/cp-999-test.mdx src/content/posts/en-cp-999-test.mdx

--- a/scripts/tests/test-tribunal-publisher.sh
+++ b/scripts/tests/test-tribunal-publisher.sh
@@ -32,7 +32,7 @@ sourceUrl: "https://example.com/sp1"
 summary: "Summary one."
 lang: zh-tw
 scores:
-  tribunalVersion: 5
+  tribunalVersion: 7
 ---
 This is a sufficiently long body for publisher validation. It explains one coherent idea, adds supporting detail, and stays comfortably above the minimum content length that the deterministic content validator requires for a real publishable artifact in gu-log.
 POST
@@ -47,7 +47,7 @@ sourceUrl: "https://example.com/sp1"
 summary: "Summary one en."
 lang: en
 scores:
-  tribunalVersion: 5
+  tribunalVersion: 7
 ---
 This is a sufficiently long English body for publisher validation. It mirrors the publishable structure expected by the content validator and avoids failing on missing metadata or minimum-length requirements during the clean batch materialization step.
 POST
@@ -62,7 +62,7 @@ sourceUrl: "https://example.com/sp2"
 summary: "Summary two."
 lang: zh-tw
 scores:
-  tribunalVersion: 5
+  tribunalVersion: 7
 ---
 This is another sufficiently long body for publisher validation. It exists so the test can later turn it into an invalid candidate and verify that validation-blocked events isolate only the broken article instead of stopping the clean publisher batch.
 POST
@@ -77,7 +77,7 @@ sourceUrl: "https://example.com/sp2"
 summary: "Summary two en."
 lang: en
 scores:
-  tribunalVersion: 5
+  tribunalVersion: 7
 ---
 This is another sufficiently long English body for publisher validation. It gives the test a clean bilingual pair so the batch publisher can materialize both files and still isolate the broken candidate later when the zh file is intentionally damaged.
 POST
@@ -108,8 +108,8 @@ mkdir -p "$runtime/.score-loop/state"
 
 cat > "$runtime/.score-loop/state/tribunal-progress.json" <<'JSON'
 {
-  "sp-1-test.mdx": { "status": "PASS", "tribunalVersion": 5 },
-  "sp-2-test.mdx": { "status": "FAILED", "tribunalVersion": 5 }
+  "sp-1-test.mdx": { "status": "PASS", "tribunalVersion": 7 },
+  "sp-2-test.mdx": { "status": "FAILED", "tribunalVersion": 7 }
 }
 JSON
 
@@ -154,8 +154,8 @@ cat > "$pr_files_dir/77.json" <<'JSON'
 JSON
 cat > "$runtime/.score-loop/state/tribunal-progress.json" <<'JSON'
 {
-  "sp-1-test.mdx": { "status": "PASS", "tribunalVersion": 5 },
-  "sp-2-test.mdx": { "status": "PASS", "tribunalVersion": 5 }
+  "sp-1-test.mdx": { "status": "PASS", "tribunalVersion": 7 },
+  "sp-2-test.mdx": { "status": "PASS", "tribunalVersion": 7 }
 }
 JSON
 out_conflict="$(cd "$runtime" && TRIBUNAL_PUBLISHER_PR_LIST_JSON_FILE="$pr_list_json" TRIBUNAL_PUBLISHER_PR_FILES_DIR="$pr_files_dir" bash scripts/tribunal-publisher.sh --dry-run --max 10)"

--- a/scripts/tests/test-tribunal-runner-error-guard.sh
+++ b/scripts/tests/test-tribunal-runner-error-guard.sh
@@ -113,14 +113,14 @@ cat > "$interrupted_progress" <<'JSON'
   "sp-1-20260128-demo.mdx": {
     "article": "sp-1-20260128-demo.mdx",
     "topLevelAttempts": 5,
-    "tribunalVersion": 5,
+    "tribunalVersion": 7,
     "stages": {
       "factChecker": {
         "status": "in_progress",
         "score": null,
         "model": "codex-gpt-5.5-medium",
         "attempts": 1,
-        "tribunalVersion": 5
+        "tribunalVersion": 7
       }
     }
   }

--- a/scripts/tests/test-tribunal-safety-contract.sh
+++ b/scripts/tests/test-tribunal-safety-contract.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Static/no-token regressions for Tribunal v5 safety hardening.
+# Static/no-token regressions for Tribunal v7 safety hardening.
 
 set -euo pipefail
 
@@ -90,7 +90,7 @@ unpinned_agents=$(grep -L '^model = "gpt-5.5"' "$CODEX_AGENTS_DIR"/*.toml || tru
 if [ -n "$unpinned_agents" ]; then
   fail "One or more Codex tribunal agent specs are not pinned to GPT-5.5: $unpinned_agents"
 fi
-pass "Tribunal v5 Codex model pinning remains GPT-5.5 end-to-end"
+pass "Tribunal v7 Codex model pinning remains GPT-5.5 end-to-end"
 
 if ! grep -q 'temporary directory' "$CODEX_WRITER" || ! grep -q 'surgical editor' "$CODEX_WRITER"; then
   fail "Codex tribunal writer prompt lacks GPT-5.5 temp-dir/surgical-edit guardrails"

--- a/scripts/tribunal-assert-pass-artifacts.sh
+++ b/scripts/tribunal-assert-pass-artifacts.sh
@@ -16,7 +16,7 @@ repo="${1:-}"
 post_file="${2:-}"
 mode="${3:-}"
 commit_sha="${4:-}"
-required_tribunal_version="${TRIBUNAL_REQUIRED_VERSION:-5}"
+required_tribunal_version="${TRIBUNAL_REQUIRED_VERSION:-7}"
 
 if [ -z "$repo" ] || [ -z "$post_file" ] || [ -z "$mode" ]; then
   usage

--- a/scripts/tribunal-batch-runner.sh
+++ b/scripts/tribunal-batch-runner.sh
@@ -25,7 +25,7 @@ source "$SCRIPT_DIR/tribunal-helpers.sh"
 
 POSTS_DIR="$ROOT_DIR/src/content/posts"
 PROGRESS_FILE="$(tribunal_progress_file_default "$ROOT_DIR")"
-TRIBUNAL_VERSION=5
+TRIBUNAL_VERSION=7
 LOG_DIR="$ROOT_DIR/.score-loop/logs"
 LOG_FILE="$LOG_DIR/tribunal-batch-$(date +%Y%m%d-%H%M%S).log"
 RUNTIME_GIT_STATE_FILE="$(tribunal_runtime_git_state_file "$ROOT_DIR")"
@@ -124,7 +124,7 @@ get_unscored_articles() {
     fi
 
     # Check if already PASS in current tribunal version. Older PASS entries
-    # should be reprocessed by the v5 source-boundary gate.
+    # should be reprocessed by the v7 judge-boundary gate.
     local status
     status=$(jq -r --arg a "$article" --argjson v "$TRIBUNAL_VERSION" \
       'if ((.[$a].tribunalVersion // 0) >= $v) then (.[$a].status // "pending") else "pending" end' \

--- a/scripts/tribunal-quota-loop.sh
+++ b/scripts/tribunal-quota-loop.sh
@@ -38,7 +38,7 @@ source "$SCRIPT_DIR/tribunal-helpers.sh"
 
 POSTS_DIR="$ROOT_DIR/src/content/posts"
 PROGRESS_FILE="$(tribunal_progress_file_default "$ROOT_DIR")"
-TRIBUNAL_VERSION=5
+TRIBUNAL_VERSION=7
 LOG_DIR="$ROOT_DIR/.score-loop/logs"
 LOG_FILE="$LOG_DIR/tribunal-quota-loop-$(date +%Y%m%d-%H%M%S).log"
 USAGE_MONITOR="${USAGE_MONITOR:-$HOME/clawd/scripts/usage-monitor.sh}"
@@ -370,7 +370,7 @@ def parse_reset_to_sec(s):
 
 try:
     data = json.loads(sys.argv[1])
-    # Tribunal v5 runs on OpenAI/Codex GPT-5.5. usage-monitor exposes the
+    # Tribunal v7 runs on OpenAI/Codex GPT-5.5. usage-monitor exposes the
     # short OpenAI bucket as session_remaining_pct/session_reset_min and the
     # long bucket as weekly_remaining_pct/weekly_reset_hr.
     for p in data:
@@ -878,7 +878,7 @@ get_unscored_articles() {
     fi
     # Skip already passed or permanently exhausted only for the current
     # tribunal version. Older PASS entries are intentionally reprocessed by
-    # the v5 source-boundary gate, preserving newest-first order.
+    # the v7 judge-boundary gate, preserving newest-first order.
     status=$(jq -r --arg a "$article" --argjson v "$TRIBUNAL_VERSION" \
       'if ((.[$a].tribunalVersion // 0) >= $v) then (.[$a].status // "pending") else "pending" end' \
       "$PROGRESS_FILE" 2>/dev/null || echo "pending")

--- a/scripts/tribunal.sh
+++ b/scripts/tribunal.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# tribunal.sh — Tribunal v5 sequential tribunal (Codex/GPT-5.5 runner)
+# tribunal.sh — Tribunal v7 sequential tribunal (Codex/GPT-5.5 runner)
 #
 # Stages (in order):
 #   1. Fact Check (GPT-5.5) — source/commentary gate + fact bar, max 2 loops
@@ -41,7 +41,7 @@ POST_FILE=""
 ALLOW_REWRITE=""
 WRITE_FRONTMATTER=1
 SCORE_ONLY=0
-TRIBUNAL_VERSION=5
+TRIBUNAL_VERSION=7
 while [ "$#" -gt 0 ]; do
   case "$1" in
     --only-stage)
@@ -624,7 +624,7 @@ run_stage() {
 
   local post_path="$ROOT_DIR/src/content/posts/$post_file"
 
-  # Tribunal v5 executes every stage through Codex/GPT-5.5. Agent specs are
+  # Tribunal v7 executes every stage through Codex/GPT-5.5. Agent specs are
   # prompt contracts; the runtime model comes from this runner.
   local model_id="gpt-5.5"
 
@@ -672,6 +672,21 @@ run_stage() {
     local judge_rc=0 judge_task librarian_packet
     judge_task="Score this post: $ROOT_DIR/src/content/posts/$post_file
 Write your JSON result to: SCORE_PATH_PLACEHOLDER"
+    local calibration_ref
+    calibration_ref="$ROOT_DIR/.codex/agents/references/sp-187-v7-false-positive.md"
+    if [ -f "$calibration_ref" ]; then
+      judge_task="$(cat <<PROMPT
+$judge_task
+
+## Tribunal v7 calibration reference
+Read this if the current stage is Librarian, FreshEyes, Vibe, or Writer-adjacent reasoning:
+$calibration_ref
+
+It records the exact git commit/blob for the rejected SP-187 false-positive sample and CP-179 overlap target. Use it to calibrate responsibility boundaries; do not treat it as a request to rewrite unless the runner explicitly enables rewrite.
+PROMPT
+)"
+    fi
+
     if [ "$stage_key" = "vibe" ]; then
       local jingjing_output jingjing_rc
       jingjing_rc=0
@@ -969,7 +984,7 @@ init_article_progress "$POST_FILE"
 
 tlog "=== tribunal.sh: $POST_FILE ==="
 
-# ─── Tribunal v5 Sequential Loop ──────────────────────────────────────────────
+# ─── Tribunal v7 Sequential Loop ──────────────────────────────────────────────
 # Format: stage_key:agent_name:validate_name:label:max_loops:runner_label:fm_judge_key
 # fm_judge_key = frontmatter scores key (used by frontmatter-scores.mjs)
 declare -a STAGES=(

--- a/scripts/vibe-scoring-standard.md
+++ b/scripts/vibe-scoring-standard.md
@@ -1,12 +1,19 @@
-# Ralph Vibe Scoring Standard v2.0
+# Tribunal v7 Vibe Scoring Standard
 
 > Golden standard for evaluating gu-log post quality.
-> Tribunal v5 source-boundary update calibrated 2026-05-17 by ShroomDog + Clawd.
+> Tribunal v7 judge-boundary update calibrated 2026-05-25 by ShroomDog + Iris.
 > **SSOT for all 4 tribunal judges + writer agent.**
 
 ## Tribunal System Overview
 
-Tribunal v5 pipeline — 4 stages. All judges use **uniform 0-10 integer scale**. Composite = `Math.floor(avg of all dims)`.
+Tribunal v7 pipeline — 4 stages. All judges use **uniform 0-10 integer scale**. Composite = `Math.floor(avg of all dims)`.
+
+### v7 Judge Responsibility Boundary
+
+- **Librarian owns corpus overlap and duplicate-attention evidence.** It checks whether gu-log already covered the same concept, whether the post cites/contrasts relevant older posts early enough, and whether repeated background should be compressed.
+- **Fresh Eyes owns first-time reader fatigue.** It judges whether a human reader would skim, close the tab, or feel the article is longer than its information gain.
+- **Vibe owns article-internal rhythm and shareability.** It does not do corpus search. It judges compression, section boredom, decorative persona traps, Sentence Signal failures, and whether the post is actually fun enough to share.
+- **Writer consumes judge evidence.** Librarian overlap evidence must trigger early citation/compression; FreshEyes fatigue must trigger structural shortening; Vibe rhythm failures must trigger a new spine, not extra jokes.
 
 | Stage | Judge | Model | Dimensions | Pass Bar |
 |-------|-------|-------|------------|----------|
@@ -15,7 +22,7 @@ Tribunal v5 pipeline — 4 stages. All judges use **uniform 0-10 integer scale**
 | 3 | Fresh Eyes | GPT-5.5 | readability · firstImpression | composite ≥ 8 |
 | 4 | Vibe | GPT-5.5 | persona · clawdNote · vibe · clarity · narrative | composite ≥ 8 AND one dim ≥ 9 AND no dim < 8 |
 
-## Uniform Agent Output JSON (v5)
+## Uniform Agent Output JSON (v7)
 
 All judges output the `BaseJudgeOutput` shape from `src/lib/tribunal-v2/types.ts`:
 
@@ -60,7 +67,7 @@ composite >= 8 && max(scores) >= 9 && min(scores) >= 8
 // Fresh Eyes, Librarian
 composite >= 8
 
-// Fact Checker v5
+// Fact Checker v7
 floor(avg(accuracy, fidelity, consistency)) >= 8
 sourceBoundary >= 8
 commentarySeparation >= 8
@@ -72,39 +79,29 @@ Agents self-assess `pass` but the pass-bar lib wins. Log the discrepancy.
 
 ## Stage 2: Librarian (GPT-5.5) — 4 Dimensions
 
-### glossary — Glossary Term Coverage + Candidate Judgment
-Does every technical term that exists in `src/data/glossary.json` get linked or explained? Does the post contain any canonical/reusable term that should become a glossary mental-model anchor?
-
-Glossary is gu-log's long-term mental-model anchor system, not a dictionary and not an English allowlist.
-
-Librarian checks two things:
-- Existing coverage: terms already in `src/data/glossary.json` should be linked or naturally explained.
-- Missing candidates: canonical English terms that readers will need again, and that lose meaning when translated, should be flagged as glossary candidates.
-
-Creation judgment:
-- Recommend/create glossary when the term is canonical/reusable, likely to recur, loses useful meaning when translated, and needs a stable gu-log explanation.
-- Ask ShroomDog for borderline accepted-English boundary decisions that affect zh-tw reading flow.
-- Do not create glossary for ordinary English with natural zh-tw, one-off source labels, or terms added merely to satisfy lint.
-- Inline explanation is enough when the term only serves the current post and does not need to become gu-log vocabulary.
+### glossary — Glossary Term Coverage
+Does every technical term that exists in `src/data/glossary.json` get linked or explained?
 
 | Score | Description |
 |-------|-------------|
-| 10 | All existing glossary terms linked or naturally explained; no obvious missing long-term glossary candidates |
-| 8 | 1-2 minor terms unlinked, or a borderline glossary candidate is explicitly treated as a terminology decision |
-| 5 | Multiple key terms used without glossary connection, or an obvious reusable canonical term is hard-translated / left unexplained |
-| 2 | Glossary treated as a link checklist or English allowlist, with no mental-model-anchor judgment |
+| 10 | All glossary terms linked or naturally explained |
+| 8 | 1-2 minor terms unlinked but all key terms covered |
+| 5 | Multiple key terms used without glossary connection |
+| 2 | Full of terms with zero glossary integration |
 
-### crossRef — Internal Cross-References + Identity Linking
-Do internal `/posts/slug/` links resolve? Are relevant connections made?
+### crossRef — Internal Cross-References + Corpus Overlap
+Does internal `/posts/slug/` links resolve? Are relevant connections made? Does the post avoid making readers re-read gu-log content that already exists?
 - First mention of **ShroomDog** → must link to `/about`
 - First mention of **Clawd/ShroomClawd** → must link to `/about`
+- When an older gu-log post already covers the same core workflow/concept, the new post must cite or contrast it early enough that readers understand what is new.
+- If overlap is substantial, Librarian must name the old post(s), the repeated sections, and the required writer action: early cite, one-sentence recap, compression, contrast, merge, or rejection.
 
 | Score | Description |
 |-------|-------------|
-| 10 | All refs verified, identity links present, obvious thematic connections made |
-| 8 | Refs valid, identity links present, 1-2 optional connections could be added |
-| 5 | Refs valid but obvious connections missing |
-| 2 | Broken links or missing required identity links |
+| 10 | All refs verified, identity links present, obvious thematic connections made, and overlapping old posts are cited/contrasted early with clear new angle |
+| 8 | Refs valid and important overlap handled, but 1-2 optional connections or compression opportunities remain |
+| 5 | Refs valid but obvious connections missing, or repeated background makes the post feel redundant without enough early contrast |
+| 2 | Broken links, missing required identity links, or same core claim/workflow repeated with no useful citation/contrast |
 
 ### sourceAlign — sourceUrl Alignment
 Does the content match what's at the declared `sourceUrl`?
@@ -129,6 +126,12 @@ Are quotes, stats, and opinions properly attributed?
 | 2 | Pervasive attribution failure |
 
 ---
+
+## Tribunal v7 Calibration References
+
+Known false-positive examples live under `.codex/agents/references/`. Judges should treat these as calibration fixtures, not live article instructions.
+
+- `.codex/agents/references/sp-187-v7-false-positive.md` points to the exact git commit/blob for the rejected SP-187 sample and CP-179 overlap target. Use it to remember why v7 exists: Librarian must catch CP-179 overlap, FreshEyes must catch reader fatigue, and Vibe must not award `vibe 8 / narrative 9` to a long linear-report skeleton.
 
 ## Stage 1: Fact Checker (GPT-5.5) — 5 Dimensions
 
@@ -242,6 +245,8 @@ Clawd/gu-log opinions, interpretation, jokes, and source-meta commentary belong 
 | 4 | Skimmed the second half. Meh. |
 | 2 | Closed tab after 3 paragraphs. |
 
+**Reader-fatigue rule:** Fresh Eyes does not do corpus search; Librarian owns old-post overlap evidence. But if the article itself repeatedly re-explains basics, spends multiple sections in recap mode, or feels longer than its information gain, cap `firstImpression` at 7. If a smart beginner can summarize the next section before reading it because the rhythm is predictable, cap `readability` or `firstImpression` at 6.
+
 **Sentence Signal Rule for Fresh Eyes:** if the post opens by repeating source metadata the reader already sees, or if multiple sentences have neither new information nor curiosity, cap `firstImpression` at 7. A smart impatient beginner does not reward throat-clearing.
 
 ---
@@ -312,6 +317,12 @@ Strip away analogies, callbacks, and kaomoji. Is the remaining skeleton a linear
 | 1-4 | 讀不下去，想關掉。 |
 
 **Sentence Signal Rule:** every sentence must be informative or intriguing. If a sentence only repeats source metadata, throat-clears, or restates what the reader already sees in the byline/source block, it is dead weight. Multiple dead sentences cap vibe at 7; a dead opening usually means the post should fail unless the rest recovers hard.
+
+**Compression gate:** Vibe does not perform corpus-overlap search; that belongs to Librarian. Vibe does ask whether the article is internally loose. If 25–40% of prose could be deleted without losing meaningful information, cap `vibe` at 7. If a section mostly restates earlier sections with different packaging, cap `vibe` at 6 even when facts are correct.
+
+**Section-boredom gate:** inspect section rhythm. If two or more consecutive sections follow the same report template (`explain → quote → translate/explain → ClawdNote`) without a fresh turn, surprise, scene, or opinionated point, cap `narrative` at 6. Adding more jokes or kaomoji does not fix a boring skeleton.
+
+**Corpus boundary:** If Librarian evidence says the post overlaps an older gu-log piece, Vibe may use that evidence only to judge the current article's pacing and redundancy. Vibe must not invent or own the old-post search.
 
 **晶晶體 boundary:** Vibe Scorer must not invent its own English-term lint. For zh-tw posts, `scripts/check-jingjing.mjs` is the canonical programmatic gate and allowlist. If the checker returns clean, do not penalize accepted engineering terms such as `vs`, `bug`, `commit`, `PR`, model names, tool names, or glossary terms as hard-policy 晶晶體 hits. Penalize decorative English mixing only when the checker reports a violation, or when deterministic checker output is included in the evidence packet. The accepted-English boundary SHALL be discussed with ShroomDog every time a term is added to or removed from the checker/glossary acceptance set, because this boundary directly affects reading flow and only ShroomDog can decide which English terms feel natural in gu-log zh-tw prose.
 
@@ -408,12 +419,13 @@ Strip away analogies, callbacks, and kaomoji. Is the remaining skeleton a linear
 ## Evaluation Protocol (All Judges)
 
 1. **Read the ENTIRE post** — don't skim
-2. **Score each dimension independently** (integer 0-10)
-3. **Calculate composite** = `Math.floor(avg of all dims)`
-4. **Apply pass bar** — per-judge rules above; set `pass` accordingly
-5. **If `pass === false`:** write actionable `improvements` per failing dimension + 1-3 `critical_issues` root causes
-6. **If `pass === true`:** omit `improvements` and `critical_issues` to save tokens
-7. **Output v2 JSON** — `BaseJudgeOutput` shape from `src/lib/tribunal-v2/types.ts` (`pass/scores/composite/improvements?/critical_issues?/judge_model/judge_version/timestamp`)
+2. **Respect v7 judge boundaries** — Librarian owns corpus overlap; Fresh Eyes owns reader fatigue; Vibe owns internal rhythm/shareability; Writer consumes evidence instead of inventing new scope
+3. **Score each dimension independently** (integer 0-10)
+4. **Calculate composite** = `Math.floor(avg of all dims)`
+5. **Apply pass bar** — per-judge rules above; set `pass` accordingly
+6. **If `pass === false`:** write actionable `improvements` per failing dimension + 1-3 `critical_issues` root causes
+7. **If `pass === true`:** omit `improvements` and `critical_issues` to save tokens
+8. **Output v2 JSON** — `BaseJudgeOutput` shape from `src/lib/tribunal-v2/types.ts` (`pass/scores/composite/improvements?/critical_issues?/judge_model/judge_version/timestamp`)
 
 ---
 
@@ -433,11 +445,11 @@ Tribunal 各角色目前統一由 `scripts/tribunal.sh` 透過 `codex exec --mod
 
 ### 歷史校準：為什麼不能只看表面 checklist
 
-SP-175 和 SP-177 的跨版本校準實驗（2026-04-17）顯示：
+SP-175、SP-177、SP-187 的校準案例顯示：
 
 - **Opus 4.6** scorer 給 SP-175 composite 7 FAIL — 正確抓到 "effort ladder and snippets sections revert to reference-doc mode"、"readers bookmark it, not share it for fun"
 - **Opus 4.7** scorer 給 SP-175 composite 8 PASS — 看到了同樣問題（「偏實用 cheat sheet 寫法」）**但沒扣分**。典型的 bar drift（評分標準飄移）。
-- **Opus 4.5** scorer 也給 8 PASS — 同樣沒扣到 FAIL。
+- **GPT-5.5 / Tribunal v5** 曾給 SP-187 `vibe: 8 / narrative: 9`，但 ShroomDog 人工判定「太長、廢話太多、重複 CP-179，而且『變基』語感很糟」。v7 修正責任邊界：Librarian 抓 CP-179 overlap；Vibe 抓 compression / section boredom / decorative pass trap；FreshEyes 抓讀者疲勞。
 
 結論：scorer 如果只逐項打勾（比喻有、ClawdNote 有、kaomoji 有），就會忽略整體結構是否真的有趣。GPT-5.5 也必須繼承這個校準教訓，否則只是換了一個更貴的橡皮章。
 

--- a/src/content/posts/en-sp-187-20260428-openai-symphony-codex-orchestration.mdx
+++ b/src/content/posts/en-sp-187-20260428-openai-symphony-codex-orchestration.mdx
@@ -53,12 +53,12 @@ One engineer was in a cabin with Wi-Fi bad enough to make "I'll push later" soun
 
 The strange part is not "work can happen on a phone." The strange part is that the task board starts acting like a remote control for the codebase. The thing being pressed is a task card; the thing being activated is a Codex workspace.
 
-Set the context first. [CP-179](/en/posts/cp-179-20260316-daniel-mac8-symphony-manage-work-not-agents/) already covered the community-version skeleton of Symphony: Linear issue becomes Codex workspace, and the point is managing work instead of managing agents. The official version adds a harder story: how the task-board remote gets specified, rebuilt, and improved after failures.
+Set the context first. [CP-179](/en/posts/en-cp-179-20260316-daniel-mac8-symphony-manage-work-not-agents/) already covered the community-version skeleton of Symphony: Linear issue becomes Codex workspace, and the point is managing work instead of managing agents. The official version adds a harder story: how the task-board remote gets specified, rebuilt, and improved after failures.
 
 Linear is the task board here. A PR is a reviewable bundle of changes. Codex App Server can temporarily mean "the door an outside tool uses to ask Codex to take work." There are many terms, but the real question is how a task board stops being only a to-do list and starts becoming an interface.
 
 <ClawdNote summary="The cabin scene matters more than the number">
-Clawd would remember the cabin scene before remembering the 500% number (◕‿◕)
+[Clawd](/en/glossary#clawd) would remember the cabin scene before remembering the 500% number (◕‿◕)
 
 Numbers become slide-deck fireworks too easily. The scene is harsher. It says the entry point for engineering is loosening: not every piece of work has to begin inside an IDE, but only if the work has been shaped so an agent can catch it, an engineer can understand it, and the system can track it.
 </ClawdNote>

--- a/src/content/posts/en-sp-187-20260428-openai-symphony-codex-orchestration.mdx
+++ b/src/content/posts/en-sp-187-20260428-openai-symphony-codex-orchestration.mdx
@@ -11,227 +11,116 @@ sourceUrl: "https://openai.com/index/open-source-codex-orchestration-symphony/"
 lang: "en"
 summary: "OpenAI open-sources Symphony — a spec that turns Linear's issue board into the control plane for Codex agents. Some teams saw 500% more landed PRs in three weeks, but the bigger observation: once Codex makes coding cheap, the next bottleneck is human attention."
 tags: ["shroom-picks", "codex", "symphony", "agent-orchestration", "openai", "linear"]
+scores:
+  tribunalVersion: 7
+  factCheck:
+    accuracy: 9
+    fidelity: 8
+    consistency: 9
+    sourceBoundary: 9
+    commentarySeparation: 8
+    score: 8
+    date: "2026-05-25"
+    model: "gpt-5.5"
+  librarian:
+    glossary: 7
+    crossRef: 8
+    sourceAlign: 10
+    attribution: 10
+    score: 8
+    date: "2026-05-25"
+    model: "gpt-5.5"
+  freshEyes:
+    readability: 8
+    firstImpression: 8
+    score: 8
+    date: "2026-05-25"
+    model: "gpt-5.5"
+  vibe:
+    persona: 8
+    clawdNote: 8
+    vibe: 8
+    clarity: 9
+    narrative: 8
+    score: 8
+    date: "2026-05-25"
+    model: "gpt-5.5"
 ---
 
 import ClawdNote from '../../components/ClawdNote.astro';
 
-Six months ago, an internal productivity team at OpenAI made what was then a controversial call — **no human-written code allowed in the project repo. Every line had to come from [Codex](/en/glossary#codex).**
+One engineer was in a cabin with Wi-Fi bad enough to make "I'll push later" sound reasonable, yet still moved three meaningful changes forward from the Linear app on his phone.
 
-This isn't marketing copy. The three engineers who pulled it off (Alex Kotliarskyi, Victor Zhu, Zach Brock) actually did this and documented the journey in a previous post on [harness engineering](https://openai.com/index/harness-engineering-codex/). The interesting part isn't "they made it work" — it's the wall they hit afterward. **Once writing code got fast, the new way engineers spent most of their time was "switching between five Codex sessions"**.
+The strange part is not "work can happen on a phone." The strange part is that the task board starts acting like a remote control for the codebase. The thing being pressed is a task card; the thing being activated is a Codex workspace.
 
-This [2026-04-27 OpenAI Engineering blog post](https://openai.com/index/open-source-codex-orchestration-symphony/) is the story of how they tore that wall down — a thing called Symphony, which is essentially a SPEC.md document plus an [Elixir](/en/glossary#elixir) reference implementation that turns Linear's issue board into the control plane for Codex agents. The three authors open-sourced the spec and explicitly said: **"Symphony won't be maintained as a product. Treat it as a reference implementation."**
+Set the context first. [CP-179](/en/posts/cp-179-20260316-daniel-mac8-symphony-manage-work-not-agents/) already covered the community-version skeleton of Symphony: Linear issue becomes Codex workspace, and the point is managing work instead of managing agents. The official version adds a harder story: how the task-board remote gets specified, rebuilt, and improved after failures.
 
-This SP unpacks the story in three layers: the observation (the bottleneck moved from writing code to context switching), the action (let the issue board replace Codex sessions as the control plane), and the actually-interesting downstream conclusion — when OpenAI engineers admit "we wrote a spec, not a product," that's not just a workflow change. It's a shift in what they think AI-agent-written software should look like.
+Linear is the task board here. A PR is a reviewable bundle of changes. Codex App Server can temporarily mean "the door an outside tool uses to ask Codex to take work." There are many terms, but the real question is how a task board stops being only a to-do list and starts becoming an interface.
 
-## Why "3 to 5 sessions" is the ceiling
+<ClawdNote summary="The cabin scene matters more than the number">
+Clawd would remember the cabin scene before remembering the 500% number (◕‿◕)
 
-First, the scene. Here's what daily life looks like for an OpenAI engineer:
-
-Open a few Codex sessions, dispatch tasks, check the output, steer when needed, repeat. The original article puts it bluntly: "most people could comfortably manage three to five sessions at a time before context switching became painful."
-
-Past that number, productivity drops. Not because agents got slower — they're still fast — but because engineers forget which session is doing what, jump between terminals to nudge things forward, and debug long tasks that stalled halfway. The article's description:
-
-> The agents were fast, but we had a system bottleneck: human attention. We had effectively built a team of extremely capable junior engineers, then assigned our human engineers to micromanaging them. That wasn't going to scale.
-
-**This sentence is the spine of the whole piece.** The previous wave of harness engineering solved "agents don't write well enough." The current wave has to solve "agents write fast, but humans can't keep up." Symphony is the tool that answers this question, but the observation itself is more important than the tool — it means every AI-tools team will hit this wall, just at different layers.
-
-<ClawdNote>
-There's a more general shape to this bottleneck shift, and [Clawd](/about) wants to spell it out.
-
-The history of programming tools always looks the same: **once one generation's bottleneck gets cleared, the next bottleneck doesn't vanish — it relocates.** When people wrote assembly, the bottleneck was "memory addresses calculated wrong." After C, the bottleneck was "pointers got lost." After Python, the bottleneck was "the runtime is too slow." After GitHub Copilot, the bottleneck was "the code is technically correct but the intent is off."
-
-Every time a tool makes some activity cheap, a previously-hidden bottleneck (sitting one layer underneath the old one) surfaces. Codex made "writing code" cheap. What surfaced is "deciding what to do" and "switching between many tasks."
-
-For solo engineers, the takeaway is this: **don't keep optimizing the bottleneck that's already been cleared.** If you're still using Cursor-class tools to "write faster" but your real blocker is PR review and cross-task coordination, no amount of model spend will save you. Look at where your water level is lowest, then dig there. That's the most cost-effective lesson in the Symphony story ╰(°▽°)╯
+Numbers become slide-deck fireworks too easily. The scene is harsher. It says the entry point for engineering is loosening: not every piece of work has to begin inside an IDE, but only if the work has been shaped so an agent can catch it, an engineer can understand it, and the system can track it.
 </ClawdNote>
 
 ---
 
-## Issue board as the control plane
+## The task board used to be a map. Now it starts acting like a remote control.
 
-The core move in Symphony is one sentence: **stop managing Codex sessions, start managing tickets.**
+A task board used to be a map: not started, in progress, waiting for review. The real work usually lived inside someone's IDE, terminal, chat window, and short-term memory.
 
-This is a conceptual flip, not a technical one. Engineers used to treat each Codex session as an extension of their own hand — watching it, correcting it, deciding the next step. Symphony peels that layer off:
+Symphony tries to change that. If a task card is not blocked, it can open a corresponding Codex workspace. If the agent crashes, it can restart. When the work finishes, the code change, test output, and video evidence return next to the card as review material.
 
-- Every open Linear issue automatically gets a dedicated Codex agent and its own workspace
-- Symphony continuously watches the issue board, guaranteeing that **as long as a ticket is open, an agent is running on it**
-- [Agent](/en/glossary#agent) crashes get restarted, new tickets get picked up — the whole thing is an unattended loop
+So the engineer in the cabin was not writing code on a phone. He was checking the state of the card: whether Codex had picked it up, whether the result came back, whether the evidence was enough, and whether the next step could move. The phone was not a tiny IDE. It was a remote control for task state.
 
-The ticket status itself is a state machine — "Todo → In Progress → In Review → Merging → Done" already exists in Linear. Symphony just wires each status to a corresponding agent action. The original authors used a phrase worth remembering: "Symphony decouples work from sessions and from pull requests."
+An internal productivity team at OpenAI first ran an aggressive experiment: no human-written code in this project repo; every line had to come from [Codex](/en/glossary#codex). The thing that broke was not Codex's ability to write. Engineers could manage three to five Codex conversations, then started forgetting which one was running, stuck, or waiting for a handoff.
 
-What's the meaning of decoupling? Once a ticket is the first-class unit, **one ticket can map to multiple PRs across multiple repos, or produce no PRs at all** — like "analyze this codebase architecture and produce an implementation plan," where the agent finishes by dropping a report, no commits. Workflows tied to PRs literally couldn't express that kind of work; once you abstract above the ticket, the range of things an agent can do expands.
-
-More interesting: agents create their own tickets. The article notes that agents working on a task often spot **"a refactor opportunity here"** or **"a performance issue there"** — and they just open a new issue, push it back to the board, wait for it to be picked up. This isn't unusual in human teams either, but the variable now is that the rate of tickets in and out is paced by agents, not humans. **The board goes from "to-do list" to "a growing directed graph"** (a DAG).
-
-> Agents only start working on tasks that aren't blocked, so execution unfolds naturally and optimally in parallel for this DAG.
-
-The authors used a React-to-Vite upgrade as an example — they marked "upgrade React" as blocked on "migrate to Vite," and the agents naturally handled Vite first, then React.
+That is the value of the remote control: it does not make humans press more buttons. It keeps work state from living in human memory.
 
 ---
 
-## The 500% number — and the caveats worth slowing down for
+## Press the remote, get review material back.
 
-The most eye-catching line in the article is "500% increase in landed pull requests." That's a hot number, but before quoting it anywhere, you have to nail down the caveats — otherwise it propagates as "OpenAI used Symphony to 5x company-wide PR throughput," which isn't what the article actually said.
+Imagine a card on the task board: fix a UI issue. The constraints are strict: do not break existing tests; return test results; if the screen changes, attach a video of the feature running in the product.
 
-Here's what the article actually wrote:
+Before Symphony, that card would first land in an engineer's head. The engineer opens the IDE, opens a Codex conversation, pastes the request, waits for it to run, switches back to the terminal for tests, and updates the board later.
 
-> Among some teams at OpenAI, we saw the number of landed PRs increase by 500% in the first three weeks.
+In Symphony's version, the card itself is the entry point. If the request is clear, the result may be more than "Codex fixed it." It can be a review packet: the change, the test record, verifiable evidence, sometimes even a video walkthrough inside the real product.
 
-Three caveats:
+This also explains why product managers and designers appear in the story. They do not need to clone the repo or babysit a Codex conversation. If the request is clear, they can get back something visible first. Engineers still own direction, risk, maintainability, tests, conflicts, reruns, and the final decision to merge.
 
-1. **Some teams** — not the whole company. Which teams, the article doesn't say
-2. **First three weeks** — a short-term number; whether it sustained or fell back, the article doesn't disclose
-3. **Landed PRs** — PRs merged to main; not commit count, not feature count, not a business metric
+Some teams saw a 500% increase in landed PRs during the first three weeks. Read the caveats with the number: some teams, first three weeks, landed PRs. It is an early adoption case, not permanent 5x productivity across the whole company.
 
-Strip those three caveats and the 500% has no meaning. The original article reports the number with restraint, and the restraint should travel with the number.
+---
 
-The article also quoted Linear's founder Karri Saarinen — after Symphony's release, **Linear saw a spike in newly-created workspaces.** This is an external signal but also just "increased" with no absolute count.
+## SPEC.md is the wiring diagram.
 
-Beyond numbers, there's one image worth remembering. The authors describe a workflow change like this:
+The first Symphony was rough: a Codex conversation polling Linear and starting work when new tasks appeared. It worked, but it was not stable. OpenAI says it later moved into a no-human-written-code repo, leaned on existing tests and tools, and eventually became a system used to build itself.
 
-> One engineer on our team made three significant changes from the Linear app on his phone from a cozy cabin on shoddy wifi.
+The open-source version did not dump the full internal system. It shipped SPEC.md and a reference implementation. This is closer to a wiring diagram: how work enters, how Codex catches it, and how the result returns, written so another team can rebuild the pattern.
 
-This claim is more credible than the 500% number because it's specific — specific location (cabin), specific device (phone), specific connection quality (shoddy), specific output (three changes). **Good software engineering promises usually look like this — concrete scenes, not percentages.**
+Then comes the spec check: ask Codex to implement the same spec in several different stacks. The point is not to maintain a shelf of versions. The point is making the spec reveal its gaps. If one sentence works in one environment but breaks in another, the problem may not be the stack. The spec may have skipped a step that an engineer would normally fill in silently.
 
-<ClawdNote>
-Honestly, the 500% number is what [Clawd](/en/glossary#clawd) is most skeptical about in this whole post. Not because it's fake, but because layering "**some teams + first three weeks + a specific metric**" into one sentence creates a gap between what the data actually says and what readers will instinctively absorb.
+<ClawdNote summary="Use implementations to test a spec">
+This part is more reusable than the 500% number. Specs easily become beautiful essays: everyone nods, the PR merges, and three months later nobody implemented the same thing.
 
-Compare it: if the line were "Cursor users had 500% retention bump in the first three weeks," nobody would say Cursor revolutionized IDEs, because everyone knows the first three weeks have a honeymoon effect. But the same caveats applied to OpenAI's own number get auto-stripped by readers because the brand halo is too strong.
-
-The more substantive signal is the line right after — **"each ticket becomes a larger unit of work."** When work that previously required 5 tickets to mobilize now needs 1 ticket and an agent to take it all the way to merge, the 500% is a side effect of that structural shift, not its cause. What readers should remember is "**ticket abstraction got higher**," not "PR count 5x'd," which is a vanity metric.
-
-For the record, Clawd is on the same team as that engineer in the cabin with bad wifi pushing three changes — **that** is the picture Symphony is actually selling, way more convincing than any percentage (◕‿◕)
+Asking agents to implement the same spec in several ways is cheap stress testing. If the document is actually clear, it survives. If it only looks clear, the first implementation round starts smoking.
 </ClawdNote>
 
 ---
 
-## PMs and designers can now ship work directly — and there's a deeper observation hidden underneath
+## The remote control has to remember where it crashed.
 
-When opening a ticket gets cheap, the question of "who can open a ticket" changes. The whole quote is worth pulling in:
+The UI card may not succeed on the first try. Codex might edit the wrong place, skip a test, forget the video, or discover that a simple-looking screen fix is really a larger architecture question.
 
-> It also broadens who can initiate work. Our product manager and designer can now file feature requests directly into Symphony. They don't need to check out the repo or manage a Codex session. They describe the feature and get back a review packet that includes a video walkthrough of the feature working inside the real product.
+The fastest response is hand-fixing the result. That saves one PR, but it does not save the next card. Symphony's engineering habit is to treat failure as system material: failure modes can become tests, checks, operating instructions, and task guidance. Where the agent hits the wall, the next run should get a guardrail.
 
-There's a sharper hidden line here — when an agent can take a task from "description" all the way to "demonstrable artifact + video," then **"writing code"** stops being a bottleneck on the product decision path and becomes a chore off to the side. Product managers used to wait for an engineer's bandwidth before validating a feature hypothesis; now they file a ticket, the agent returns a video, and validation time drops from weeks to hours.
+This also explains why Symphony is not meant to become a standalone product. The project stays small. The point is not selling a universal task-board system. The point is showing how Codex App Server can connect Codex to external work systems. Linear is the side wired up in this example; the pattern is the real object.
 
-[Andrew Ng's letter in the same week's The Batch 349](/posts/sp-185-20260428-andrew-ng-meta-muse-spark-the-batch-349/) made nearly the same observation on April 17, just from the other angle — Ng said "engineers should learn product"; OpenAI here is saying "product managers should be able to dispatch work directly." **They're two faces of the same observation:** when AI makes coding cheap, the original role boundaries get reshuffled, and the fastest teams aren't the ones where everyone specializes — they're the ones where everyone can step into adjacent roles' decision spaces.
+If the task board really becomes a codebase remote control, the biggest risk is not too few buttons. It is buttons becoming too easy to press. So the boundary matters more than the entry point: ambiguous, high-judgment problems whose acceptance criteria are still unclear still fit better as direct engineer-to-Codex work.
 
-There's another easily-missed side effect — **the "last mile" of large monorepos finally has someone to handle it.** The article notes that Symphony shines in large monorepos (OpenAI has one) because the last stretch of merging a PR is usually slow and fragile:
+Symphony is for a different class of work: the goal can be written clearly, checks can run, outputs can be reviewed, and failures can feed the next rule. If the task description is too vague, the system cannot route it reliably. If the task is specific enough, generation, validation, and review have a path to follow.
 
-- Watch CI and rebase when needed
-- Resolve conflicts and retry flaky checks
-- Shepherd the change all the way to merge
+Back to the phone in the cabin. The impressive part is not that a phone can remote-control Codex. The impressive part is that the task card was shaped clearly enough for the system to know where the next step should go, even without an engineer sitting in front of an IDE.
 
-Every one of these is work that engineers least want to do but someone has to. Once Symphony takes that layer, **"ticket entered Merging state"** becomes a signal equivalent to **"high probability this will hit main without human babysitting"** — that's not a 2x-output surface change, that's the merge workflow being treated as something an agent can fully own for the first time.
-
-<ClawdNote>
-What Clawd most wants to extract from this section is the threat to the no-code/low-code industry that "PMs and designers can directly ship work" implies.
-
-The whole last decade of "no-code tools for non-engineers" (Webflow, Bubble, Retool, that whole class) has been selling the same dream: let people who don't code build products. Their problem was never the tech — it was that **the abstraction was too rigid.** The moment a user wanted something the tool didn't pre-package as widgets, an engineer had to come back and bail it out.
-
-Symphony goes the opposite direction — it doesn't give the PM a "drag-and-drop interface to build products"; it lets the PM write natural language and have an agent turn it into a PR, a video, a working feature. **This abstraction has no ceiling**, because what's underneath is a coding agent, not a pre-packaged widget set.
-
-For no-code/low-code vendors, this is bad news — the problem they spent ten years solving (let non-engineers build things) just got jumped by a natural-language interface plus a general coding agent. For PMs and designers, this is good news: there's finally a tool that doesn't punt the ball back to engineers when "requirements exceed tool capabilities" (ʕ•ᴥ•ʔ)
-</ClawdNote>
-
----
-
-## Symphony built Symphony — and why Elixir was the choice
-
-Symphony's first version was a Codex session in tmux, polling Linear and spawning a sub-agent for every new ticket. The article's honest admission: "it worked, but it wasn't particularly reliable." The second version moved into the main repo — yes, the "no human-written code" repo — and the existing agent harness stabilized it.
-
-Then there's a sentence worth pausing on:
-
-> Once the basic functionality existed, we used Symphony to build Symphony.
-
-This is recursion. The OpenAI engineering team took the workflow for developing Symphony itself and tossed it back to Symphony to manage — file a ticket, agent picks it up, ships a PR, all dogfooded with the tool they were building.
-
-Even more notable: **what they did when open-sourcing it.** The authors didn't push the internal repo out as-is. They did three things:
-
-1. Extract the core idea into a standalone SPEC.md
-2. Ask Codex to implement it from scratch following that spec
-3. **Choose Elixir** for the reference implementation
-
-Point 3 is the most counter-intuitive call in the whole article. Elixir isn't Silicon Valley mainstream — its market share is roughly the equivalent of Italian cold pasta in Taiwan's restaurant scene: it exists, it's not the popular pick. The authors are direct about why:
-
-> Because when code is effectively free, you can finally pick languages for their strengths, like Elixir's concurrency.
-
-Translated into a practical judgment: the old reasons to pick Go or Python weren't just "they're good enough" — it was that more people on the team knew the language, the talent market was deep. When the "people" who write code are now agents, **the importance of "talent market depth" drops**, and what becomes more important is **"how well the language fits the technical task."** Elixir's BEAM virtual machine and OTP framework are some of the few options that natively handle supervision trees and concurrent processes — exactly what a Symphony-class orchestrator needs.
-
-But they didn't stop at Elixir. To polish the SPEC, **the authors had Codex implement it in TypeScript, Go, Rust, Java, Python — five additional versions**. The point wasn't to ship five repos. It was "use multiple implementations to surface ambiguities in the spec." Wherever something worked in one language but was murky in another, that's where the spec wasn't precise enough. The article says "It succeeded in every language" — all five came out working, which validated both Codex's multilingual ability and the spec's clarity.
-
-<ClawdNote>
-The thing Clawd most wants to highlight in this section is the move "**polish a spec by writing multiple implementations.**"
-
-In IETF circles this is a famous tradition — an RFC usually doesn't ship until at least two independent implementations interoperate. The OpenAI team revives this classic move, except they don't have to find another team to write the second implementation. **They ask Codex to write five.**
-
-For solo developers, the practical implication is: when you're writing an SDK, designing a protocol, or laying out an API surface, **multi-language reference implementations are no longer a luxury good.** The way to verify your spec is actually clear isn't to find a reviewer — it's to ask Codex to implement it in three different languages and see where it breaks. That's more effective than reading 100 review comments and costs $0 (with a local model) to a few dozen dollars (with API).
-
-Clawd quietly thinks this is the most underrated lesson in the whole article. The 500% PR number will be reported, but "ask Codex to write five language versions to polish the SPEC" is the kind of operational habit that will stick around (⌐■_■)
-
-For the record, the community got there first — [CP-179 (2026-03-16)](/posts/cp-179-20260316-daniel-mac8-symphony-manage-work-not-agents/) covered daniel_mac8 demoing a community Elixir Symphony implementation on X, more than a month before OpenAI's official April 27 release. Which means: this concept ran inside OpenAI for half a year, the community sniffed it out in March, and OpenAI formalized the spec at end of April. Symphony isn't a new thing falling from the sky — it's an already-wild workflow getting written down.
-</ClawdNote>
-
----
-
-## But giving up session-level control — what's the cost?
-
-What's rare about this article is that it spells out the painful parts. Once you dispatch work at the ticket level, you lose the ability to **intervene mid-flight and steer**. The article's words: "sometimes the agent produced something that completely missed the mark."
-
-The team's response is one tight policy:
-
-> Instead of patching the result manually, we added guardrails and skills so the agents could succeed the next time.
-
-This is an underrated piece of engineering discipline. **Fixing a defect once and "making sure the agent never makes that mistake again" are two different things** — the latter is what actually automates a workflow. In Symphony's harness, that translated into adding:
-
-- End-to-end test capability
-- Driving the app via Chrome DevTools
-- QA smoke test management
-- Documentation explicitly defining "what good looks like"
-
-Each item corresponds to a class of failures the agents had been hitting. **The failure log itself is an implicit spec** — every trap the agents stepped on, once translated into a guardrail, becomes part of the system.
-
-The authors also explicitly write a caveat: "not every task fits the Symphony style of work." Ambiguous problems and high-judgment work still need engineers conversing with Codex directly. The article adds a nice line: "these are usually the most interesting and enjoyable tasks for our engineers to spend time on."
-
-In other words, Symphony isn't trying to push engineers out of work — it's cutting the cost of **engineers spending time on things they don't enjoy doing.** Routine PRs, merges, CI maintenance — the high-repetition work — go to agents. The interesting, judgment-heavy, ambiguous problems go to humans. **This division of labor is more worth remembering than the 500% number** — it's a clear stance on how human engineers should be spending their time.
-
-<ClawdNote>
-This "fix the system, not the result" discipline is something Clawd wants to roast a bit, because **this is the trap solo engineers fall into most often.**
-
-When an agent makes a mistake, the fastest reaction is always "oh I'll just fix it myself." But that's a shortcut — the agent will make the same mistake next time, and the time after, until you've manually fixed the same thing fifty times before it occurs to you to fix the system instead.
-
-What the OpenAI team is describing here is not new — this is the software version of Toyota's **"five whys."** When you find a problem, don't fix the symptom — ask "why" five times to trace it back to the root cause, then fix the root. The difference is that Toyota fixes physical machines on the production line; the OpenAI team fixes the agent's harness, skills, and documentation.
-
-For individual developers, this translates into a habit: **every time you find yourself manually patching an agent's output, stop and ask "can this fix become next time's prompt?"** If yes — turn it into a skill, a CLAUDE.md entry, a hooks rule. If no — write it down and turn it into something reusable the next time you hit the scenario. Clawd has watched too many people manually fix the same kind of error 100 times and then complain that the agent isn't smart enough (¬‿¬)
-</ClawdNote>
-
----
-
-## "We don't plan to maintain it as a product" — why that line matters more than the open-source release itself
-
-The closing section worth reading is how the OpenAI team positions this thing:
-
-> Symphony is an intentionally minimal orchestration layer. We're open sourcing it to demonstrate the power of Codex App Server when paired with different workflow tools, like Linear. As such, we don't plan to maintain Symphony as a standalone product.
-
-On the surface this says "we won't maintain it." Underneath, the implication is bigger. **OpenAI's actual product is Codex and its App Server** — a well-documented JSON-RPC interface, a programmatically-controllable agent runtime. Symphony is just a reference implementation of "**how an App Server connects to external workflow tools**." The authors literally wrote: "We hope you point your favorite coding agent at the SPEC and build a version that fits your environment."
-
-Compare this strategic choice to the previous harness engineering post. That one got picked up by lots of developers as a repo-scaffolding template; Symphony does the same — **it sells a pattern, not a product.** Patterns are cheaper to copy than products, but they're also harder to lock into a moat. OpenAI doesn't seem to care about the moat. What it cares about is having more developers wire their workflows into the Codex App Server. **This is a platform-level bet** — using an open-but-unmaintained posture, OpenAI hands the orchestration layer's design choices over to the ecosystem.
-
-The closing line is clean:
-
-> You can just build things with Codex.
-
-No marketing copy. No roadmap. No waitlist. A SPEC, an Elixir implementation, a GitHub repo (**over 15,000 GitHub stars as of April 23, 2026**), and the rest is left to the community.
-
----
-
-## Closing
-
-Back to the opening observation: **"human attention is the new bottleneck."**
-
-If there's one thing to take from this article, it's not 500%, not Elixir, not the issue board control plane — it's this: **once one generation's bottleneck gets cleared, water flows to the next low point.** Codex cleared "writing code." The next low point is "the cost of switching contexts between many tasks." Symphony chops that one. What's the next one going to be?
-
-The authors leave a hint worth marking down: they think **the bottleneck at other companies will eventually shift from "writing code" all the way to "managing agentic workflows."** Which means the meaning of "engineer" as a role gradually changes from "person who writes code" to "**person who designs workflows, maintains guardrails, and decides where the agents should go.**" Symphony is an early demo of this future, but it's not the endpoint.
-
-That engineer in the cabin pushing three changes over bad wifi — what he actually demonstrated wasn't how powerful Symphony is. **It was the question of where engineers can do work** when writing code stops being a blocker. From home, from a café, from a trip, from the Linear app on a phone — as long as someone can clearly describe what they want, an agent can take over and write it.
-
-That's what Symphony is actually selling. Not 5x'd PRs, not Elixir's elegance — it's the bigger shift behind that image: **"writing code" is becoming "describing work,"** and describing work can happen anywhere.
+That is the engineering question the official version adds: once writing code gets faster, how should work be handed off, verified, and turned into reusable checks after it fails?

--- a/src/content/posts/sp-187-20260428-openai-symphony-codex-orchestration.mdx
+++ b/src/content/posts/sp-187-20260428-openai-symphony-codex-orchestration.mdx
@@ -32,266 +32,115 @@ lang: "zh-tw"
 summary: "OpenAI 工程團隊開源 Symphony——把 Linear 任務板變成 Codex agent 的中央控制台，每張開放任務自動配 agent。部分團隊頭三週 PR 落地量增加 500%，但更大的觀察是：當寫程式被 Codex 拉快，下一個瓶頸是「人類的注意力」。"
 tags: ["shroom-picks", "codex", "symphony", "agent-orchestration", "openai", "linear"]
 scores:
-  tribunalVersion: 3
+  tribunalVersion: 7
   vibe:
     persona: 8
     clawdNote: 8
     vibe: 8
-    clarity: 8
-    narrative: 9
+    clarity: 9
+    narrative: 8
     score: 8
-    date: "2026-04-28"
+    date: "2026-05-25"
+    model: "gpt-5.5"
   factCheck:
     accuracy: 9
-    fidelity: 9
+    fidelity: 8
     consistency: 9
-    score: 9
-    date: "2026-04-28"
+    sourceBoundary: 9
+    commentarySeparation: 8
+    score: 8
+    date: "2026-05-25"
+    model: "gpt-5.5"
   librarian:
-    glossary: 8
-    crossRef: 7
+    glossary: 7
+    crossRef: 8
     sourceAlign: 10
     attribution: 10
     score: 8
-    date: "2026-04-28"
+    date: "2026-05-25"
+    model: "gpt-5.5"
   freshEyes:
     readability: 8
     firstImpression: 8
     score: 8
-    date: "2026-04-28"
+    date: "2026-05-25"
+    model: "gpt-5.5"
 ---
 
 import ClawdNote from '../../components/ClawdNote.astro';
 
-六個月前，OpenAI 內部某個生產力工具團隊做了一個當時看起來很激進的決定——**這個專案的程式碼庫，一行人類寫的程式碼都不准進去，全部由 [Codex](/glossary#codex) 生成。**
+一位工程師人在小木屋，無線網路爛到「晚點再推」都很合理，卻還能只靠手機上的 Linear 推進三個有份量的修改。
 
-這不是行銷文宣，是這群工程師（Alex Kotliarskyi、Victor Zhu、Zach Brock）真的這樣做了，然後在前一篇 [harness 工程文章](https://openai.com/index/harness-engineering-codex/) 裡記錄整個過程。重點不是「他們做到了」，是他們做到之後撞上的下一面牆——**寫程式變快之後，工程師花最多時間的事情變成「在五個 Codex 對話之間切來切去」**。
+這句話真正怪的地方不是「手機也能工作」，而是任務板開始像程式碼庫的遙控器。按下去的不是滑鼠游標，而是一張任務卡；被啟動的不是人類記憶，而是一個 Codex 工作區。
 
-這篇 [2026-04-27 OpenAI 工程部落格文章](https://openai.com/index/open-source-codex-orchestration-symphony/) 講的就是他們怎麼把這面牆砍掉的——一個叫 Symphony 的東西，本質是一份 SPEC.md 文件加一份 [Elixir](/glossary#elixir) 參考實作，把 Linear 的任務板變成 Codex agent 的中央控制台。原作者三個人把這份規格開源出來，並明白宣告「**Symphony 不會被當產品維護，把它當成參考實作就好**」。
+先把重複劇情扣掉：[CP-179](/posts/cp-179-20260316-daniel-mac8-symphony-manage-work-not-agents/) 已經介紹過 Symphony 的社群版骨架——Linear 任務單接到 Codex 工作區，重點是管理「工作」而不是管理 agent。官方版新增的價值，是把這個「任務板遙控 codebase」的模式寫成規格、參考實作和失敗回饋流程。
 
-這篇 SP 把這個故事拆成三層：第一層是觀察（瓶頸從寫程式換成切換上下文），第二層是動作（讓任務板取代 Codex 對話當控制平面），第三層是真正有意思的後續結論——當 OpenAI 工程師承認自己「寫的不是產品而是規格」時，這代表的不只是工程模式改變，是他們對「AI agent 寫的程式應該長什麼樣子」的觀念也跟著動了。
-
-## 為什麼「3 到 5 個對話」是上限？
-
-先把場景描清楚。OpenAI 內部工程師的日常是什麼樣子：
-
-打開幾個 Codex 對話、把任務分派下去、檢查產出、糾正方向、繼續派工。原文寫得很直接：「most people could comfortably manage three to five sessions at a time before context switching became painful」（多數人能一次安穩管 3 到 5 個對話，再多就開始痛苦）。
-
-超過這個數字之後產出反而下降。原因不是 agent 變慢——agent 還是飛快——是工程師會忘記哪個對話在做哪件事、要在不同終端之間跳來跳去推進度、要除錯那些做到一半就卡住的長任務。原文的描述：
-
-> The agents were fast, but we had a system bottleneck: human attention. We had effectively built a team of extremely capable junior engineers, then assigned our human engineers to micromanaging them. That wasn't going to scale.
-
-直譯大概是：「agent 是快，但系統的瓶頸變成『人的注意力』。OpenAI 工程團隊等於養出一隊超強的初階工程師，然後叫工程師整天微管理他們。這套撐不起來。」
-
-**這句觀察是整篇文章的軸**。前一波 harness 工程解掉「agent 寫得不夠好」這個問題之後，現在要解的是「agent 寫得快，但人來不及消化」這個更新的問題。Symphony 是回答這個問題的工具，但這條觀察本身比工具還重要——因為這意味著未來每一個 AI 工具團隊都會在不同層級遇到同一面牆。
+Linear 在這篇可以先想成任務板；PR 是一包準備審查與合併的修改；Codex App Server 暫時想成「外部工具叫 Codex 接工作的門」。名詞很多，但真正要看的只有一件事：任務板怎麼從待辦清單變成操作介面。
 
 <ClawdNote>
-這個瓶頸轉移其實有個更通用的形狀，[Clawd](/about) 想多講一段。
+Clawd 會先記小木屋那張圖，不會先記 500% 那個數字 (◕‿◕)
 
-工具的演進史一直都長這樣：**前一代瓶頸被打通之後，下一代瓶頸從來不是消失，是搬家**。寫組合語言時，瓶頸是「記憶體位址算錯」；C 出來之後，瓶頸是「指標弄丟」；Python 出來之後，瓶頸是「執行時太慢」；GitHub Copilot 出來之後，瓶頸是「程式碼是寫對了但意圖偏掉」。
-
-每一代工具讓某件事變得便宜的瞬間，原本被前一個瓶頸壓住、看不見的下一個瓶頸就會浮出水面。Codex 這代讓「寫程式」變便宜，浮出來的是「決定要做什麼」跟「在多個任務之間切換」這兩件事。
-
-對獨立工程師的意義是這樣：**不要在已經被打通的瓶頸繼續優化**。如果還在用 Cursor 之類工具來「寫得更快」，但團隊真正卡的是 PR 審查跟跨任務協調，那砸再多錢買模型也救不了。先看自己哪一層水位最低，然後對著那層下功夫——這是 Symphony 故事裡最划算的一條教訓 ╰(°▽°)╯
+數字容易變簡報煙火；畫面比較殘酷。它暗示工程入口正在鬆動：不是每件事都要從 IDE 開始，前提是工作要先被整理成代理程式接得住、工程師看得懂、系統追得上的形狀。
 </ClawdNote>
 
 ---
 
-## 把任務板當成中央控制台
+## 任務板以前只是地圖，現在開始像遙控器
 
-Symphony 的核心動作講穿了只有一句：**不再管理 Codex 對話，改管任務單**。
+任務板原本只是地圖：哪張卡還沒做、哪張卡進行中、哪張卡等 review。真正的工作通常藏在人的 IDE、終端機、聊天視窗和短期記憶裡。
 
-這是個觀念翻轉，不是技術翻轉。原本工程師把每個 Codex 對話當成自己延伸出去的手——看著它、糾正它、決定下一步。Symphony 把這層拿掉：
+Symphony 想改掉這件事。任務卡沒有被封鎖，就能開出對應的 Codex 工作區；代理程式如果掛掉，可以重啟；做完的修改、測試輸出、影片證據，回到卡片旁邊，變成一包可審查的結果。
 
-- 每張 Linear 上開放的任務都自動配一個 Codex agent 跟一個專屬工作區
-- Symphony 在背景持續監看任務板，確保「**只要任務單還開著，就有一個 agent 在裡面跑**」
-- agent 當掉就重啟，新任務單進來就接手，整套是個無人值守的循環
+所以小木屋那位工程師不是用手機寫程式碼。手機上看到的是這張卡目前狀態：Codex 是否接到、結果是否回來、證據夠不夠、下一步能不能放行。手機不是縮小版 IDE，而是任務狀態的遙控器。
 
-任務單狀態本身就是個狀態機——「待處理 → 處理中 → 等審核 → 合併 → 完成」這些欄位 Linear 本來就有，Symphony 只是把每個狀態接到對應的 agent 動作上。原作者用了一個值得記下來的描述：「Symphony decouples work from sessions and from pull requests」（Symphony 把「工作」這件事跟對話、PR 解綁）。
+OpenAI 內部某個生產力工具團隊先做過一個激進實驗：專案程式碼庫不收人類手寫程式碼，全部交給 [Codex](/glossary#codex) 生成。真正爆掉的不是 Codex 寫不出來，而是工程師同時顧三到五個 Codex 對話後，開始忘記哪個在跑、哪個卡住、哪個需要接手。
 
-解綁的意義在哪？當任務單變成第一級單位之後，**一張任務單可以對應多個 PR、跨多個程式碼庫，或者完全不產生 PR**——例如「分析這份程式碼庫的架構並產出實作計畫」這種純調查任務，agent 跑完只丟一份報告，沒有任何提交。原本綁在 PR 上的工作流根本沒辦法表達這種任務；任務單抽象上去之後，agent 可以做的事範圍被放大了。
-
-更有意思的是 agent 自己會開新任務。文章寫到，agent 在做某個任務時順手發現「**這裡有個重構機會**」、「**這個地方有效能問題**」——agent 就直接開一張新任務，丟回任務板，等之後被排到。這條工作流在人類團隊也不少見，但變數是現在任務進出的速度被 agent 本身的速度頂著走，**任務板從以前的「待辦清單」變成一個會長大的有向圖**（DAG）。
-
-> Agents only start working on tasks that aren't blocked, so execution unfolds naturally and optimally in parallel for this DAG.
-
-直譯：「agent 只接還沒被卡住的任務，所以執行會自然地以最佳的平行方式展開。」原作者用了 React 升 Vite 那個例子——他們先標記「升級 React」依賴「先遷移到 Vite」，agent 自動先處理 Vite，做完之後才開始升 React。
+遙控器的價值就在這裡：它不是讓人類按更多按鈕，而是讓工作狀態不要塞在人腦裡。
 
 ---
 
-## 那個 500% 的數字、跟值得停下來看的限制條件
+## 遙控器按下去，回來的是審查材料
 
-文章開頭最抓眼球的一句是「500% increase in landed pull requests」。這個數字確實很猛，但翻譯這篇文章前要先把限制條件抓出來——否則一傳出去就會變成「OpenAI 全公司用 Symphony PR 量翻五倍」這種失準的口耳相傳。
+想像任務板上有一張卡：修一個介面問題。條件寫得很死：不能破壞既有測試；完成時要附測試結果；如果畫面有變，還要有產品裡跑起來的影片。
 
-原文寫的是：
+以前這張卡會先落到工程師腦袋裡。工程師開 IDE、開 Codex 對話、貼需求、等它跑、切回終端機看測試、再回任務板更新狀態。
 
-> Among some teams at OpenAI, we saw the number of landed PRs increase by 500% in the first three weeks.
+在 Symphony 的版本裡，這張卡本身就是入口。需求如果寫清楚，結果可能不只是「Codex 改好了」一句話，而是一包審查材料：修改內容、測試紀錄、可驗證的畫面，甚至是功能在真實產品裡跑起來的影片。
 
-直譯：「在 OpenAI 的**某些團隊**，前三個禮拜的 PR 落地數量看到 500% 的增長。」三條限制條件：
+這也解釋為什麼產品經理和設計師會出現在故事裡。他們不需要抓程式碼庫，也不用顧 Codex 對話；需求寫清楚，就可能先拿回可看的版本。工程師仍然負責方向、風險、可維護性、測試、衝突處理，以及最後是否合併。
 
-1. **某些團隊**——不是 OpenAI 全公司，是部分團隊。哪些團隊原文沒講
-2. **前三個禮拜**——這是個短期數字，後續是否維持、是否回落，原文沒給
-3. **PR 落地數**——是合併進主幹的 PR 數量，不是提交數、不是新功能數、也不是業務指標
+部分團隊在導入後前三週，已合併 PR 增加 500%。這個數字要連同邊界一起讀：部分團隊、前三週、已合併 PR。它是早期案例自述，不是全公司長期產能永久翻五倍。
 
-把這三條條件拿掉之後 500% 才有意義。原文是有節制地報告自家觀察，傳達時要把節制感一起傳出去。
+---
 
-文章還引了 Linear 創辦人 Karri Saarinen 的話——Symphony 釋出後 Linear 上**新建工作區的數量出現尖峰**。這條是外部訊號，但同樣只是「上升」，沒給絕對數字。
+## SPEC.md 是遙控器的接線圖
 
-數字之外還有一個畫面值得記下來。原作者用一段話描述工作模式的改變：
+第一版 Symphony 很粗：一個 Codex 對話定期去看 Linear，有新任務就開工。能動，但不穩。後來它搬進 OpenAI 那個「不接受人類手寫程式碼」的程式碼庫，靠既有測試與工具穩下來，最後變成用 Symphony 開發 Symphony。
 
-> One engineer on our team made three significant changes from the Linear app on his phone from a cozy cabin on shoddy wifi.
+開源版沒有把內部完整系統整包丟出來，而是先給 SPEC.md 和參考實作。這比較像接線圖：任務怎麼進來、Codex 怎麼接、結果怎麼回去，寫到外部團隊能照著重做。
 
-直譯：「OpenAI 工程團隊有一位工程師人在某間舒服的小木屋裡、無線網路又爛，光用手機上的 Linear 就推了三個有份量的修改。」
-
-這句話的可信度比 500% 高，因為它具體——具體到地點（小木屋）、具體到設備（手機）、具體到網路品質（爛到爆）、具體到產出（三個修改）。**好的軟體工程承諾通常長這樣，不是百分比，而是具體的場景**。
+接著是規格檢查：讓 Codex 根據同一份規格，用不同技術棧各做一次。目的不是養一排版本，而是逼規格露出缺口。某段描述在一種環境能跑，換一種環境就歪掉，問題可能不是技術棧麻煩，而是 SPEC.md 少寫了一個工程師平常會默默補上的動作。
 
 <ClawdNote>
-[Clawd](/glossary#clawd) 其實對這篇文章最有疑慮的就是 500% 這個數字。不是說它造假，是「**部分團隊、前三週、某個特定指標**」這三層限制堆起來之後，這個數字的意義跟讀者直覺接收到的訊息差距很大。
+這段比 500% 更值得偷學。規格文件平常很容易變漂亮作文：大家點頭、PR 合併，三個月後才發現每個人腦中的版本都不一樣。
 
-舉個對比——如果換成「Cursor 使用者前三週留存率提升 500%」，沒人會說 Cursor 從此革命了 IDE 業界，因為大家都知道前三週會有蜜月期。但同樣的限制套在 OpenAI 自家數字上，因為品牌光環太強，限制條件就被讀者自動過濾掉了。
-
-更實在的訊號其實是後面那句「[每個任務變成更大的工作單位](https://openai.com/index/open-source-codex-orchestration-symphony/)」——當原本要拆成 5 張任務單才動得了的工作，現在 1 張任務單就能讓 agent 一路打通到合併，500% 反而是這個結構性改變的副作用，不是原因。讀者真正要記下來的是「**任務抽象等級提升**」這件事，不是「PR 數翻五倍」這個漂亮數字。
-
-順帶一提，Clawd 跟那位「在小木屋用爛網路推三個修改」的工程師站同一邊——這個畫面才是 Symphony 真正想賣的承諾，比百分比有說服力多了 (◕‿◕)
+叫代理程式照同一份規格用不同方式做幾次，就是便宜版壓力測試。文件如果真的清楚，會活下來；如果只是看起來清楚，第一輪實作就會開始冒煙。
 </ClawdNote>
 
 ---
 
-## PM 跟設計師也能直接派活——但這條藏了一個更深的觀察
+## 遙控器最重要的是撞牆後會記住
 
-當開任務單變便宜之後，誰能開任務單就變得不一樣了。原文這段值得整段引出來：
+那張介面卡第一次不一定會成功。Codex 可能改到錯的地方，可能測試漏跑，可能影片沒附，可能把一個看似簡單的畫面問題牽進更大的架構判斷。
 
-> It also broadens who can initiate work. Our product manager and designer can now file feature requests directly into Symphony. They don't need to check out the repo or manage a Codex session. They describe the feature and get back a review packet that includes a video walkthrough of the feature working inside the real product.
+最省事的做法是工程師手修。這能救一個 PR，但救不了下一張卡。Symphony 的工程習慣，是把失敗當成系統材料：失敗模式可以變成測試、檢查、操作指令、工作說明。代理程式撞牆的位置，下一輪就該多一支護欄。
 
-直譯：「能發起工作的人變多了。產品經理跟設計師現在可以直接在 Symphony 開功能需求單。他們不用拷下整份程式碼庫、不用管 Codex 對話。他們把功能描述清楚，就能拿回一份包含『產品內實際運作影片』的審查包。」
+這也解釋為什麼 Symphony 不打算被包成獨立產品長期維護。它會刻意保持小，重點不是賣一套萬用任務板，而是示範 Codex App Server 這扇門可以怎麼接外部工作系統。Linear 只是這次被接上的那一端；真正被展示的是模式。
 
-這條觀察底下有一個更尖的暗線——當 agent 能把任務從「描述」走到「能展示的成品 + 影片」，那「**寫程式**」這個動作就從產品決策路徑上的瓶頸變成路徑外的雜務。產品經理過去要等工程師排檔期才能驗證一個功能假設；現在他開一張任務單、agent 回他一段影片，假設驗證的時間從幾週壓到幾小時。
+如果任務板真的變成 codebase 遙控器，最大的風險不是按鈕太少，而是按鈕太容易按。所以邊界比入口重要：模糊、需要高判斷力、驗收條件還沒長出來的問題，仍然適合工程師直接跟 Codex 互動。
 
-[同一期 The Batch 349 的 Andrew Ng 信](/posts/sp-185-20260428-andrew-ng-meta-muse-spark-the-batch-349/) 在 4 月 17 號講過幾乎一樣的觀察，只是從另一邊切——Ng 講的是「工程師應該學產品」，OpenAI 這篇講的是「產品經理應該能直接派活」。**兩邊是同一條觀察的兩面**：當 AI 把寫程式變便宜，原本的角色分工就會被重新洗牌，最快的團隊不是讓每個人專精，而是讓每個人都能跨進其他角色的決策空間。
+Symphony 適合的是另一類工作：目標能寫清楚，檢查能自動跑，結果能被審查，失敗能回饋成下一輪規則。任務描述如果太模糊，系統就無法可靠分派；任務描述足夠明確，後面的生成、驗證和審查才有路徑可走。
 
-這條工作流還有一個容易被忽略的副作用——**大型單一儲存庫的「最後一哩」終於有人接手**。原文寫到 Symphony 在大型單一儲存庫（OpenAI 自己就有一個）特別好用，因為合併 PR 的最後一段路通常很慢、很脆弱：
+回到小木屋那支手機。真正厲害的不是手機可以遠端控制 Codex，而是那張任務卡已經被整理到足夠清楚：工程師不用坐在 IDE 前，系統也知道下一步該往哪裡走。
 
-- 監看 CI、需要時自動變基
-- 解衝突、自動重試那些不穩定的檢查
-- 一路把改動推到合併
-
-這些都是工程師最不想做、又一定要有人做的工作。Symphony 把這層接走之後，「**任務單進入合併中狀態**」這個訊號就等同於「**已經高機率會合進主幹，不需要人類盯**」——這不是產出量翻倍那種表面改變，這是合併工作流第一次被當成可被 agent 完整擁有的階段。
-
-<ClawdNote>
-Clawd 在這段最想拉出來的，是「PM 跟設計師也能直接派活」這條對 AI 工具產業的真正威脅。
-
-過去十年所有「給非工程師用的免寫程式工具」（像 Webflow、Bubble、Retool 這類）都在賣同一個夢：讓不會寫程式的人也能做產品。它們的問題從來不是技術，是**抽象層卡得太死**——一旦使用者想做的事情超出工具預設的元件組合，就要請工程師回來救火。
-
-Symphony 走的是相反方向——它不給 PM 一個「拖拉介面就能蓋產品」的低程式碼工具，它直接讓 PM 寫自然語言、agent 把它變成 PR、影片、實際運作的功能。這個抽象層**沒有上限**，因為底下接的是寫程式的 agent，不是預先打包好的元件集合。
-
-對免寫程式／低程式碼工具廠商來說這是個壞消息——他們花了十年解的問題（讓非工程師能造東西）被一個自然語言介面 + 通用 coding agent 直接跨過去。對 PM 跟設計師是好消息：終於有個工具不會在「需求超出工具能力」時把球丟回工程師手上 (ʕ•ᴥ•ʔ)
-</ClawdNote>
-
----
-
-## Symphony 開發 Symphony——以及為什麼用 Elixir
-
-Symphony 第一個版本是個 Codex 對話跑在 tmux 裡，輪詢 Linear、看到新任務就生出一個子 agent。原文老實承認「it worked, but it wasn't particularly reliable」（能動，但不太穩）。第二版搬進主程式碼庫——也就是那個「不准人類寫程式」的程式碼庫——靠著已經建好的 agent harness，第二版才穩下來。
-
-然後有一句話值得停下來：
-
-> Once the basic functionality existed, we used Symphony to build Symphony.
-
-直譯：「基本功能跑起來之後，OpenAI 工程團隊就用 Symphony 來開發 Symphony。」這是個遞迴——他們把開發 Symphony 本身的工作流，丟回 Symphony 自己去管：開任務、agent 接手、產出 PR，整套用自己造的工具吃自己的狗糧。
-
-更值得注意的是**正式對外開源時做的選擇**。原作者沒有把內部程式碼庫直接推出去，而是做了三件事：
-
-1. 把核心想法抽出來變成一份獨立的 SPEC.md
-2. 叫 Codex 照這份 SPEC 從零實作
-3. 為了參考實作，**選了 Elixir**
-
-第三點是這篇文章裡最反直覺的選擇。Elixir 不是矽谷主流——比例大概像台灣餐飲界的義式冷麵，存在但不是熱門選項。原作者在文章裡寫得很直白：
-
-> Because when code is effectively free, you can finally pick languages for their strengths, like Elixir's concurrency.
-
-直譯：「當寫程式的成本趨近於零的時候，團隊終於可以為了語言本身的長處選語言——像 Elixir 在並行性上的優勢。」
-
-這句話翻成現實的判斷是這樣：以前選 Go 或 Python 不只是因為它們夠用，是因為團隊裡會這個語言的人多、人才市場深。當會寫程式的「人」變成 agent，那「**人才市場深度**」這個變數的重要性會下降，變成「**這個語言在這個任務上的技術契合度**」變成更重要的考量。Elixir 的 BEAM 虛擬機跟 OTP 框架在做監督樹跟並行進程上是少數能直接上場的選項，剛好是 Symphony 這種編排系統的天然契合點。
-
-但他們沒停在 Elixir。為了打磨 SPEC，**原作者讓 Codex 把同一份規格實作了 TypeScript、Go、Rust、Java、Python 五個版本**——目的不是釋出五個程式碼庫，是「用多個實作來找規格本身的歧義」。哪個地方在某個語言生效但在另一個語言模糊，那就是規格寫得不夠精準。原文寫「It succeeded in every language」——五個版本都成功跑起來，這同時驗證了 Codex 的多語言能力跟 SPEC 本身的清晰度。
-
-<ClawdNote>
-Clawd 在這段最想拉出來講的，是「**用多個實作打磨同一份規格**」這個動作。
-
-這在 IETF 圈子裡是有名的傳統——一份 RFC 通常要等到至少兩個獨立實作能互通，才算正式釋出。OpenAI 工程團隊把這個古典做法拉回來用，差別是他們不需要找另一個團隊來寫第二份實作，**他們叫 Codex 寫五份**。
-
-這對獨立開發者的意義很實際：以後寫 SDK、設計通訊協定、規劃 API 介面的時候，**多語言的實作不再是奢侈品**。要驗證自己寫的規格是不是真的清楚，不是找人審查，而是叫 Codex 用三個不同語言實作一遍，看哪裡接不起來——這比讀 100 篇審查留言都有效，而且成本是 $0（如果用自家本機模型）到幾十美元（如果用 API）。
-
-Clawd 私心覺得這是這篇文章裡最被低估的一條教訓。500% PR 那個數字會被報導，但「叫 Codex 寫五個語言版本來打磨 SPEC」這種操作習慣才是會留下來的工程文化變化 (⌐■_■)
-
-對了，社群也已經先動了一步——[CP-179 那篇 (2026-03-16)](/posts/cp-179-20260316-daniel-mac8-symphony-manage-work-not-agents/) 講的就是 daniel_mac8 在 X 上展示一個社群版的 Elixir 實作，比 OpenAI 這次 4 月 27 日的官方開源還要早一個多月。意思是這個概念 OpenAI 內部跑了半年、社群在 3 月就嗅到味道、4 月底 OpenAI 才把規格正式化釋出。Symphony 不是天上掉下來的新東西，是把一條已經在野生的工作模式定型寫下來。
-</ClawdNote>
-
----
-
-## 但放掉對話控制權，代價是什麼？
-
-這篇文章難得的是它有交代痛點。轉成任務單級別派活之後，工程師失去了「**即時介入修正方向**」這件事的能力。原文寫「sometimes the agent produced something that completely missed the mark」（有時候 agent 產出的東西完全跑偏）。
-
-OpenAI 工程團隊的回應是一句很簡潔的方針：
-
-> Instead of patching the result manually, we added guardrails and skills so the agents could succeed the next time.
-
-直譯：「不要自己動手修結果，而是加新的防護欄跟技能讓 agent 下次能做對。」
-
-這是一條會被低估的工程紀律。修一次缺陷跟「**讓 agent 從此不會再犯這個缺陷**」是兩件事，後者才是把工作流真正自動化的方法。落實到 Symphony 的 harness，他們陸續加了：
-
-- 跑端到端測試的能力
-- 透過 Chrome DevTools 操控應用程式
-- 管 QA 冒煙測試
-- 寫文件、明確說「好的成品長什麼樣」
-
-每一條都對應到一類「agent 之前會踩到」的失敗模式。**這份失敗紀錄本身就是隱性的規格**——agent 踩過的雷，被翻譯成防護欄之後就變成系統的一部分。
-
-但同時原作者也明白寫了一條限制：「not every task fits the Symphony style of work」（不是每個任務都適合 Symphony 這套）。模糊的、需要強判斷力的問題還是要工程師親自跟 Codex 對話。原文補了一句很有意思的話——「these are usually the most interesting and enjoyable tasks for our engineers to spend time on」（這些往往才是工程師花時間花得最爽的任務）。
-
-換句話說 Symphony 不是要把工程師從工作裡擠出去，是把**工程師花時間在不喜歡做的事情**這條成本砍掉。例行 PR、合併、CI 維護這些重複性高的工作丟給 agent；那些有趣的、需要判斷力的、模糊的問題留給人。**這條分工本身比 500% 那個數字更值得記住**——它是個關於「人類工程師應該怎麼花時間」的明確態度。
-
-<ClawdNote>
-這條「不要修結果、要修系統」的紀律 Clawd 想多吐槽一下，因為這是**獨立工程師最容易踩偏的雷**。
-
-當 agent 出錯，最快的反應永遠是「啊我自己改一下就好」。但這個動作其實是在偷工——下一次 agent 還會犯同一個錯，下下次也是，直到工程師被同樣的修改重複到崩潰，才會回頭問「為什麼一開始不修系統」。
-
-OpenAI 工程團隊在這篇文章裡講的不是新觀念——這就是豐田那套**「五個為什麼」**的軟體版本。發現問題不是要立刻修症狀，是問五次「為什麼」一路追到根因，再去修根因。差別是豐田修的是生產線上的物理機器，OpenAI 工程團隊修的是 agent 的 harness、技能、文件。
-
-對個人開發者來說，這條翻譯成行動是這樣：**每次發現自己手動修補一個 agent 產出，停下來問「這次的修改可不可以變成下次的提示？」** 如果可以——把它寫成技能、寫成 CLAUDE.md 條目、寫成 hooks。如果不能——記下來，等下次再遇到一樣的場景時把它變成可重用的東西。Clawd 看過太多人手動改 100 次同一種錯誤、然後抱怨 agent 不夠聰明 (¬‿¬)
-</ClawdNote>
-
----
-
-## 「OpenAI 工程團隊不會把它當產品維護」——為什麼這句話比開源還重要
-
-文章結尾那段最值得讀的是 OpenAI 工程團隊對這套東西的定位：
-
-> Symphony is an intentionally minimal orchestration layer. We're open sourcing it to demonstrate the power of Codex App Server when paired with different workflow tools, like Linear. As such, we don't plan to maintain Symphony as a standalone product.
-
-直譯：「Symphony 是一層刻意保持最簡的編排層。OpenAI 工程團隊把它開源是為了展示 Codex 應用伺服器配上 Linear 這類工作流工具的可能性。因此，OpenAI 工程團隊**不打算把 Symphony 當成獨立產品來維護**。」
-
-這句話表面是「不維護」，底下的含意更大。OpenAI 的真正產品是 Codex 跟它的應用伺服器模式——一個有完整文件的 JSON-RPC 介面、可以被外部程式化操控的 agent 執行環境。Symphony 只是「**這個應用伺服器怎麼跟外部工作流工具接起來**」的一份參考實作。原作者明白寫：「希望讀者把自家的 coding agent 對著這份 SPEC，去做適合自家環境的版本」。
-
-這條策略選擇值得拿來跟前一篇 harness 工程文章比。當時那篇文章被很多開發者拿去當程式碼庫的骨架指南，Symphony 這次也走同樣的路——**不賣產品，賣模式**。模式比產品更便宜複製，但也更難變成鎖定使用者的護城河。OpenAI 似乎不在乎護城河，他們在乎的是讓更多開發者把自己的工作流接上 Codex 應用伺服器。**這是「平台」級別的賭注**——用這種開放但不維護的姿態，把編排層的選擇權讓給生態系。
-
-文章的結尾那句話總結得乾脆：
-
-> You can just build things with Codex.
-
-直譯：「就用 Codex 把東西造出來吧。」沒有行銷文宣，沒有路線圖，沒有候補名單。一份 SPEC、一份 Elixir 實作、一個 GitHub 儲存庫（**截至 2026 年 4 月 23 日已經拿到超過 15,000 顆星**），剩下的交給社群決定。
-
----
-
-## 結語
-
-回到開頭那句觀察：「**人類的注意力是新的瓶頸**」。
-
-這篇文章如果只能帶走一條，不是 500%、不是 Elixir、不是任務板控制台——是這條：當前一代瓶頸被打通，水會流到下一個低點。Codex 解掉了「寫程式」這個瓶頸，下一個低點是「人在多任務之間切換的成本」。Symphony 砍掉這個低點，下一個低點會是什麼？
-
-原作者自己留了一條暗線值得記下來：他們覺得**未來各家公司的瓶頸會從「寫程式」整個移到「管理 agent 工作流」**。這意味著「工程師」這個角色的內涵會慢慢從「寫程式的人」變成「**設計工作流、維護防護欄、決定 agent 該往哪走的人**」。Symphony 是這個未來的一個早期示範，但它不是終點。
-
-那個在小木屋用爛網路推三個修改的工程師，他真正展示的不是 Symphony 多猛——是當寫程式不再卡人，**工程師可以從哪些地方做事**。從家裡、從咖啡店、從旅行途中、從手機上的 Linear 介面——只要他能描述清楚自己想要什麼，agent 就能接手把它寫出來。
-
-這是 Symphony 真正想賣的東西。不是 PR 翻五倍，不是 Elixir 多優雅，是這個畫面背後那個更基本的轉移——**「寫程式」這件事正在變成「描述工作」這件事**，而描述工作可以在任何地方發生。
+這才是 Symphony 官方版補上的工程問題：寫程式變快以後，工作要怎麼被交出去、驗回來，並把失敗轉成下一輪可重用的檢查。

--- a/src/content/posts/sp-187-20260428-openai-symphony-codex-orchestration.mdx
+++ b/src/content/posts/sp-187-20260428-openai-symphony-codex-orchestration.mdx
@@ -78,7 +78,7 @@ import ClawdNote from '../../components/ClawdNote.astro';
 Linear 在這篇可以先想成任務板；PR 是一包準備審查與合併的修改；Codex App Server 暫時想成「外部工具叫 Codex 接工作的門」。名詞很多，但真正要看的只有一件事：任務板怎麼從待辦清單變成操作介面。
 
 <ClawdNote>
-Clawd 會先記小木屋那張圖，不會先記 500% 那個數字 (◕‿◕)
+[Clawd](/glossary#clawd) 會先記小木屋那張圖，不會先記 500% 那個數字 (◕‿◕)
 
 數字容易變簡報煙火；畫面比較殘酷。它暗示工程入口正在鬆動：不是每件事都要從 IDE 開始，前提是工作要先被整理成代理程式接得住、工程師看得懂、系統追得上的形狀。
 </ClawdNote>


### PR DESCRIPTION
## Summary
- bump Tribunal/judge prompt runtime from v6/v5-era assumptions to v7
- add SP-187 false-positive calibration reference with exact git/blob pointers
- tighten Librarian/FreshEyes/Vibe/Writer responsibility boundaries
- rewrite SP-187 around the sharper “task board becomes codebase remote control” angle, with early CP-179 context and less duplicate Symphony recap

## Verification
- `node scripts/validate-posts.mjs src/content/posts/sp-187-20260428-openai-symphony-codex-orchestration.mdx src/content/posts/en-sp-187-20260428-openai-symphony-codex-orchestration.mdx`
- `node scripts/check-pronoun-clarity.mjs src/content/posts/sp-187-20260428-openai-symphony-codex-orchestration.mdx`
- `node scripts/check-jingjing.mjs src/content/posts/sp-187-20260428-openai-symphony-codex-orchestration.mdx`
- `pnpm exec astro check`
- `bash scripts/tests/test-frontmatter-scores-v7.sh`
- `bash scripts/tests/test-tribunal-pass-artifact-guards.sh`
- `bash scripts/tests/test-tribunal-publish-worker-changes.sh`
- `bash scripts/tests/test-tribunal-safety-contract.sh`
- `bash scripts/tests/test-tribunal-runner-error-guard.sh`
- `bash scripts/tests/test-tribunal-progress-ledger-migration.sh`
- `TRIBUNAL_ARTIFACT_DIR=/tmp/sp187-v7-angle-c-score-20260525-205302 TRIBUNAL_NO_COMMIT=1 bash scripts/tribunal.sh --score-only src/content/posts/sp-187-20260428-openai-symphony-codex-orchestration.mdx`
  - FactChecker PASS 8
  - Librarian PASS 9
  - FreshEyes PASS 8
  - Vibe PASS 8
  - final build passed
