### PR TITLE
experiment: compact feed homepage

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -31,13 +31,18 @@ const lvPosts = allPosts.filter((p) => p.data.ticketId?.startsWith('Lv-')).sort(
 const spPosts = allPosts.filter((p) => p.data.ticketId?.startsWith('SP-')).sort(sortByTicketNumber);
 
 const cpPosts = allPosts.filter((p) => p.data.ticketId?.startsWith('CP-')).sort(sortByTicketNumber);
+
+const experimentHeroStyle = `margin:1rem 0 1.2rem;padding:.95rem 0;border-top:1px solid var(--color-divider);border-bottom:1px solid var(--color-divider);`;
+const experimentKickerStyle = `margin:0 0 .25rem;color:var(--color-accent);font-size:.7rem;font-weight:800;letter-spacing:.14em;text-transform:uppercase;`;
+const experimentTitleStyle = `margin:0;font-size:clamp(1.55rem,5vw,3rem);line-height:1.02;letter-spacing:-.055em;`;
+const experimentCopyStyle = `max-width:42rem;margin:.45rem 0 0;color:var(--color-text-muted);font-size:.88rem;line-height:1.65;`;
 ---
 
 <BaseLayout title="ShroomDog">
-  <section class="experiment-hero compact-hero" aria-label="Gu-log compact feed experiment">
-    <p class="hero-kicker">Experimental UI · Compact Feed</p>
-    <h1>少一點裝飾，多一點掃讀速度。</h1>
-    <p class="hero-copy">
+  <section style={experimentHeroStyle} aria-label="Gu-log compact feed experiment">
+    <p style={experimentKickerStyle}>Experimental UI · Compact Feed</p>
+    <h1 style={experimentTitleStyle}>少一點裝飾，多一點掃讀速度。</h1>
+    <p style={experimentCopyStyle}>
       這條 branch 把首頁推向 inbox / changelog 手感：密度更高、meta
       更清楚、每個分類像可快速掃過的閱讀 queue。
     </p>
@@ -344,119 +349,5 @@ const cpPosts = allPosts.filter((p) => p.data.ticketId?.startsWith('CP-')).sort(
 
   .view-all a:hover {
     text-decoration: underline;
-  }
-
-  /* Experiment: Compact Feed */
-  :global(.container) {
-    max-width: 860px;
-  }
-
-  .experiment-hero {
-    margin: 1rem 0 1.2rem;
-    padding: 0.95rem 0;
-    border-top: 1px solid var(--color-divider);
-    border-bottom: 1px solid var(--color-divider);
-  }
-
-  .hero-kicker {
-    margin: 0 0 0.25rem;
-    color: var(--color-accent);
-    font-size: 0.7rem;
-    font-weight: 800;
-    letter-spacing: 0.14em;
-    text-transform: uppercase;
-  }
-
-  .experiment-hero h1 {
-    margin: 0;
-    font-size: clamp(1.55rem, 5vw, 3rem);
-    line-height: 1.02;
-    letter-spacing: -0.055em;
-  }
-
-  .hero-copy {
-    max-width: 42rem;
-    margin: 0.45rem 0 0;
-    color: var(--color-text-muted);
-    font-size: 0.88rem;
-    line-height: 1.65;
-  }
-
-  .posts-section,
-  .clawd-picks-section {
-    margin-bottom: 0.85rem;
-    padding-top: 0.7rem;
-  }
-
-  .posts-section h2,
-  .clawd-picks-section h2 {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.35rem;
-    margin: 0 0 0.1rem;
-    font-size: 1rem;
-    letter-spacing: -0.025em;
-  }
-
-  .section-subtitle {
-    display: inline;
-    margin-left: 0.5rem;
-    font-size: 0.72rem;
-  }
-
-  .post-preview,
-  .pick-preview {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) auto;
-    gap: 0.25rem 0.85rem;
-    align-items: baseline;
-    padding: 0.42rem 0;
-    border-bottom: 1px solid var(--color-divider);
-    font-size: 0.86rem;
-  }
-
-  .post-preview h3 {
-    margin: 0;
-    font-size: 0.96rem;
-    line-height: 1.35;
-  }
-
-  .post-preview .post-meta,
-  .pick-meta {
-    grid-column: 2;
-    grid-row: 1;
-    text-align: right;
-    white-space: nowrap;
-    font-size: 0.7rem;
-  }
-
-  .post-preview :global(.toggle-container),
-  .pick-preview :global(.toggle-container) {
-    grid-column: 1 / -1;
-    margin-top: 0.15rem;
-    opacity: 0.86;
-  }
-
-  .view-all {
-    margin-top: 0.4rem;
-  }
-
-  .clawd-section-icon,
-  .section-icon {
-    width: 18px;
-    height: 18px;
-  }
-
-  @media (max-width: 720px) {
-    .post-preview,
-    .pick-preview {
-      display: block;
-    }
-
-    .post-preview .post-meta,
-    .pick-meta {
-      text-align: left;
-      white-space: normal;
-    }
   }
 </style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -34,6 +34,15 @@ const cpPosts = allPosts.filter((p) => p.data.ticketId?.startsWith('CP-')).sort(
 ---
 
 <BaseLayout title="ShroomDog">
+  <section class="experiment-hero compact-hero" aria-label="Gu-log compact feed experiment">
+    <p class="hero-kicker">Experimental UI · Compact Feed</p>
+    <h1>少一點裝飾，多一點掃讀速度。</h1>
+    <p class="hero-copy">
+      這條 branch 把首頁推向 inbox / changelog 手感：密度更高、meta
+      更清楚、每個分類像可快速掃過的閱讀 queue。
+    </p>
+  </section>
+
   {/* SP: ShroomDog Picks — 最頻繁更新 */}
   {
     spPosts.length > 0 && (
@@ -335,5 +344,119 @@ const cpPosts = allPosts.filter((p) => p.data.ticketId?.startsWith('CP-')).sort(
 
   .view-all a:hover {
     text-decoration: underline;
+  }
+
+  /* Experiment: Compact Feed */
+  :global(.container) {
+    max-width: 860px;
+  }
+
+  .experiment-hero {
+    margin: 1rem 0 1.2rem;
+    padding: 0.95rem 0;
+    border-top: 1px solid var(--color-divider);
+    border-bottom: 1px solid var(--color-divider);
+  }
+
+  .hero-kicker {
+    margin: 0 0 0.25rem;
+    color: var(--color-accent);
+    font-size: 0.7rem;
+    font-weight: 800;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+  }
+
+  .experiment-hero h1 {
+    margin: 0;
+    font-size: clamp(1.55rem, 5vw, 3rem);
+    line-height: 1.02;
+    letter-spacing: -0.055em;
+  }
+
+  .hero-copy {
+    max-width: 42rem;
+    margin: 0.45rem 0 0;
+    color: var(--color-text-muted);
+    font-size: 0.88rem;
+    line-height: 1.65;
+  }
+
+  .posts-section,
+  .clawd-picks-section {
+    margin-bottom: 0.85rem;
+    padding-top: 0.7rem;
+  }
+
+  .posts-section h2,
+  .clawd-picks-section h2 {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    margin: 0 0 0.1rem;
+    font-size: 1rem;
+    letter-spacing: -0.025em;
+  }
+
+  .section-subtitle {
+    display: inline;
+    margin-left: 0.5rem;
+    font-size: 0.72rem;
+  }
+
+  .post-preview,
+  .pick-preview {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 0.25rem 0.85rem;
+    align-items: baseline;
+    padding: 0.42rem 0;
+    border-bottom: 1px solid var(--color-divider);
+    font-size: 0.86rem;
+  }
+
+  .post-preview h3 {
+    margin: 0;
+    font-size: 0.96rem;
+    line-height: 1.35;
+  }
+
+  .post-preview .post-meta,
+  .pick-meta {
+    grid-column: 2;
+    grid-row: 1;
+    text-align: right;
+    white-space: nowrap;
+    font-size: 0.7rem;
+  }
+
+  .post-preview :global(.toggle-container),
+  .pick-preview :global(.toggle-container) {
+    grid-column: 1 / -1;
+    margin-top: 0.15rem;
+    opacity: 0.86;
+  }
+
+  .view-all {
+    margin-top: 0.4rem;
+  }
+
+  .clawd-section-icon,
+  .section-icon {
+    width: 18px;
+    height: 18px;
+  }
+
+  @media (max-width: 720px) {
+    .post-preview,
+    .pick-preview {
+      display: block;
+    }
+
+    .post-preview .post-meta,
+    .pick-meta {
+      text-align: left;
+      white-space: normal;
+    }
   }
 </style>


### PR DESCRIPTION
## Summary
- Adds an experimental compact feed hero to the zh-tw homepage
- Tightens homepage sections into a denser inbox/changelog-style scan path
- Keeps the experiment scoped to src/pages/index.astro only

## Skill / design direction
- Taste Skill inspired: high-density reading queue, less decoration, faster scanning

## Test Plan
- pnpm exec prettier --write src/pages/index.astro
- pnpm run build

Draft PR for visual review only. Do not merge as-is.