### PR TITLE
fix: salvage tribunal score card styling

### DIFF
--- a/src/components/AiJudgeScore.astro
+++ b/src/components/AiJudgeScore.astro
@@ -417,13 +417,16 @@ const labels = {
     border-radius: 8px;
     border: 1px solid var(--color-border);
     font-size: 0.85rem;
+    text-align: left;
   }
 
   .judge-header {
     margin-bottom: 0.75rem;
     display: flex;
-    justify-content: space-between;
-    align-items: center;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.2rem;
+    text-align: left;
   }
 
   .judge-title {
@@ -462,14 +465,19 @@ const labels = {
     display: flex;
     flex-direction: column;
     gap: 0.4rem;
+    align-items: flex-start;
     min-width: 0;
+    text-align: left;
   }
 
   .card-header {
     display: flex;
     align-items: center;
     gap: 0.5rem;
+    width: 100%;
+    justify-content: flex-start;
     min-width: 0;
+    text-align: left;
   }
 
   .judge-icon {
@@ -484,6 +492,8 @@ const labels = {
     gap: 0.1rem;
     flex: 1;
     min-width: 0;
+    align-items: flex-start;
+    text-align: left;
   }
 
   .judge-name {
@@ -497,6 +507,8 @@ const labels = {
     font-weight: 700;
     line-height: 1;
     margin: 0.1rem 0;
+    width: 100%;
+    text-align: left;
   }
 
   .score-denom {
@@ -520,20 +532,20 @@ const labels = {
 
   /* Score value colors */
   .score-high {
-    color: #34d399; /* bright emerald — exceptional */
+    color: #88a17f; /* muted sage — exceptional */
   }
   .score-pass {
-    color: #93a1a1; /* Solarized base1 — passing */
+    color: #738b6c; /* softened olive-sage — passing */
   }
   .score-fail {
-    color: #e57373; /* soft red — failing */
+    color: #e09a9a; /* brighter dusty rose — failing */
   }
 
   :global([data-theme='light']) .score-high {
-    color: #047857;
+    color: #55704d;
   }
   :global([data-theme='light']) .score-pass {
-    color: #586e75;
+    color: #65795e;
   }
   :global([data-theme='light']) .score-fail {
     color: #b71c1c;
@@ -544,7 +556,7 @@ const labels = {
     color: #78b4ff;
   }
   .judge-color-factcheck {
-    color: #34d399;
+    color: #b8657d;
   }
   .judge-color-fresheyes {
     color: #c084fc;
@@ -557,7 +569,7 @@ const labels = {
     color: #1d4ed8;
   }
   :global([data-theme='light']) .judge-color-factcheck {
-    color: #047857;
+    color: #8f3852;
   }
   :global([data-theme='light']) .judge-color-fresheyes {
     color: #7e22ce;
@@ -567,20 +579,25 @@ const labels = {
   }
 
   .dim-list {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.2rem 0.15rem;
-    align-items: center;
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 0.18rem;
+    align-items: start;
+    justify-items: start;
     color: var(--color-text-muted);
     font-size: 0.7rem;
     margin-top: 0.1rem;
+    width: 100%;
     min-width: 0;
+    text-align: left;
   }
 
   .dim-item {
     display: flex;
-    gap: 0.2rem;
+    gap: 0.35rem;
     align-items: baseline;
+    justify-content: flex-start;
+    width: 100%;
     min-width: 0;
   }
 
@@ -592,13 +609,6 @@ const labels = {
   .dim-item strong {
     font-weight: 600;
     font-size: 0.75rem;
-  }
-
-  .dim-item + .dim-item::before {
-    content: '·';
-    color: var(--color-border);
-    font-size: 0.7rem;
-    margin-right: 0.15rem;
   }
 
   @media (max-width: 480px) {
@@ -638,7 +648,7 @@ const labels = {
     }
 
     .dim-list {
-      gap: 0.14rem 0.12rem;
+      gap: 0.14rem;
     }
 
     .dim-item {
@@ -652,10 +662,6 @@ const labels = {
     .dim-label::after {
       content: attr(data-short);
       font-size: 0.62rem;
-    }
-
-    .dim-item + .dim-item::before {
-      margin-right: 0.12rem;
     }
   }
 </style>

--- a/tests/tribunal-score-panel.spec.ts
+++ b/tests/tribunal-score-panel.spec.ts
@@ -55,12 +55,14 @@ test('tribunal score panel content aligns with the post info block', async ({ pa
     waitUntil: 'domcontentloaded',
   });
 
-  const offsets = await page.evaluate(() => {
+  const layout = await page.evaluate(() => {
     const infoLine = document.querySelector('.translation-info div:nth-of-type(2)');
     const judgeCards = document.querySelector('.ai-judge-panel .judge-cards');
     const judgeHeader = document.querySelector('.ai-judge-panel .judge-header');
+    const judgeCard = document.querySelector('.ai-judge-panel .judge-card');
+    const dimList = document.querySelector('.ai-judge-panel .dim-list');
 
-    if (!infoLine || !judgeCards || !judgeHeader) {
+    if (!infoLine || !judgeCards || !judgeHeader || !judgeCard || !dimList) {
       throw new Error('Expected post info and tribunal score panel to be present');
     }
 
@@ -68,11 +70,46 @@ test('tribunal score panel content aligns with the post info block', async ({ pa
       infoLeft: infoLine.getBoundingClientRect().left,
       cardsLeft: judgeCards.getBoundingClientRect().left,
       headerLeft: judgeHeader.getBoundingClientRect().left,
+      headerFlexDirection: getComputedStyle(judgeHeader).flexDirection,
+      headerAlignItems: getComputedStyle(judgeHeader).alignItems,
+      cardTextAlign: getComputedStyle(judgeCard).textAlign,
+      cardAlignItems: getComputedStyle(judgeCard).alignItems,
+      dimListDisplay: getComputedStyle(dimList).display,
+      dimListTextAlign: getComputedStyle(dimList).textAlign,
     };
   });
 
-  expect(Math.abs(offsets.cardsLeft - offsets.infoLeft)).toBeLessThanOrEqual(1);
-  expect(Math.abs(offsets.headerLeft - offsets.infoLeft)).toBeLessThanOrEqual(1);
+  expect(Math.abs(layout.cardsLeft - layout.infoLeft)).toBeLessThanOrEqual(1);
+  expect(Math.abs(layout.headerLeft - layout.infoLeft)).toBeLessThanOrEqual(1);
+  expect(layout.headerFlexDirection).toBe('column');
+  expect(layout.headerAlignItems).toBe('flex-start');
+  expect(['left', 'start']).toContain(layout.cardTextAlign);
+  expect(layout.cardAlignItems).toBe('flex-start');
+  expect(layout.dimListDisplay).toBe('grid');
+  expect(['left', 'start']).toContain(layout.dimListTextAlign);
+});
+
+test('tribunal fact-check accent uses wine-red instead of pass-green', async ({ page }) => {
+  await page.addInitScript(() => localStorage.setItem('theme', 'dark'));
+  await page.goto(POST_WITH_TRIBUNAL, { waitUntil: 'domcontentloaded' });
+  await page.evaluate(() => document.documentElement.setAttribute('data-theme', 'dark'));
+
+  const accent = page.locator('.ai-judge-panel .judge-color-factcheck').first();
+  await expect(accent).toBeVisible();
+
+  const [r, g, b] = await accent.evaluate((node) => {
+    const match = getComputedStyle(node).color.match(/\d+/g);
+    if (!match || match.length < 3) {
+      throw new Error('Fact Check accent did not resolve to an RGB color');
+    }
+
+    return match.slice(0, 3).map(Number);
+  });
+
+  expect(r).toBeGreaterThan(150);
+  expect(g).toBeLessThan(140);
+  expect(r).toBeGreaterThan(g);
+  expect(b).toBeGreaterThan(g);
 });
 
 test('tribunal score panel collapses only on extra narrow screens', async ({ page }) => {


### PR DESCRIPTION
## Summary
- salvage the still-useful score-card UI polish from draft/conflicting PR #314 onto current origin/main
- keep the current v8 tribunal/frontmatter schema intact; do not bring stale PR #314 v6 clarity migration, old .claude agents, or script churn
- make Tribunal score cards left-aligned, use vertical dimension rows, and switch Fact Check/score colors away from pass-green collisions
- extend the existing Playwright score-panel spec to lock alignment/grid styling and wine-red Fact Check accent

## PR #314 triage notes
- PR #314 frontmatter changes move clarity from Vibe to Fresh Eyes and bump writes to tribunalVersion 6.
- current main is already tribunalVersion 8 with Fresh Eyes dimensions readability/firstImpression/payoffDensity/lengthFit and Vibe still carrying clarity, so that part is superseded/stale.
- main already contains later mobile two-column score-panel tests; this PR only salvages the remaining non-stale UI polish.

## Validation
- pnpm exec prettier --check src/components/AiJudgeScore.astro tests/tribunal-score-panel.spec.ts
- pnpm exec playwright test tests/tribunal-score-panel.spec.ts
- pnpm run build