### PR TITLE
fix: refresh post versions after SP-186 merge

### DIFF
--- a/src/data/post-versions.json
+++ b/src/data/post-versions.json
@@ -1,6 +1,6 @@
 {
-  "en-sp-186-20260428-article-openclaw-task-flow": 5,
-  "sp-186-20260428-article-openclaw-task-flow": 7,
+  "en-sp-186-20260428-article-openclaw-task-flow": 4,
+  "sp-186-20260428-article-openclaw-task-flow": 6,
   "en-sp-213-20260529-moting284-codex-learning-tools": 1,
   "sp-213-20260529-moting284-codex-learning-tools": 1,
   "cp-304-20260529-clawd-rip-claude-timeline": 1,


### PR DESCRIPTION
Follow-up for squash merge of #347. Refreshes the committed post version manifest so main CI and shallow Vercel builds agree with current git history.\n\nValidation:\n- node scripts/build-version-manifest.mjs --check\n- pnpm exec vitest run tests/post-version-manifest.test.ts --reporter=default