### PR TITLE
fix: refresh SP-213 version manifest

### DIFF
--- a/src/data/post-versions.json
+++ b/src/data/post-versions.json
@@ -1,6 +1,6 @@
 {
-  "en-sp-213-20260529-moting284-codex-learning-tools": 2,
-  "sp-213-20260529-moting284-codex-learning-tools": 2,
+  "en-sp-213-20260529-moting284-codex-learning-tools": 1,
+  "sp-213-20260529-moting284-codex-learning-tools": 1,
   "cp-304-20260529-clawd-rip-claude-timeline": 1,
   "en-cp-304-20260529-clawd-rip-claude-timeline": 1,
   "cp-303-20260528-openai-gpt-5-5-api-migration-checklist": 1,


### PR DESCRIPTION
Refreshes post-versions after SP-213 was squash-merged, so the production manifest matches current main history.\n\nValidation:\n- node scripts/build-version-manifest.mjs --check