### PR TITLE
fix: refresh CP-303 version manifest

### DIFF
--- a/src/data/post-versions.json
+++ b/src/data/post-versions.json
@@ -1,5 +1,5 @@
 {
-  "cp-303-20260528-openai-gpt-5-5-api-migration-checklist": 2,
+  "cp-303-20260528-openai-gpt-5-5-api-migration-checklist": 1,
   "en-cp-303-20260528-openai-gpt-5-5-api-migration-checklist": 1,
   "en-sp-212-20260525-anthropic-claude-containment": 1,
   "sp-212-20260525-anthropic-claude-containment": 1,


### PR DESCRIPTION
## Summary
- Refresh post-versions.json after PR #340 squash merge so CP-303 has production-correct version count on main

## Verification
- pnpm run versions:check
- pnpm exec vitest run tests/post-version-manifest.test.ts --reporter=default