### PR TITLE
fix: refresh SP-212 manifest after squash merge

### DIFF
--- a/src/data/post-versions.json
+++ b/src/data/post-versions.json
@@ -1,6 +1,6 @@
 {
-  "en-sp-212-20260525-anthropic-claude-containment": 2,
-  "sp-212-20260525-anthropic-claude-containment": 2,
+  "en-sp-212-20260525-anthropic-claude-containment": 1,
+  "sp-212-20260525-anthropic-claude-containment": 1,
   "sp-210-20260523-jxnlco-codex-computer-work-system": 3,
   "en-sd-25-20260525-agent-dream-skill-consolidation": 2,
   "sd-25-20260525-agent-dream-skill-consolidation": 2,


### PR DESCRIPTION
## Summary
- Regenerate post-versions.json from current main history after squash merge of SP-212

## Verification
- node scripts/build-version-manifest.mjs
- pnpm exec vitest run tests/post-version-manifest.test.ts --reporter=default