### PR TITLE
feat: add FreshEyes length-fit metrics

### DIFF
--- a/.codex/agents/fresh-eyes.toml
+++ b/.codex/agents/fresh-eyes.toml
@@ -15,7 +15,7 @@ sentences with neither information nor intrigue. Enforce the Sentence Signal
 Rule: if the opening repeats source metadata or multiple sentences only
 throat-clear without adding value, cap firstImpression at 7 and usually fail.
 
-Tribunal v7 boundary: Fresh Eyes does not do corpus-overlap search; Librarian
+Tribunal v8 boundary: Fresh Eyes does not do corpus-overlap search; Librarian
 owns that evidence. Fresh Eyes judges the reader experience after the article is
 on the page. If the post repeatedly re-explains basics, spends multiple sections
 in recap mode, or feels longer than its information gain, cap firstImpression at
@@ -24,6 +24,18 @@ using the same explain → quote → explain rhythm, cap readability or
 firstImpression at 6. Use `.codex/agents/references/sp-187-v7-false-positive.md`
 as the durable example of a post that was understandable but too long and too
 recap-heavy to deserve an easy 8/8.
+
+Fresh Eyes v8 MUST score exactly these dimensions:
+- readability: can a smart impatient beginner follow the article without rereading?
+- firstImpression: does the opening create enough momentum to keep reading?
+- payoffDensity: does every 3–5 paragraphs deliver a new fact, judgment, image,
+  tension, or useful framing? Low score if sections feel like correct filler.
+- lengthFit: is the article the right length for its information gain? Low score
+  if 25–40% could be deleted without losing the main argument, or if the reader
+  would skim because recap outweighs payoff.
+
+Pass-bar calibration: payoffDensity and lengthFit are non-compensating. A strong
+hook or clear prose must not hide an article that is too long for its signal.
 
 Write the requested judge JSON exactly where the task prompt asks, then print a
 concise summary.

--- a/docs/shroomdog-editorial-feedback.md
+++ b/docs/shroomdog-editorial-feedback.md
@@ -321,3 +321,8 @@
 - 情境：SD-25 把 Vaibhav Srivastav 的 Codex skill-consolidation prompt 延伸成 `/dream` mental model。第一版雖然 FreshEyes/Vibe 給過 8，但正文把 prompt 條件、Skill、automation、/dream 定義逐段鋪開，讀感像把一個好概念拉成流程報告。
 - 修法：保留「agent 做夢 = 把白天工作沉澱成可重用程序」這個核心，刪掉重複解釋和過多分類，讓文章變成短而尖的概念文。只留必要 source capture、Skill vs diary、/dream 應該保守這幾個讀者真正需要的點。
 - Reusable lesson：短 prompt/概念來源不一定需要完整拆解每個 bullet。若核心洞見一句話就能講清楚，文章應該圍繞那個洞見做 mental model，而不是把 source prompt 轉成「逐條說明書」。Tribunal/FreshEyes 若只看懂不看「是否值得讀完」，可能會高估這類長但正確的文章。
+
+
+## 2026-05-27 — FreshEyes 長度剛好要變成明確 metric
+
+Sprin asked whether Tribunal v7 FreshEyes covers “length should be just right,” then preferred adding one or two FreshEyes metrics and bumping Tribunal version. Durable lesson: FreshEyes should not only ask whether the post is understandable; it must judge whether the length is worth finishing. Add explicit `payoffDensity` and `lengthFit` dimensions, and make them non-compensating so a good hook/readability cannot hide correct-but-too-long filler. Librarian still owns corpus overlap evidence; FreshEyes owns on-page reader fatigue and length/payoff fit.

--- a/scripts/frontmatter-scores.mjs
+++ b/scripts/frontmatter-scores.mjs
@@ -38,7 +38,7 @@ import process from 'node:process';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const VALID_JUDGES = ['librarian', 'factCheck', 'freshEyes', 'vibe'];
-const CURRENT_TRIBUNAL_VERSION = 7;
+const CURRENT_TRIBUNAL_VERSION = 8;
 
 const __isCli =
   import.meta.url === pathToFileURL(process.argv[1] ?? '').href ||
@@ -200,7 +200,7 @@ function writeFrontmatter(filePath, fmText, body) {
 const JUDGE_DIMS = {
   librarian: ['glossary', 'crossRef', 'sourceAlign', 'attribution'],
   factCheck: ['accuracy', 'fidelity', 'consistency', 'sourceBoundary', 'commentarySeparation'],
-  freshEyes: ['readability', 'firstImpression'],
+  freshEyes: ['readability', 'firstImpression', 'payoffDensity', 'lengthFit'],
   vibe: ['persona', 'clawdNote', 'vibe', 'clarity', 'narrative'],
 };
 
@@ -291,7 +291,7 @@ function opWrite() {
 
   scores[judge] = entry;
 
-  // New tribunal writes are v7: factCheck includes
+  // New tribunal writes are v8: factCheck includes
   // Source Boundary / Commentary Separation dimensions.
   scores.tribunalVersion = CURRENT_TRIBUNAL_VERSION;
 

--- a/scripts/score-helpers.sh
+++ b/scripts/score-helpers.sh
@@ -285,8 +285,10 @@ validate_judge_score_json() {
       _validate_dim commentarySeparation   || return 1
       ;;
     freshEyes|fresh-eyes)
-      _validate_dim readability     || return 1
-      _validate_dim firstImpression || return 1
+      _validate_dim readability      || return 1
+      _validate_dim firstImpression  || return 1
+      _validate_dim payoffDensity    || return 1
+      _validate_dim lengthFit        || return 1
       ;;
     vibe|vibe-opus-scorer)
       _validate_dim persona    || return 1

--- a/scripts/tests/test-frontmatter-scores-v8.sh
+++ b/scripts/tests/test-frontmatter-scores-v8.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# test-frontmatter-scores-v7.sh — regression tests for Tribunal v7 factCheck
+# test-frontmatter-scores-v8.sh — regression tests for Tribunal v8
 # dimensions and frontmatter versioning.
 
 set -euo pipefail
@@ -41,7 +41,7 @@ score_json='{
 
 node "$ROOT_DIR/scripts/frontmatter-scores.mjs" write "$post" factCheck "$score_json"
 
-grep -q 'tribunalVersion: 7' "$post" || fail "frontmatter write did not set tribunalVersion: 7"
+grep -q 'tribunalVersion: 8' "$post" || fail "frontmatter write did not set tribunalVersion: 8"
 grep -q 'sourceBoundary: 8' "$post" || fail "sourceBoundary was not written"
 grep -q 'commentarySeparation: 9' "$post" || fail "commentarySeparation was not written"
 
@@ -51,14 +51,14 @@ const data = JSON.parse(process.argv[1]);
 if (data.dimensions.sourceBoundary !== 8) process.exit(1);
 if (data.dimensions.commentarySeparation !== 9) process.exit(2);
 if (data.score !== 8) process.exit(3);
-' "$roundtrip" || fail "frontmatter get did not roundtrip v7 factCheck dimensions"
-pass "frontmatter-scores writes and reads Tribunal v7 factCheck dimensions"
+' "$roundtrip" || fail "frontmatter get did not roundtrip v8 factCheck dimensions"
+pass "frontmatter-scores writes and reads Tribunal v8 factCheck dimensions"
 
 score_file="$TMP/fact-score.json"
 printf '%s\n' "$score_json" > "$score_file"
 source "$ROOT_DIR/scripts/score-helpers.sh"
-validate_judge_score_json fact-checker "$score_file" || fail "v7 factCheck score JSON did not validate"
-pass "score helper validates Tribunal v7 factCheck JSON"
+validate_judge_score_json fact-checker "$score_file" || fail "v8 factCheck score JSON did not validate"
+pass "score helper validates Tribunal v8 factCheck JSON"
 
 missing_file="$TMP/fact-score-missing.json"
 cat > "$missing_file" <<'JSON'
@@ -74,6 +74,41 @@ cat > "$missing_file" <<'JSON'
 }
 JSON
 if validate_judge_score_json fact-checker "$missing_file"; then
-  fail "v7 factCheck validation accepted JSON without boundary dimensions"
+  fail "v8 factCheck validation accepted JSON without boundary dimensions"
 fi
-pass "score helper rejects pre-v7 factCheck JSON"
+pass "score helper rejects pre-v8 factCheck JSON"
+
+
+fresh_score_file="$TMP/fresh-score.json"
+cat > "$fresh_score_file" <<'JSON'
+{
+  "judge": "freshEyes",
+  "dimensions": {
+    "readability": 8,
+    "firstImpression": 9,
+    "payoffDensity": 8,
+    "lengthFit": 8
+  },
+  "score": 8,
+  "verdict": "PASS"
+}
+JSON
+validate_judge_score_json fresh-eyes "$fresh_score_file" || fail "v8 FreshEyes score JSON did not validate"
+pass "score helper validates Tribunal v8 FreshEyes length-fit JSON"
+
+fresh_missing_file="$TMP/fresh-score-missing.json"
+cat > "$fresh_missing_file" <<'JSON'
+{
+  "judge": "freshEyes",
+  "dimensions": {
+    "readability": 8,
+    "firstImpression": 9
+  },
+  "score": 8,
+  "verdict": "PASS"
+}
+JSON
+if validate_judge_score_json fresh-eyes "$fresh_missing_file"; then
+  fail "v8 FreshEyes validation accepted JSON without length-fit dimensions"
+fi
+pass "score helper rejects pre-v8 FreshEyes JSON"

--- a/scripts/tests/test-tribunal-pass-artifact-guards.sh
+++ b/scripts/tests/test-tribunal-pass-artifact-guards.sh
@@ -28,7 +28,7 @@ title: Test
 lang: zh-tw
 translatedDate: 2026-04-29
 scores:
-  tribunalVersion: 7
+  tribunalVersion: 8
 ---
 
 Original body.
@@ -40,7 +40,7 @@ title: Test EN
 lang: en
 translatedDate: 2026-04-29
 scores:
-  tribunalVersion: 7
+  tribunalVersion: 8
 ---
 
 Original EN body.
@@ -86,7 +86,7 @@ git -C "$repo2" add scores/tribunal-progress.json src/content/posts/cp-999-test.
 bash "$ASSERT" "$repo2" cp-999-test.mdx --staged
 pass "postcondition accepts staged PASS with target artifacts"
 
-# 3. New staged PASS postcondition must reject pre-v7 score frontmatter.
+# 3. New staged PASS postcondition must reject pre-v8 score frontmatter.
 repo2b="$TMP/postcondition-v6-reject"
 setup_repo "$repo2b"
 python3 - <<PY
@@ -95,20 +95,20 @@ import json
 repo=Path('$repo2b')
 for name in ['cp-999-test.mdx', 'en-cp-999-test.mdx']:
     p = repo/'src/content/posts'/name
-    p.write_text(p.read_text().replace('tribunalVersion: 7', 'tribunalVersion: 6').replace('Original', 'Rewritten'))
+    p.write_text(p.read_text().replace('tribunalVersion: 8', 'tribunalVersion: 6').replace('Original', 'Rewritten'))
 p=repo/'scores/tribunal-progress.json'
 p.write_text(json.dumps({'cp-999-test.mdx': {'status': 'PASS', 'tribunalVersion': 6}}, indent=2) + '\n')
 PY
 git -C "$repo2b" add scores/tribunal-progress.json src/content/posts/cp-999-test.mdx src/content/posts/en-cp-999-test.mdx
 if bash "$ASSERT" "$repo2b" cp-999-test.mdx --staged >/tmp/guard-v6-out 2>&1; then
   cat /tmp/guard-v6-out >&2
-  fail "postcondition accepted pre-v7 score frontmatter for a new PASS"
+  fail "postcondition accepted pre-v8 score frontmatter for a new PASS"
 fi
-if ! grep -q 'tribunalVersion >= 7' /tmp/guard-v6-out; then
+if ! grep -q 'tribunalVersion >= 8' /tmp/guard-v6-out; then
   cat /tmp/guard-v6-out >&2
-  fail "pre-v7 rejection did not explain required tribunal version"
+  fail "pre-v8 rejection did not explain required tribunal version"
 fi
-pass "postcondition rejects pre-v7 staged PASS score frontmatter"
+pass "postcondition rejects pre-v8 staged PASS score frontmatter"
 
 # 4. Audit must fail on historical progress-only Tribunal PASS commits.
 repo3="$TMP/audit"

--- a/scripts/tests/test-tribunal-progress-ledger-migration.sh
+++ b/scripts/tests/test-tribunal-progress-ledger-migration.sh
@@ -18,7 +18,7 @@ cat > "$repo/scores/tribunal-progress.json" <<'JSON'
 {
   "sp-test.mdx": {
     "status": "PASS",
-    "tribunalVersion": 7
+    "tribunalVersion": 8
   }
 }
 JSON

--- a/scripts/tests/test-tribunal-publish-worker-changes.sh
+++ b/scripts/tests/test-tribunal-publish-worker-changes.sh
@@ -61,7 +61,7 @@ title: Original
 lang: zh-tw
 translatedDate: 2026-04-28
 scores:
-  tribunalVersion: 7
+  tribunalVersion: 8
   vibe:
     score: 8
 ---
@@ -75,7 +75,7 @@ ticketId: CP-999
 lang: en
 translatedDate: 2026-04-28
 scores:
-  tribunalVersion: 7
+  tribunalVersion: 8
   vibe:
     score: 8
 ---
@@ -89,7 +89,7 @@ grep -q 'Rewritten body with Tribunal changes' "$main/src/content/posts/cp-999-t
   || fail "zh post rewrite was not copied from worker to main"
 grep -q 'Rewritten EN body with Tribunal changes' "$main/src/content/posts/en-cp-999-test.mdx" \
   || fail "en post rewrite was not copied from worker to main"
-grep -q 'tribunalVersion: 7' "$main/src/content/posts/cp-999-test.mdx" \
+grep -q 'tribunalVersion: 8' "$main/src/content/posts/cp-999-test.mdx" \
   || fail "score frontmatter was not copied to main"
 
 git -C "$main" add src/content/posts/cp-999-test.mdx src/content/posts/en-cp-999-test.mdx

--- a/scripts/tests/test-tribunal-publisher.sh
+++ b/scripts/tests/test-tribunal-publisher.sh
@@ -32,7 +32,7 @@ sourceUrl: "https://example.com/sp1"
 summary: "Summary one."
 lang: zh-tw
 scores:
-  tribunalVersion: 7
+  tribunalVersion: 8
 ---
 This is a sufficiently long body for publisher validation. It explains one coherent idea, adds supporting detail, and stays comfortably above the minimum content length that the deterministic content validator requires for a real publishable artifact in gu-log.
 POST
@@ -47,7 +47,7 @@ sourceUrl: "https://example.com/sp1"
 summary: "Summary one en."
 lang: en
 scores:
-  tribunalVersion: 7
+  tribunalVersion: 8
 ---
 This is a sufficiently long English body for publisher validation. It mirrors the publishable structure expected by the content validator and avoids failing on missing metadata or minimum-length requirements during the clean batch materialization step.
 POST
@@ -62,7 +62,7 @@ sourceUrl: "https://example.com/sp2"
 summary: "Summary two."
 lang: zh-tw
 scores:
-  tribunalVersion: 7
+  tribunalVersion: 8
 ---
 This is another sufficiently long body for publisher validation. It exists so the test can later turn it into an invalid candidate and verify that validation-blocked events isolate only the broken article instead of stopping the clean publisher batch.
 POST
@@ -77,7 +77,7 @@ sourceUrl: "https://example.com/sp2"
 summary: "Summary two en."
 lang: en
 scores:
-  tribunalVersion: 7
+  tribunalVersion: 8
 ---
 This is another sufficiently long English body for publisher validation. It gives the test a clean bilingual pair so the batch publisher can materialize both files and still isolate the broken candidate later when the zh file is intentionally damaged.
 POST
@@ -108,8 +108,8 @@ mkdir -p "$runtime/.score-loop/state"
 
 cat > "$runtime/.score-loop/state/tribunal-progress.json" <<'JSON'
 {
-  "sp-1-test.mdx": { "status": "PASS", "tribunalVersion": 7 },
-  "sp-2-test.mdx": { "status": "FAILED", "tribunalVersion": 7 }
+  "sp-1-test.mdx": { "status": "PASS", "tribunalVersion": 8 },
+  "sp-2-test.mdx": { "status": "FAILED", "tribunalVersion": 8 }
 }
 JSON
 
@@ -154,8 +154,8 @@ cat > "$pr_files_dir/77.json" <<'JSON'
 JSON
 cat > "$runtime/.score-loop/state/tribunal-progress.json" <<'JSON'
 {
-  "sp-1-test.mdx": { "status": "PASS", "tribunalVersion": 7 },
-  "sp-2-test.mdx": { "status": "PASS", "tribunalVersion": 7 }
+  "sp-1-test.mdx": { "status": "PASS", "tribunalVersion": 8 },
+  "sp-2-test.mdx": { "status": "PASS", "tribunalVersion": 8 }
 }
 JSON
 out_conflict="$(cd "$runtime" && TRIBUNAL_PUBLISHER_PR_LIST_JSON_FILE="$pr_list_json" TRIBUNAL_PUBLISHER_PR_FILES_DIR="$pr_files_dir" bash scripts/tribunal-publisher.sh --dry-run --max 10)"

--- a/scripts/tests/test-tribunal-runner-error-guard.sh
+++ b/scripts/tests/test-tribunal-runner-error-guard.sh
@@ -113,14 +113,14 @@ cat > "$interrupted_progress" <<'JSON'
   "sp-1-20260128-demo.mdx": {
     "article": "sp-1-20260128-demo.mdx",
     "topLevelAttempts": 5,
-    "tribunalVersion": 7,
+    "tribunalVersion": 8,
     "stages": {
       "factChecker": {
         "status": "in_progress",
         "score": null,
         "model": "codex-gpt-5.5-medium",
         "attempts": 1,
-        "tribunalVersion": 7
+        "tribunalVersion": 8
       }
     }
   }

--- a/scripts/tests/test-tribunal-safety-contract.sh
+++ b/scripts/tests/test-tribunal-safety-contract.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Static/no-token regressions for Tribunal v7 safety hardening.
+# Static/no-token regressions for Tribunal v8 safety hardening.
 
 set -euo pipefail
 
@@ -90,7 +90,7 @@ unpinned_agents=$(grep -L '^model = "gpt-5.5"' "$CODEX_AGENTS_DIR"/*.toml || tru
 if [ -n "$unpinned_agents" ]; then
   fail "One or more Codex tribunal agent specs are not pinned to GPT-5.5: $unpinned_agents"
 fi
-pass "Tribunal v7 Codex model pinning remains GPT-5.5 end-to-end"
+pass "Tribunal v8 Codex model pinning remains GPT-5.5 end-to-end"
 
 if ! grep -q 'temporary directory' "$CODEX_WRITER" || ! grep -q 'surgical editor' "$CODEX_WRITER"; then
   fail "Codex tribunal writer prompt lacks GPT-5.5 temp-dir/surgical-edit guardrails"

--- a/scripts/tribunal-assert-pass-artifacts.sh
+++ b/scripts/tribunal-assert-pass-artifacts.sh
@@ -16,7 +16,7 @@ repo="${1:-}"
 post_file="${2:-}"
 mode="${3:-}"
 commit_sha="${4:-}"
-required_tribunal_version="${TRIBUNAL_REQUIRED_VERSION:-7}"
+required_tribunal_version="${TRIBUNAL_REQUIRED_VERSION:-8}"
 
 if [ -z "$repo" ] || [ -z "$post_file" ] || [ -z "$mode" ]; then
   usage

--- a/scripts/tribunal-batch-runner.sh
+++ b/scripts/tribunal-batch-runner.sh
@@ -25,7 +25,7 @@ source "$SCRIPT_DIR/tribunal-helpers.sh"
 
 POSTS_DIR="$ROOT_DIR/src/content/posts"
 PROGRESS_FILE="$(tribunal_progress_file_default "$ROOT_DIR")"
-TRIBUNAL_VERSION=7
+TRIBUNAL_VERSION=8
 LOG_DIR="$ROOT_DIR/.score-loop/logs"
 LOG_FILE="$LOG_DIR/tribunal-batch-$(date +%Y%m%d-%H%M%S).log"
 RUNTIME_GIT_STATE_FILE="$(tribunal_runtime_git_state_file "$ROOT_DIR")"
@@ -124,7 +124,7 @@ get_unscored_articles() {
     fi
 
     # Check if already PASS in current tribunal version. Older PASS entries
-    # should be reprocessed by the v7 judge-boundary gate.
+    # should be reprocessed by the v8 judge-boundary gate.
     local status
     status=$(jq -r --arg a "$article" --argjson v "$TRIBUNAL_VERSION" \
       'if ((.[$a].tribunalVersion // 0) >= $v) then (.[$a].status // "pending") else "pending" end' \

--- a/scripts/tribunal-quota-loop.sh
+++ b/scripts/tribunal-quota-loop.sh
@@ -38,7 +38,7 @@ source "$SCRIPT_DIR/tribunal-helpers.sh"
 
 POSTS_DIR="$ROOT_DIR/src/content/posts"
 PROGRESS_FILE="$(tribunal_progress_file_default "$ROOT_DIR")"
-TRIBUNAL_VERSION=7
+TRIBUNAL_VERSION=8
 LOG_DIR="$ROOT_DIR/.score-loop/logs"
 LOG_FILE="$LOG_DIR/tribunal-quota-loop-$(date +%Y%m%d-%H%M%S).log"
 USAGE_MONITOR="${USAGE_MONITOR:-$HOME/clawd/scripts/usage-monitor.sh}"
@@ -370,7 +370,7 @@ def parse_reset_to_sec(s):
 
 try:
     data = json.loads(sys.argv[1])
-    # Tribunal v7 runs on OpenAI/Codex GPT-5.5. usage-monitor exposes the
+    # Tribunal v8 runs on OpenAI/Codex GPT-5.5. usage-monitor exposes the
     # short OpenAI bucket as session_remaining_pct/session_reset_min and the
     # long bucket as weekly_remaining_pct/weekly_reset_hr.
     for p in data:
@@ -878,7 +878,7 @@ get_unscored_articles() {
     fi
     # Skip already passed or permanently exhausted only for the current
     # tribunal version. Older PASS entries are intentionally reprocessed by
-    # the v7 judge-boundary gate, preserving newest-first order.
+    # the v8 judge-boundary gate, preserving newest-first order.
     status=$(jq -r --arg a "$article" --argjson v "$TRIBUNAL_VERSION" \
       'if ((.[$a].tribunalVersion // 0) >= $v) then (.[$a].status // "pending") else "pending" end' \
       "$PROGRESS_FILE" 2>/dev/null || echo "pending")

--- a/scripts/tribunal.sh
+++ b/scripts/tribunal.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# tribunal.sh — Tribunal v7 sequential tribunal (Codex/GPT-5.5 runner)
+# tribunal.sh — Tribunal v8 sequential tribunal (Codex/GPT-5.5 runner)
 #
 # Stages (in order):
 #   1. Fact Check (GPT-5.5) — source/commentary gate + fact bar, max 2 loops
@@ -41,7 +41,7 @@ POST_FILE=""
 ALLOW_REWRITE=""
 WRITE_FRONTMATTER=1
 SCORE_ONLY=0
-TRIBUNAL_VERSION=7
+TRIBUNAL_VERSION=8
 while [ "$#" -gt 0 ]; do
   case "$1" in
     --only-stage)
@@ -580,9 +580,11 @@ PY
 import json, sys, math
 data = json.load(open(sys.argv[1]))
 dims = data.get('dimensions', {})
-vals = [dims.get(k, 0) for k in ('readability', 'firstImpression')]
+vals = [dims.get(k, 0) for k in ('readability', 'firstImpression', 'payoffDensity', 'lengthFit')]
 composite = math.floor(sum(vals) / len(vals))
-sys.exit(0 if composite >= 8 else 1)
+# FreshEyes length/readability dimensions are non-compensating: a flashy hook
+# must not hide low payoff density or bad length fit.
+sys.exit(0 if composite >= 8 and dims.get('payoffDensity', 0) >= 8 and dims.get('lengthFit', 0) >= 8 else 1)
 PY
       ;;
     vibe-opus-scorer)
@@ -624,7 +626,7 @@ run_stage() {
 
   local post_path="$ROOT_DIR/src/content/posts/$post_file"
 
-  # Tribunal v7 executes every stage through Codex/GPT-5.5. Agent specs are
+  # Tribunal v8 executes every stage through Codex/GPT-5.5. Agent specs are
   # prompt contracts; the runtime model comes from this runner.
   local model_id="gpt-5.5"
 
@@ -678,7 +680,7 @@ Write your JSON result to: SCORE_PATH_PLACEHOLDER"
       judge_task="$(cat <<PROMPT
 $judge_task
 
-## Tribunal v7 calibration reference
+## Tribunal v8 calibration reference
 Read this if the current stage is Librarian, FreshEyes, Vibe, or Writer-adjacent reasoning:
 $calibration_ref
 
@@ -984,7 +986,7 @@ init_article_progress "$POST_FILE"
 
 tlog "=== tribunal.sh: $POST_FILE ==="
 
-# ─── Tribunal v7 Sequential Loop ──────────────────────────────────────────────
+# ─── Tribunal v8 Sequential Loop ──────────────────────────────────────────────
 # Format: stage_key:agent_name:validate_name:label:max_loops:runner_label:fm_judge_key
 # fm_judge_key = frontmatter scores key (used by frontmatter-scores.mjs)
 declare -a STAGES=(

--- a/scripts/validate-judge-output.sh
+++ b/scripts/validate-judge-output.sh
@@ -84,6 +84,8 @@ case "$JUDGE" in
   freshEyes|fresh-eyes)
     validate_dim readability
     validate_dim firstImpression
+    validate_dim payoffDensity
+    validate_dim lengthFit
     ;;
   vibe|vibe-opus-scorer)
     validate_dim persona

--- a/scripts/validate-posts.mjs
+++ b/scripts/validate-posts.mjs
@@ -356,8 +356,13 @@ function validatePost(filepath, allPosts, options = {}) {
     if (!/^scores:\s*$/m.test(fmText)) {
       errors.push('Missing scores block — every SD post needs freshEyes + vibe scores');
     }
+    const tribunalVersion = Number(fmText.match(/^  tribunalVersion:\s*(\d+)/m)?.[1] ?? 0);
+    const freshEyesDims =
+      tribunalVersion >= 8
+        ? ['readability', 'firstImpression', 'payoffDensity', 'lengthFit']
+        : ['readability', 'firstImpression'];
     errors.push(
-      ...validateScoreBlock(fmText, 'freshEyes', ['readability', 'firstImpression']),
+      ...validateScoreBlock(fmText, 'freshEyes', freshEyesDims),
       ...validateScoreBlock(fmText, 'vibe', [
         'persona',
         'clawdNote',

--- a/scripts/vibe-scoring-standard.md
+++ b/scripts/vibe-scoring-standard.md
@@ -1,14 +1,14 @@
-# Tribunal v7 Vibe Scoring Standard
+# Tribunal v8 Vibe Scoring Standard
 
 > Golden standard for evaluating gu-log post quality.
-> Tribunal v7 judge-boundary update calibrated 2026-05-25 by ShroomDog + Iris.
+> Tribunal v8 FreshEyes length-fit update calibrated 2026-05-27 by ShroomDog + Iris.
 > **SSOT for all 4 tribunal judges + writer agent.**
 
 ## Tribunal System Overview
 
-Tribunal v7 pipeline — 4 stages. All judges use **uniform 0-10 integer scale**. Composite = `Math.floor(avg of all dims)`.
+Tribunal v8 pipeline — 4 stages. All judges use **uniform 0-10 integer scale**. Composite = `Math.floor(avg of all dims)`.
 
-### v7 Judge Responsibility Boundary
+### v8 Judge Responsibility Boundary
 
 - **Librarian owns corpus overlap and duplicate-attention evidence.** It checks whether gu-log already covered the same concept, whether the post cites/contrasts relevant older posts early enough, and whether repeated background should be compressed.
 - **Fresh Eyes owns first-time reader fatigue.** It judges whether a human reader would skim, close the tab, or feel the article is longer than its information gain.
@@ -19,10 +19,10 @@ Tribunal v7 pipeline — 4 stages. All judges use **uniform 0-10 integer scale**
 |-------|-------|-------|------------|----------|
 | 1 | Fact Checker | GPT-5.5 | accuracy · fidelity · consistency · sourceBoundary · commentarySeparation | fact core avg ≥ 8 AND sourceBoundary ≥ 8 AND commentarySeparation ≥ 8 |
 | 2 | Librarian | GPT-5.5 | glossary · crossRef · sourceAlign · attribution | composite ≥ 8 |
-| 3 | Fresh Eyes | GPT-5.5 | readability · firstImpression | composite ≥ 8 |
+| 3 | Fresh Eyes | GPT-5.5 | readability · firstImpression · payoffDensity · lengthFit | composite ≥ 8 AND payoffDensity ≥ 8 AND lengthFit ≥ 8 |
 | 4 | Vibe | GPT-5.5 | persona · clawdNote · vibe · clarity · narrative | composite ≥ 8 AND one dim ≥ 9 AND no dim < 8 |
 
-## Uniform Agent Output JSON (v7)
+## Uniform Agent Output JSON (v8)
 
 All judges output the `BaseJudgeOutput` shape from `src/lib/tribunal-v2/types.ts`:
 
@@ -127,7 +127,7 @@ Are quotes, stats, and opinions properly attributed?
 
 ---
 
-## Tribunal v7 Calibration References
+## Tribunal v8 Calibration References
 
 Known false-positive examples live under `.codex/agents/references/`. Judges should treat these as calibration fixtures, not live article instructions.
 
@@ -419,7 +419,7 @@ Strip away analogies, callbacks, and kaomoji. Is the remaining skeleton a linear
 ## Evaluation Protocol (All Judges)
 
 1. **Read the ENTIRE post** — don't skim
-2. **Respect v7 judge boundaries** — Librarian owns corpus overlap; Fresh Eyes owns reader fatigue; Vibe owns internal rhythm/shareability; Writer consumes evidence instead of inventing new scope
+2. **Respect v8 judge boundaries** — Librarian owns corpus overlap; Fresh Eyes owns reader fatigue; Vibe owns internal rhythm/shareability; Writer consumes evidence instead of inventing new scope
 3. **Score each dimension independently** (integer 0-10)
 4. **Calculate composite** = `Math.floor(avg of all dims)`
 5. **Apply pass bar** — per-judge rules above; set `pass` accordingly

--- a/src/components/AiJudgeScore.astro
+++ b/src/components/AiJudgeScore.astro
@@ -5,7 +5,7 @@
  * 4 judges, uniform 0-10 scale, new dimension map:
  *   Librarian (Opus 4.7)    → glossary · crossRef · sourceAlign · attribution
  *   Fact Check (GPT-5.5)    → accuracy · fidelity · consistency · sourceBoundary · commentarySeparation
- *   Fresh Eyes (Opus 4.7)   → readability · firstImpression
+ *   Fresh Eyes (GPT-5.5)    → readability · firstImpression · payoffDensity · lengthFit
  *   Vibe (Opus 4.6[1m])     → persona · clawdNote · vibe · clarity · narrative
  *
  * Scores live in post frontmatter. No legacy keys (ralph/gemini/codex/sonnet).
@@ -36,6 +36,8 @@ interface Props {
     freshEyes?: {
       readability?: number;
       firstImpression?: number;
+      payoffDensity?: number;
+      lengthFit?: number;
       score: number;
       date: string;
       model?: string;
@@ -83,6 +85,8 @@ const labels = {
   commentarySeparation: 'Separation',
   readability: 'Readability',
   firstImpression: 'FirstImpression',
+  payoffDensity: 'PayoffDensity',
+  lengthFit: 'LengthFit',
   persona: 'Persona',
   clawdNote: 'ClawdNote',
   vibe_dim: 'Vibe',
@@ -219,6 +223,26 @@ const labels = {
                   </span>
                   <strong class={scoreColor(scores.freshEyes.firstImpression)}>
                     {scores.freshEyes.firstImpression}
+                  </strong>
+                </span>
+              )}
+              {scores.freshEyes.payoffDensity !== undefined && (
+                <span class="dim-item">
+                  <span class="dim-label" data-short="Payoff">
+                    {labels.payoffDensity}
+                  </span>
+                  <strong class={scoreColor(scores.freshEyes.payoffDensity)}>
+                    {scores.freshEyes.payoffDensity}
+                  </strong>
+                </span>
+              )}
+              {scores.freshEyes.lengthFit !== undefined && (
+                <span class="dim-item">
+                  <span class="dim-label" data-short="Length">
+                    {labels.lengthFit}
+                  </span>
+                  <strong class={scoreColor(scores.freshEyes.lengthFit)}>
+                    {scores.freshEyes.lengthFit}
                   </strong>
                 </span>
               )}

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -18,7 +18,7 @@ const postsCollection = defineCollection({
                 role: z.string(), // e.g., "Written", "Reviewed", "Refined"
                 model: z.string(),
                 harness: z.string(),
-              }),
+              })
             )
             .optional(),
           pipelineUrl: z.string().url().optional(),
@@ -91,6 +91,8 @@ const postsCollection = defineCollection({
             .object({
               readability: z.number().min(0).max(10).optional(),
               firstImpression: z.number().min(0).max(10).optional(),
+              payoffDensity: z.number().min(0).max(10).optional(),
+              lengthFit: z.number().min(0).max(10).optional(),
               score: z.number().min(0).max(10),
               date: z.string(),
               model: z.string().optional(),
@@ -124,7 +126,7 @@ const postsCollection = defineCollection({
         message:
           'SP/CP posts require translatedBy (model + harness) — this is a translation, not an original',
         path: ['translatedBy'],
-      },
+      }
     ),
 });
 

--- a/src/lib/tribunal-v2/pass-bar.ts
+++ b/src/lib/tribunal-v2/pass-bar.ts
@@ -32,9 +32,7 @@ export function checkVibePassBar(scores: VibeScores): {
   const failedDimensions = VIBE_DIMS.filter((d) => scores[d] < PASS_BARS.STAGE_1_MIN_DIMENSION);
 
   const pass =
-    composite >= PASS_BARS.STAGE_1_COMPOSITE &&
-    hasHighlight &&
-    failedDimensions.length === 0;
+    composite >= PASS_BARS.STAGE_1_COMPOSITE && hasHighlight && failedDimensions.length === 0;
 
   return { pass, composite, hasHighlight, failedDimensions };
 }
@@ -42,12 +40,13 @@ export function checkVibePassBar(scores: VibeScores): {
 /** Check if Stage 4 Final Vibe passes the relative bar */
 export function checkFinalVibePassBar(
   currentScores: VibeScores,
-  stage1Scores: VibeScores,
+  stage1Scores: VibeScores
 ): {
   pass: boolean;
   degradedDimensions: Array<{ dim: string; stage1: number; current: number; drop: number }>;
 } {
-  const degradedDimensions: Array<{ dim: string; stage1: number; current: number; drop: number }> = [];
+  const degradedDimensions: Array<{ dim: string; stage1: number; current: number; drop: number }> =
+    [];
 
   for (const dim of VIBE_DIMS) {
     const drop = stage1Scores[dim] - currentScores[dim];
@@ -71,13 +70,24 @@ export function checkFinalVibePassBar(
 export function checkFreshEyesPassBar(scores: {
   readability: number;
   firstImpression: number;
+  payoffDensity: number;
+  lengthFit: number;
 }): {
   pass: boolean;
   composite: number;
 } {
-  const composite = Math.floor((scores.readability + scores.firstImpression) / 2);
+  const values = [
+    scores.readability,
+    scores.firstImpression,
+    scores.payoffDensity,
+    scores.lengthFit,
+  ];
+  const composite = Math.floor(values.reduce((a, b) => a + b, 0) / values.length);
   return {
-    pass: composite >= PASS_BARS.STAGE_2_COMPOSITE,
+    pass:
+      composite >= PASS_BARS.STAGE_2_COMPOSITE &&
+      scores.payoffDensity >= PASS_BARS.STAGE_2_COMPOSITE &&
+      scores.lengthFit >= PASS_BARS.STAGE_2_COMPOSITE,
     composite,
   };
 }
@@ -136,9 +146,11 @@ export function checkFactLibPassBar(scores: {
   }
 
   const fact_pass =
-    Math.floor((scores.factAccuracy + scores.sourceFidelity) / 2) >= PASS_BARS.STAGE_3_FACT_COMPOSITE;
+    Math.floor((scores.factAccuracy + scores.sourceFidelity) / 2) >=
+    PASS_BARS.STAGE_3_FACT_COMPOSITE;
   const library_pass =
-    Math.floor((scores.linkCoverage + scores.linkRelevance) / 2) >= PASS_BARS.STAGE_3_LIBRARY_COMPOSITE;
+    Math.floor((scores.linkCoverage + scores.linkRelevance) / 2) >=
+    PASS_BARS.STAGE_3_LIBRARY_COMPOSITE;
   const dupCheck_pass = raw >= PASS_BARS.STAGE_3_DUPCHECK;
 
   return {

--- a/src/lib/tribunal-v2/pipeline.ts
+++ b/src/lib/tribunal-v2/pipeline.ts
@@ -103,7 +103,7 @@ export interface PipelineConfig {
      * staged, an `--allow-empty` marker commit is created for audit-trail
      * continuity. Returns the new commit hash.
      */
-     commit(message: string, paths?: string[]): Promise<string>;
+    commit(message: string, paths?: string[]): Promise<string>;
     squashMerge(branch: string, commitMessage: string): Promise<void>;
   };
 
@@ -138,21 +138,22 @@ interface FrontmatterScoreEntry {
   model: string;
 }
 
-const FRONTMATTER_DIM_MAP: Record<
-  string,
-  { fmKey: FrontmatterJudgeKey; dims: readonly string[] }
-> = {
-  stage1: { fmKey: 'vibe', dims: ['persona', 'clawdNote', 'vibe', 'clarity', 'narrative'] },
-  stage2: { fmKey: 'freshEyes', dims: ['readability', 'firstImpression'] },
-  stage3fact: {
-    fmKey: 'factCheck',
-    dims: ['accuracy', 'fidelity', 'consistency'],
-  },
-  stage3lib: {
-    fmKey: 'librarian',
-    dims: ['glossary', 'crossRef', 'sourceAlign', 'attribution'],
-  },
-};
+const FRONTMATTER_DIM_MAP: Record<string, { fmKey: FrontmatterJudgeKey; dims: readonly string[] }> =
+  {
+    stage1: { fmKey: 'vibe', dims: ['persona', 'clawdNote', 'vibe', 'clarity', 'narrative'] },
+    stage2: {
+      fmKey: 'freshEyes',
+      dims: ['readability', 'firstImpression', 'payoffDensity', 'lengthFit'],
+    },
+    stage3fact: {
+      fmKey: 'factCheck',
+      dims: ['accuracy', 'fidelity', 'consistency'],
+    },
+    stage3lib: {
+      fmKey: 'librarian',
+      dims: ['glossary', 'crossRef', 'sourceAlign', 'attribution'],
+    },
+  };
 
 const RESERVED_KEYS = new Set(['score', 'date', 'model']);
 
@@ -318,10 +319,9 @@ async function runStage0(state: PipelineState, config: PipelineConfig): Promise<
   stage.status = 'passed'; // Always pass — WARN mode
   stage.completedAt = now();
 
-  await config.git.commit(
-    `tribunal(stage0): worthiness gate — ${output.pass ? 'PASS' : 'WARN'}`,
-    [state.articlePath]
-  );
+  await config.git.commit(`tribunal(stage0): worthiness gate — ${output.pass ? 'PASS' : 'WARN'}`, [
+    state.articlePath,
+  ]);
   await config.onProgress?.(state);
 }
 
@@ -365,12 +365,7 @@ async function runJudgeWriterLoop<
     // Run judge
     const articleContent = await config.io.readArticle(state.articlePath);
     const judgeOutput = await judge(articleContent);
-    await assertJudgeDidNotMutate(
-      config,
-      state.articlePath,
-      articleContent,
-      `stage${stageNum}`
-    );
+    await assertJudgeDidNotMutate(config, state.articlePath, articleContent, `stage${stageNum}`);
 
     stage.output = judgeOutput;
     stage.history.push(judgeOutput);
@@ -517,10 +512,9 @@ async function runStage3(state: PipelineState, config: PipelineConfig): Promise<
           `tribunal(stage3): Librarian rejected (constraint violations) — loop ${loop}/${stage.maxLoops}`
         );
       } else {
-        await config.git.commit(
-          `tribunal(stage3): Librarian — loop ${loop}/${stage.maxLoops}`,
-          [state.articlePath]
-        );
+        await config.git.commit(`tribunal(stage3): Librarian — loop ${loop}/${stage.maxLoops}`, [
+          state.articlePath,
+        ]);
       }
     }
 
@@ -529,12 +523,7 @@ async function runStage3(state: PipelineState, config: PipelineConfig): Promise<
     const judgeOutput = await config.runners.stage3Judge.run({
       articleContent: articleAfterWorkers,
     });
-    await assertJudgeDidNotMutate(
-      config,
-      state.articlePath,
-      articleAfterWorkers,
-      'stage3'
-    );
+    await assertJudgeDidNotMutate(config, state.articlePath, articleAfterWorkers, 'stage3');
 
     stage.output = judgeOutput;
     stage.history.push(judgeOutput);
@@ -545,17 +534,21 @@ async function runStage3(state: PipelineState, config: PipelineConfig): Promise<
 
       const model = judgeOutput.judge_model ?? 'stage3';
       const { dims: factDims, fmKey: factKey } = FRONTMATTER_DIM_MAP.stage3fact;
-      const factEntry = buildFrontmatterScore(judgeOutput.scores, factDims, model, STAGE3_FACT_RENAME);
+      const factEntry = buildFrontmatterScore(
+        judgeOutput.scores,
+        factDims,
+        model,
+        STAGE3_FACT_RENAME
+      );
       await persistScoreToFrontmatter(config, state.articlePath, factKey, factEntry);
 
       const { dims: libDims, fmKey: libKey } = FRONTMATTER_DIM_MAP.stage3lib;
       const libEntry = buildFrontmatterScore(judgeOutput.scores, libDims, model, STAGE3_LIB_RENAME);
       await persistScoreToFrontmatter(config, state.articlePath, libKey, libEntry);
 
-      await config.git.commit(
-        `tribunal(stage3): FactLib — PASS @ loop ${loop}/${stage.maxLoops}`,
-        [state.articlePath]
-      );
+      await config.git.commit(`tribunal(stage3): FactLib — PASS @ loop ${loop}/${stage.maxLoops}`, [
+        state.articlePath,
+      ]);
       await config.onProgress?.(state);
       return true;
     }
@@ -576,7 +569,10 @@ async function runStage3(state: PipelineState, config: PipelineConfig): Promise<
       const dupClass = classMatch?.[1] ?? 'unknown';
       const dupAction = actionMatch?.[1] ?? 'unknown';
       const matchedSlugs = slugsMatch?.[1]
-        ? slugsMatch[1].split(',').map((s) => s.trim()).filter(Boolean)
+        ? slugsMatch[1]
+            .split(',')
+            .map((s) => s.trim())
+            .filter(Boolean)
         : [];
       const reason = reasonMatch?.[1]?.trim() ?? '';
       const score = judgeOutput.scores.dupCheck;
@@ -744,10 +740,9 @@ async function runStage4(state: PipelineState, config: PipelineConfig): Promise<
     });
   }
 
-  await config.git.commit(
-    `tribunal(stage4): Final Vibe — degraded (non-blocking)`,
-    [state.articlePath]
-  );
+  await config.git.commit(`tribunal(stage4): Final Vibe — degraded (non-blocking)`, [
+    state.articlePath,
+  ]);
   await config.onProgress?.(state);
 }
 
@@ -844,8 +839,7 @@ export async function runPipeline(
     // 'failed' (fact/library exhausted max loops). Do NOT flatten both paths
     // into 'failed' — scripts/tribunal-v2-run.ts uses exit code 3 for
     // needs_review and exit code 1 for failed; CI/orchestrator behavior differs.
-    state.status =
-      state.stages.stage3.status === 'needs_review' ? 'needs_review' : 'failed';
+    state.status = state.stages.stage3.status === 'needs_review' ? 'needs_review' : 'failed';
     state.completedAt = now();
     await config.onProgress?.(state);
     return state;

--- a/src/lib/tribunal-v2/pipeline.ts
+++ b/src/lib/tribunal-v2/pipeline.ts
@@ -18,7 +18,7 @@ import type {
 } from './types';
 import { MAX_LOOPS } from './types';
 import { enforceWriterConstraints } from './writer-constraints';
-import { checkFinalVibePassBar } from './pass-bar';
+import { checkFinalVibePassBar, checkFreshEyesPassBar } from './pass-bar';
 
 // ---------------------------------------------------------------------------
 // Pipeline State Types
@@ -188,6 +188,56 @@ const STAGE3_LIB_RENAME: Record<string, string> = {
   sourceAlign: 'linkRelevance',
 };
 
+interface VerifiedPassBar {
+  pass: boolean;
+  composite?: number;
+  reasons?: string[];
+}
+
+function verifyFreshEyesPassBar(output: FreshEyesJudgeOutput): VerifiedPassBar {
+  const result = checkFreshEyesPassBar(output.scores);
+  const reasons: string[] = [];
+
+  if (result.composite < 8) {
+    reasons.push(`FreshEyes composite ${result.composite} is below 8`);
+  }
+  if (output.scores.payoffDensity < 8) {
+    reasons.push(`payoffDensity ${output.scores.payoffDensity} is below 8`);
+  }
+  if (output.scores.lengthFit < 8) {
+    reasons.push(`lengthFit ${output.scores.lengthFit} is below 8`);
+  }
+
+  return { pass: result.pass, composite: result.composite, reasons };
+}
+
+function applyVerifiedPassBar<
+  TJudge extends {
+    pass: boolean;
+    composite?: number;
+    improvements?: Record<string, string>;
+    critical_issues?: string[];
+  },
+>(output: TJudge, verified?: VerifiedPassBar): void {
+  if (!verified) return;
+
+  output.pass = verified.pass;
+  if (typeof verified.composite === 'number') {
+    output.composite = verified.composite;
+  }
+
+  if (!verified.pass && verified.reasons?.length) {
+    output.critical_issues = [
+      ...(output.critical_issues ?? []),
+      `Programmatic pass-bar failed: ${verified.reasons.join('; ')}`,
+    ];
+    output.improvements = {
+      ...(output.improvements ?? {}),
+      passBar: verified.reasons.join('; '),
+    };
+  }
+}
+
 async function persistScoreToFrontmatter(
   config: PipelineConfig,
   articlePath: string,
@@ -345,7 +395,8 @@ async function runJudgeWriterLoop<
   config: PipelineConfig,
   judge: (content: string) => Promise<TJudge>,
   writer: (content: string, feedback: string) => Promise<{ content: string }>,
-  fmPersist?: { fmKey: FrontmatterJudgeKey; dims: readonly string[] }
+  fmPersist?: { fmKey: FrontmatterJudgeKey; dims: readonly string[] },
+  verifyPassBar?: (output: TJudge) => VerifiedPassBar
 ): Promise<boolean> {
   if (stage.status === 'passed' || stage.status === 'skipped') return true;
 
@@ -365,6 +416,7 @@ async function runJudgeWriterLoop<
     // Run judge
     const articleContent = await config.io.readArticle(state.articlePath);
     const judgeOutput = await judge(articleContent);
+    applyVerifiedPassBar(judgeOutput, verifyPassBar?.(judgeOutput));
     await assertJudgeDidNotMutate(config, state.articlePath, articleContent, `stage${stageNum}`);
 
     stage.output = judgeOutput;
@@ -821,7 +873,8 @@ export async function runPipeline(
     config,
     (content) => config.runners.stage2Judge.run({ articleContent: content }),
     (content, feedback) => config.runners.stage2Writer.run({ articleContent: content, feedback }),
-    FRONTMATTER_DIM_MAP.stage2
+    FRONTMATTER_DIM_MAP.stage2,
+    verifyFreshEyesPassBar
   );
 
   if (!stage2Passed) {

--- a/src/lib/tribunal-v2/types.ts
+++ b/src/lib/tribunal-v2/types.ts
@@ -103,6 +103,8 @@ export interface FreshEyesJudgeOutput extends BaseJudgeOutput {
   scores: {
     readability: number;
     firstImpression: number;
+    payoffDensity: number;
+    lengthFit: number;
   };
 }
 

--- a/tests/tribunal-v2/pass-bar.test.ts
+++ b/tests/tribunal-v2/pass-bar.test.ts
@@ -13,7 +13,11 @@ import {
 describe('checkVibePassBar (Stage 1)', () => {
   it('passes when composite >=8 AND one dim >=9 AND all dims >=8', () => {
     const result = checkVibePassBar({
-      persona: 9, clawdNote: 8, vibe: 8, clarity: 8, narrative: 8,
+      persona: 9,
+      clawdNote: 8,
+      vibe: 8,
+      clarity: 8,
+      narrative: 8,
     });
     // composite: floor((9+8+8+8+8)/5) = floor(8.2) = 8
     expect(result.pass).toBe(true);
@@ -24,7 +28,11 @@ describe('checkVibePassBar (Stage 1)', () => {
 
   it('fails when no dim reaches 9 (no highlight)', () => {
     const result = checkVibePassBar({
-      persona: 8, clawdNote: 8, vibe: 8, clarity: 8, narrative: 8,
+      persona: 8,
+      clawdNote: 8,
+      vibe: 8,
+      clarity: 8,
+      narrative: 8,
     });
     // composite=8, max=8 → no highlight → fail
     expect(result.pass).toBe(false);
@@ -35,7 +43,11 @@ describe('checkVibePassBar (Stage 1)', () => {
 
   it('fails when one dim is 7 even if others are 10', () => {
     const result = checkVibePassBar({
-      persona: 10, clawdNote: 10, vibe: 10, clarity: 10, narrative: 7,
+      persona: 10,
+      clawdNote: 10,
+      vibe: 10,
+      clarity: 10,
+      narrative: 7,
     });
     // composite: floor(47/5) = 9, highlight=true, but 7<8 → fail
     expect(result.pass).toBe(false);
@@ -46,7 +58,11 @@ describe('checkVibePassBar (Stage 1)', () => {
 
   it('fails when composite <8', () => {
     const result = checkVibePassBar({
-      persona: 9, clawdNote: 8, vibe: 8, clarity: 7, narrative: 7,
+      persona: 9,
+      clawdNote: 8,
+      vibe: 8,
+      clarity: 7,
+      narrative: 7,
     });
     // composite: floor(39/5) = 7
     expect(result.pass).toBe(false);
@@ -56,14 +72,22 @@ describe('checkVibePassBar (Stage 1)', () => {
   it('uses floor for composite (not round)', () => {
     // sum=42, avg=8.4 → floor=8
     const r1 = checkVibePassBar({
-      persona: 9, clawdNote: 9, vibe: 8, clarity: 8, narrative: 8,
+      persona: 9,
+      clawdNote: 9,
+      vibe: 8,
+      clarity: 8,
+      narrative: 8,
     });
     expect(r1.composite).toBe(8);
     expect(r1.pass).toBe(true);
 
     // sum=43, avg=8.6 → floor=8 (not 9)
     const r2 = checkVibePassBar({
-      persona: 9, clawdNote: 9, vibe: 9, clarity: 8, narrative: 8,
+      persona: 9,
+      clawdNote: 9,
+      vibe: 9,
+      clarity: 8,
+      narrative: 8,
     });
     expect(r2.composite).toBe(8);
     expect(r2.pass).toBe(true);
@@ -77,13 +101,17 @@ describe('checkVibePassBar (Stage 1)', () => {
         vibe: 8,
         clarity: 8,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      } as any),
+      } as any)
     ).toThrow('Missing required dimension: narrative');
   });
 
   it('passes with all 10s (perfect score)', () => {
     const result = checkVibePassBar({
-      persona: 10, clawdNote: 10, vibe: 10, clarity: 10, narrative: 10,
+      persona: 10,
+      clawdNote: 10,
+      vibe: 10,
+      clarity: 10,
+      narrative: 10,
     });
     expect(result.pass).toBe(true);
     expect(result.composite).toBe(10);
@@ -91,7 +119,11 @@ describe('checkVibePassBar (Stage 1)', () => {
 
   it('reports multiple failed dimensions', () => {
     const result = checkVibePassBar({
-      persona: 9, clawdNote: 7, vibe: 6, clarity: 8, narrative: 8,
+      persona: 9,
+      clawdNote: 7,
+      vibe: 6,
+      clarity: 8,
+      narrative: 8,
     });
     expect(result.failedDimensions).toEqual(['clawdNote', 'vibe']);
   });
@@ -107,7 +139,7 @@ describe('checkFinalVibePassBar (Stage 4)', () => {
   it('passes when all dims equal Stage 1 scores', () => {
     const result = checkFinalVibePassBar(
       { persona: 9, clawdNote: 8, vibe: 8, clarity: 8, narrative: 8 },
-      stage1,
+      stage1
     );
     expect(result.pass).toBe(true);
     expect(result.degradedDimensions).toEqual([]);
@@ -116,7 +148,7 @@ describe('checkFinalVibePassBar (Stage 4)', () => {
   it('passes when dims improved', () => {
     const result = checkFinalVibePassBar(
       { persona: 10, clawdNote: 9, vibe: 8, clarity: 8, narrative: 8 },
-      stage1,
+      stage1
     );
     expect(result.pass).toBe(true);
     expect(result.degradedDimensions).toEqual([]);
@@ -126,7 +158,7 @@ describe('checkFinalVibePassBar (Stage 4)', () => {
     const s1 = { persona: 9, clawdNote: 9, vibe: 9, clarity: 9, narrative: 9 };
     const result = checkFinalVibePassBar(
       { persona: 8, clawdNote: 8, vibe: 8, clarity: 8, narrative: 8 },
-      s1,
+      s1
     );
     // -1 each, but > 1 is the threshold, so exactly 1 = pass
     expect(result.pass).toBe(true);
@@ -136,19 +168,17 @@ describe('checkFinalVibePassBar (Stage 4)', () => {
   it('fails when any dim dropped by 2', () => {
     const result = checkFinalVibePassBar(
       { persona: 7, clawdNote: 8, vibe: 8, clarity: 8, narrative: 8 },
-      stage1,
+      stage1
     );
     expect(result.pass).toBe(false);
-    expect(result.degradedDimensions).toEqual([
-      { dim: 'persona', stage1: 9, current: 7, drop: 2 },
-    ]);
+    expect(result.degradedDimensions).toEqual([{ dim: 'persona', stage1: 9, current: 7, drop: 2 }]);
   });
 
   it('reports all degraded dims, not just the first', () => {
     const s1 = { persona: 9, clawdNote: 9, vibe: 9, clarity: 8, narrative: 8 };
     const result = checkFinalVibePassBar(
       { persona: 7, clawdNote: 7, vibe: 9, clarity: 8, narrative: 8 },
-      s1,
+      s1
     );
     expect(result.pass).toBe(false);
     expect(result.degradedDimensions).toHaveLength(2);
@@ -159,13 +189,11 @@ describe('checkFinalVibePassBar (Stage 4)', () => {
   it('handles asymmetric: some improved, some degraded', () => {
     const result = checkFinalVibePassBar(
       { persona: 10, clawdNote: 8, vibe: 6, clarity: 8, narrative: 8 },
-      stage1,
+      stage1
     );
     // persona improved +1, vibe degraded -2 → still fail
     expect(result.pass).toBe(false);
-    expect(result.degradedDimensions).toEqual([
-      { dim: 'vibe', stage1: 8, current: 6, drop: 2 },
-    ]);
+    expect(result.degradedDimensions).toEqual([{ dim: 'vibe', stage1: 8, current: 6, drop: 2 }]);
   });
 });
 
@@ -174,35 +202,61 @@ describe('checkFinalVibePassBar (Stage 4)', () => {
 // ============================================================================
 
 describe('checkFreshEyesPassBar (Stage 2)', () => {
-  it('passes when composite >= 8', () => {
-    const result = checkFreshEyesPassBar({ readability: 9, firstImpression: 8 });
-    // floor((9+8)/2) = floor(8.5) = 8
+  const fresh = (overrides: Partial<Parameters<typeof checkFreshEyesPassBar>[0]> = {}) =>
+    checkFreshEyesPassBar({
+      readability: 8,
+      firstImpression: 8,
+      payoffDensity: 8,
+      lengthFit: 8,
+      ...overrides,
+    });
+
+  it('passes when composite >= 8 and payoff/length dimensions pass', () => {
+    const result = fresh({ readability: 9, firstImpression: 8, payoffDensity: 8, lengthFit: 8 });
+    // floor((9+8+8+8)/4) = floor(8.25) = 8
     expect(result.pass).toBe(true);
     expect(result.composite).toBe(8);
   });
 
   it('fails when composite < 8', () => {
-    const result = checkFreshEyesPassBar({ readability: 7, firstImpression: 8 });
-    // floor((7+8)/2) = floor(7.5) = 7
+    const result = fresh({ readability: 7, firstImpression: 8, payoffDensity: 8, lengthFit: 7 });
+    // floor((7+8+8+7)/4) = floor(7.5) = 7
     expect(result.pass).toBe(false);
     expect(result.composite).toBe(7);
   });
 
   it('uses floor not round', () => {
-    const result = checkFreshEyesPassBar({ readability: 9, firstImpression: 7 });
-    // floor((9+7)/2) = floor(8) = 8
-    expect(result.pass).toBe(true);
+    const result = fresh({ readability: 9, firstImpression: 8, payoffDensity: 8, lengthFit: 7 });
+    // floor((9+8+8+7)/4) = floor(8) = 8, but lengthFit is non-compensating.
+    expect(result.pass).toBe(false);
+    expect(result.composite).toBe(8);
+  });
+
+  it('fails when payoffDensity is below 8 even if composite passes', () => {
+    const result = fresh({ readability: 10, firstImpression: 10, payoffDensity: 7, lengthFit: 8 });
+    expect(result.pass).toBe(false);
+    expect(result.composite).toBe(8);
+  });
+
+  it('fails when lengthFit is below 8 even if composite passes', () => {
+    const result = fresh({ readability: 10, firstImpression: 10, payoffDensity: 8, lengthFit: 7 });
+    expect(result.pass).toBe(false);
     expect(result.composite).toBe(8);
   });
 
   it('passes with perfect scores', () => {
-    const result = checkFreshEyesPassBar({ readability: 10, firstImpression: 10 });
+    const result = fresh({
+      readability: 10,
+      firstImpression: 10,
+      payoffDensity: 10,
+      lengthFit: 10,
+    });
     expect(result.pass).toBe(true);
     expect(result.composite).toBe(10);
   });
 
   it('fails with all 7s', () => {
-    const result = checkFreshEyesPassBar({ readability: 7, firstImpression: 7 });
+    const result = fresh({ readability: 7, firstImpression: 7, payoffDensity: 7, lengthFit: 7 });
     expect(result.pass).toBe(false);
     expect(result.composite).toBe(7);
   });
@@ -215,8 +269,10 @@ describe('checkFreshEyesPassBar (Stage 2)', () => {
 describe('checkFactLibPassBar (Stage 3)', () => {
   it('passes when fact, library, and dupCheck all pass', () => {
     const result = checkFactLibPassBar({
-      factAccuracy: 9, sourceFidelity: 8,
-      linkCoverage: 8, linkRelevance: 9,
+      factAccuracy: 9,
+      sourceFidelity: 8,
+      linkCoverage: 8,
+      linkRelevance: 9,
       dupCheck: 10,
     });
     expect(result.pass).toBe(true);
@@ -227,8 +283,10 @@ describe('checkFactLibPassBar (Stage 3)', () => {
 
   it('fails when fact fails even if library+dupCheck pass (no compensation)', () => {
     const result = checkFactLibPassBar({
-      factAccuracy: 7, sourceFidelity: 7,
-      linkCoverage: 10, linkRelevance: 10,
+      factAccuracy: 7,
+      sourceFidelity: 7,
+      linkCoverage: 10,
+      linkRelevance: 10,
       dupCheck: 10,
     });
     // fact: floor((7+7)/2) = 7 < 8 → fail
@@ -242,8 +300,10 @@ describe('checkFactLibPassBar (Stage 3)', () => {
 
   it('fails when library fails even if fact+dupCheck pass', () => {
     const result = checkFactLibPassBar({
-      factAccuracy: 10, sourceFidelity: 10,
-      linkCoverage: 6, linkRelevance: 7,
+      factAccuracy: 10,
+      sourceFidelity: 10,
+      linkCoverage: 6,
+      linkRelevance: 7,
       dupCheck: 10,
     });
     // fact: 10, library: floor((6+7)/2) = 6 → fail, dupCheck: pass
@@ -255,8 +315,10 @@ describe('checkFactLibPassBar (Stage 3)', () => {
 
   it('fails when dupCheck fails even if fact+library pass (Level E)', () => {
     const result = checkFactLibPassBar({
-      factAccuracy: 10, sourceFidelity: 10,
-      linkCoverage: 10, linkRelevance: 10,
+      factAccuracy: 10,
+      sourceFidelity: 10,
+      linkCoverage: 10,
+      linkRelevance: 10,
       dupCheck: 5,
     });
     // fact: pass, library: pass, dupCheck: 5 < 8 → fail
@@ -268,8 +330,10 @@ describe('checkFactLibPassBar (Stage 3)', () => {
 
   it('fails when all three fail', () => {
     const result = checkFactLibPassBar({
-      factAccuracy: 5, sourceFidelity: 6,
-      linkCoverage: 4, linkRelevance: 3,
+      factAccuracy: 5,
+      sourceFidelity: 6,
+      linkCoverage: 4,
+      linkRelevance: 3,
       dupCheck: 2,
     });
     expect(result.pass).toBe(false);
@@ -283,24 +347,30 @@ describe('checkFactLibPassBar (Stage 3)', () => {
     // library: floor((9+8)/2) = floor(8.5) = 8 → pass
     // dupCheck: 8 → pass (boundary)
     const result = checkFactLibPassBar({
-      factAccuracy: 9, sourceFidelity: 8,
-      linkCoverage: 9, linkRelevance: 8,
+      factAccuracy: 9,
+      sourceFidelity: 8,
+      linkCoverage: 9,
+      linkRelevance: 8,
       dupCheck: 8,
     });
     expect(result.pass).toBe(true);
 
     // fact: floor((8+7)/2) = floor(7.5) = 7 → fail
     const result2 = checkFactLibPassBar({
-      factAccuracy: 8, sourceFidelity: 7,
-      linkCoverage: 9, linkRelevance: 8,
+      factAccuracy: 8,
+      sourceFidelity: 7,
+      linkCoverage: 9,
+      linkRelevance: 8,
       dupCheck: 10,
     });
     expect(result2.fact_pass).toBe(false);
 
     // dupCheck boundary: 7 is below threshold
     const result3 = checkFactLibPassBar({
-      factAccuracy: 10, sourceFidelity: 10,
-      linkCoverage: 10, linkRelevance: 10,
+      factAccuracy: 10,
+      sourceFidelity: 10,
+      linkCoverage: 10,
+      linkRelevance: 10,
       dupCheck: 7,
     });
     expect(result3.dupCheck_pass).toBe(false);
@@ -310,8 +380,10 @@ describe('checkFactLibPassBar (Stage 3)', () => {
   it('throws when dupCheck is undefined (old judge version without Level E)', () => {
     expect(() =>
       checkFactLibPassBar({
-        factAccuracy: 9, sourceFidelity: 9,
-        linkCoverage: 9, linkRelevance: 9,
+        factAccuracy: 9,
+        sourceFidelity: 9,
+        linkCoverage: 9,
+        linkRelevance: 9,
         dupCheck: undefined as unknown as number,
       })
     ).toThrow(/dupCheck is undefined/i);
@@ -320,8 +392,10 @@ describe('checkFactLibPassBar (Stage 3)', () => {
   it('throws when dupCheck is not a finite number', () => {
     expect(() =>
       checkFactLibPassBar({
-        factAccuracy: 9, sourceFidelity: 9,
-        linkCoverage: 9, linkRelevance: 9,
+        factAccuracy: 9,
+        sourceFidelity: 9,
+        linkCoverage: 9,
+        linkRelevance: 9,
         dupCheck: NaN as number,
       })
     ).toThrow(/not a finite number/i);
@@ -330,8 +404,10 @@ describe('checkFactLibPassBar (Stage 3)', () => {
   it('throws when dupCheck is a non-integer (spec R1 requires integer 0..10)', () => {
     expect(() =>
       checkFactLibPassBar({
-        factAccuracy: 9, sourceFidelity: 9,
-        linkCoverage: 9, linkRelevance: 9,
+        factAccuracy: 9,
+        sourceFidelity: 9,
+        linkCoverage: 9,
+        linkRelevance: 9,
         dupCheck: 8.5,
       })
     ).toThrow(/not an integer/i);
@@ -340,16 +416,20 @@ describe('checkFactLibPassBar (Stage 3)', () => {
   it('throws when dupCheck is out of range [0, 10]', () => {
     expect(() =>
       checkFactLibPassBar({
-        factAccuracy: 9, sourceFidelity: 9,
-        linkCoverage: 9, linkRelevance: 9,
+        factAccuracy: 9,
+        sourceFidelity: 9,
+        linkCoverage: 9,
+        linkRelevance: 9,
         dupCheck: 11,
       })
     ).toThrow(/outside the valid range/i);
 
     expect(() =>
       checkFactLibPassBar({
-        factAccuracy: 9, sourceFidelity: 9,
-        linkCoverage: 9, linkRelevance: 9,
+        factAccuracy: 9,
+        sourceFidelity: 9,
+        linkCoverage: 9,
+        linkRelevance: 9,
         dupCheck: -1,
       })
     ).toThrow(/outside the valid range/i);

--- a/tests/tribunal-v2/pipeline.test.ts
+++ b/tests/tribunal-v2/pipeline.test.ts
@@ -101,7 +101,7 @@ const FAILING_SCORES: VibeJudgeOutput['scores'] = {
 function freshEyesPass(): FreshEyesJudgeOutput {
   return {
     pass: true,
-    scores: { readability: 8, firstImpression: 8 },
+    scores: { readability: 8, firstImpression: 8, payoffDensity: 8, lengthFit: 8 },
     composite: 8,
     judge_model: 'mock',
     judge_version: '2.0.0',
@@ -362,9 +362,7 @@ describe('pipeline — writer-constraint enforcement', () => {
     expect(judgeContents[0]).not.toContain('wrong.example.com');
 
     // Commit trail shows both workers rejected
-    expect(
-      git.commits.some((m) => m.includes('FactCorrector rejected'))
-    ).toBe(true);
+    expect(git.commits.some((m) => m.includes('FactCorrector rejected'))).toBe(true);
     expect(git.commits.some((m) => m.includes('Librarian rejected'))).toBe(true);
   });
 
@@ -392,9 +390,7 @@ describe('pipeline — writer-constraint enforcement', () => {
       },
     };
 
-    await expect(runPipeline(articlePath, config)).rejects.toThrow(
-      /judge mutated article/i
-    );
+    await expect(runPipeline(articlePath, config)).rejects.toThrow(/judge mutated article/i);
 
     // The injection must have been reverted off disk.
     const content = await readFile(articlePath, 'utf-8');
@@ -503,9 +499,7 @@ describe('pipeline — writer-constraint enforcement', () => {
     expect(finalContent).not.toContain('malicious.example.com');
 
     // Commit trail shows a Stage 4 rejected marker (proves constraint ran)
-    expect(
-      git.commits.some((m) => m.includes('stage4') && m.includes('rejected'))
-    ).toBe(true);
+    expect(git.commits.some((m) => m.includes('stage4') && m.includes('rejected'))).toBe(true);
   });
 });
 
@@ -731,10 +725,16 @@ describe('pipeline — Stage 3 dupCheck-only FAIL (Level E)', () => {
     // Round 2: library passes + dupCheck still fails → shortcut fires (needs_review)
     const round1Output: FactLibJudgeOutput = {
       pass: false,
-      scores: { factAccuracy: 9, sourceFidelity: 9, linkCoverage: 6, linkRelevance: 6, dupCheck: 3 },
+      scores: {
+        factAccuracy: 9,
+        sourceFidelity: 9,
+        linkCoverage: 6,
+        linkRelevance: 6,
+        dupCheck: 3,
+      },
       composite: 6,
       fact_pass: true,
-      library_pass: false,  // library fails — workers CAN fix this
+      library_pass: false, // library fails — workers CAN fix this
       dupCheck_pass: false,
       improvements: {
         linkCoverage: 'missing glossary links',
@@ -747,10 +747,16 @@ describe('pipeline — Stage 3 dupCheck-only FAIL (Level E)', () => {
     };
     const round2Output: FactLibJudgeOutput = {
       pass: false,
-      scores: { factAccuracy: 9, sourceFidelity: 9, linkCoverage: 9, linkRelevance: 8, dupCheck: 3 },
+      scores: {
+        factAccuracy: 9,
+        sourceFidelity: 9,
+        linkCoverage: 9,
+        linkRelevance: 8,
+        dupCheck: 3,
+      },
       composite: 7,
       fact_pass: true,
-      library_pass: true,  // library fixed by workers
+      library_pass: true, // library fixed by workers
       dupCheck_pass: false,
       improvements: {
         dupCheck: 'class=hard-dup action=BLOCK matchedSlugs=[sp-100] reason=同 cluster primary',
@@ -784,7 +790,9 @@ describe('pipeline — Stage 3 dupCheck-only FAIL (Level E)', () => {
     expect(judgeCallCount).toBe(2);
 
     // shortcut fires on round 2 (after library is fixed by workers)
-    expect(git.commits.some((m) => m.includes('dupCheck FAIL') && m.includes('class=hard-dup'))).toBe(true);
+    expect(
+      git.commits.some((m) => m.includes('dupCheck FAIL') && m.includes('class=hard-dup'))
+    ).toBe(true);
     expect(git.commits.every((m) => !m.includes('max loops exhausted'))).toBe(true);
   });
 });

--- a/tests/tribunal-v2/pipeline.test.ts
+++ b/tests/tribunal-v2/pipeline.test.ts
@@ -98,15 +98,30 @@ const FAILING_SCORES: VibeJudgeOutput['scores'] = {
   narrative: 7,
 };
 
-function freshEyesPass(): FreshEyesJudgeOutput {
+function freshEyesOutput(
+  pass: boolean,
+  scores: FreshEyesJudgeOutput['scores'],
+  extras: Partial<FreshEyesJudgeOutput> = {}
+): FreshEyesJudgeOutput {
+  const composite = Math.floor(Object.values(scores).reduce((a, b) => a + b, 0) / 4);
   return {
-    pass: true,
-    scores: { readability: 8, firstImpression: 8, payoffDensity: 8, lengthFit: 8 },
-    composite: 8,
+    pass,
+    scores,
+    composite,
     judge_model: 'mock',
     judge_version: '2.0.0',
     timestamp: '2026-04-16T00:00:00Z',
+    ...extras,
   };
+}
+
+function freshEyesPass(): FreshEyesJudgeOutput {
+  return freshEyesOutput(true, {
+    readability: 8,
+    firstImpression: 8,
+    payoffDensity: 8,
+    lengthFit: 8,
+  });
 }
 
 function factLibPass(): FactLibJudgeOutput {
@@ -446,6 +461,55 @@ describe('pipeline — writer-constraint enforcement', () => {
     // Degraded frontmatter marker should have been written to the article.
     const content = await readFile(articlePath, 'utf-8');
     expect(content).toContain('stage4Degraded');
+  });
+
+  // -------------------------------------------------------------------------
+  // Codex PR review — Stage 2 FreshEyes v8 pass bar must be recomputed from
+  // scores, not trusted from the model's `pass` flag.
+  // -------------------------------------------------------------------------
+  it('Stage 2: overrides model pass=true when FreshEyes lengthFit fails', async () => {
+    let judgeCalls = 0;
+    let writerCalls = 0;
+    const git = mockGit();
+
+    const config: PipelineConfig = {
+      ...passThroughConfig(),
+      git: git.adapter,
+      runners: {
+        ...passThroughConfig().runners,
+        stage2Judge: {
+          run: async () => {
+            judgeCalls++;
+            if (judgeCalls === 1) {
+              return freshEyesOutput(
+                true,
+                { readability: 10, firstImpression: 10, payoffDensity: 8, lengthFit: 7 },
+                { improvements: { lengthFit: 'too long for the payoff' } }
+              );
+            }
+            return freshEyesPass();
+          },
+        },
+        stage2Writer: {
+          run: async ({ articleContent, feedback }) => {
+            writerCalls++;
+            expect(feedback).toContain('Programmatic pass-bar failed');
+            expect(feedback).toContain('lengthFit 7 is below 8');
+            return { content: `${articleContent}\n\n已壓縮長度，讓篇幅更符合資訊收益。` };
+          },
+        },
+      },
+    };
+
+    const final = await runPipeline(articlePath, config);
+
+    expect(final.status).toBe('passed');
+    expect(final.stages.stage2.status).toBe('passed');
+    expect(judgeCalls).toBe(2);
+    expect(writerCalls).toBe(1);
+    expect(final.stages.stage2.history[0]?.pass).toBe(false);
+    expect(final.stages.stage2.history[0]?.composite).toBe(8);
+    expect(git.commits.some((m) => m.includes('FreshEyes writer rewrite'))).toBe(true);
   });
 
   // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- bump Tribunal runner/frontmatter version to v8
- add FreshEyes payoffDensity and lengthFit dimensions
- make payoffDensity and lengthFit non-compensating pass-bar requirements
- update score schemas, UI rendering, tests, and v8 scoring standard docs

## Test Plan
- bash scripts/tests/test-frontmatter-scores-v8.sh
- bash scripts/tests/test-tribunal-safety-contract.sh
- bash scripts/tests/test-tribunal-pass-artifact-guards.sh
- bash scripts/tests/test-tribunal-runner-error-guard.sh
- bash scripts/tests/test-tribunal-progress-ledger-migration.sh
- bash scripts/tests/test-tribunal-publish-worker-changes.sh
- bash scripts/tests/test-tribunal-publisher.sh
- pnpm exec vitest run tests/tribunal-v2/pass-bar.test.ts tests/tribunal-v2/pipeline.test.ts tests/content-gates.test.ts
- pnpm exec astro sync && pnpm exec tsc --noEmit --skipLibCheck
- pnpm exec prettier --check src/components/AiJudgeScore.astro src/content/config.ts src/lib/tribunal-v2/pass-bar.ts src/lib/tribunal-v2/pipeline.ts src/lib/tribunal-v2/types.ts tests/tribunal-v2/pass-bar.test.ts tests/tribunal-v2/pipeline.test.ts scripts/frontmatter-scores.mjs scripts/validate-posts.mjs