### PR TITLE
fix: tighten human signal active-read metrics

### DIFF
--- a/openspec/changes/add-human-finishability-signals/tasks.md
+++ b/openspec/changes/add-human-finishability-signals/tasks.md
@@ -27,13 +27,14 @@
 ## Phase 4 — Share and comment signal follow-up
 
 - [x] 4.1 在 `ShareButton` 記錄 share intent target/result + version snapshot
+- [x] 4.1a 修正 share 語意：raw share intent 是 strong reaction，不可預設 `sentiment=positive`；需支援 later polarity classification（positive/useful/ridicule/negative）
 - [ ] 4.2 若使用 Giscus，建立 comment sync/indexer，將 GitHub Discussion comments 補上 article version snapshot
 - [ ] 4.3 若使用 first-party feedback form，送出時直接附 version snapshot
 - [ ] 4.4 建立 comment sentiment / feedback type classifier 規則，確保明確負評歸為 negative/rewriteNeeded
 
 ## Phase 5 — Tribunal integration follow-up
 
-- [ ] 5.1 建立 per-article human signal packet 產生器
+- [x] 5.1 建立 per-article human signal packet 產生器
 - [ ] 5.2 將 unresolved human negative signals 注入 FreshEyes / Vibe / FactChecker / Librarian 對應 judge evidence
 - [ ] 5.3 明確指定 human signal ledger / triage events / progress ledger 的 SSOT 分工與 locking discipline
 - [ ] 5.4 定義 guest_reference review dashboard / summary：guest signals 可供 ShroomDog 參考，但未 approve 不進 Tribunal
@@ -44,7 +45,7 @@
 
 - [x] 6.1 Unit test：v1 reading tracker migration 不丟失已讀 slugs
 - [x] 6.2 Unit test：read finish event 必含 article identity + version
-- [ ] 6.3 Unit test：negative comment record 必含 version snapshot
+- [x] 6.3 Unit test：negative comment record 必含 version snapshot
 - [x] 6.4 Unit test：share intent record 必含 target/result/version
 - [ ] 6.5 Integration test：Tribunal packet 讀到 unresolved negative feedback 並標示 requeue/block publish
 - [ ] 6.6 Manual smoke：文章頁讀到底、留言、分享後可查到 versioned event

--- a/src/components/ReadStatusButton.astro
+++ b/src/components/ReadStatusButton.astro
@@ -31,9 +31,13 @@ const { slug, lang = 'zh-tw', postId, ticketId, postVersion, pathname } = Astro.
 </div>
 
 <script>
-  import { isRead, toggleRead, getReadSlugs } from '../lib/reading-tracker';
+  import { isRead, toggleRead, getReadSlugs, markAsRead } from '../lib/reading-tracker';
   import { getGitHubToken, pushToGist, pullFromGist, mergeSync } from '../lib/gist-sync';
-  import { recordManualMarkRead, recordReadFinish } from '../lib/human-signals';
+  import {
+    recordManualMarkRead,
+    recordReadAbandonCandidate,
+    recordReadFinish,
+  } from '../lib/human-signals';
   import type { ArticleVersionSnapshot, GuLogLang } from '../lib/human-signals';
 
   const LAST_SYNC_KEY = 'gu-log-last-sync';
@@ -141,8 +145,23 @@ const { slug, lang = 'zh-tw', postId, ticketId, postVersion, pathname } = Astro.
     if (!postContent) return;
     const postContentEl = postContent as HTMLElement;
 
-    const startedAt = Date.now();
+    const ACTIVE_WINDOW_MS = 5_000;
+    const FINISH_SCROLL_GUARD_PERCENT = 95;
     let maxScrollPercent = 0;
+    let activeReadMs = 0;
+    let lastTickAt = Date.now();
+    let lastActivityAt = Date.now();
+    let finished = false;
+
+    function checkpointActiveRead() {
+      const now = Date.now();
+      const elapsedMs = Math.max(0, now - lastTickAt);
+      if (document.visibilityState === 'visible' && now - lastActivityAt <= ACTIVE_WINDOW_MS) {
+        activeReadMs += elapsedMs;
+      }
+      lastTickAt = now;
+      return activeReadMs;
+    }
 
     function updateMaxScroll() {
       const rect = postContentEl.getBoundingClientRect();
@@ -151,37 +170,82 @@ const { slug, lang = 'zh-tw', postId, ticketId, postVersion, pathname } = Astro.
       if (percent > maxScrollPercent) maxScrollPercent = percent;
     }
 
-    window.addEventListener('scroll', updateMaxScroll, { passive: true });
+    function noteReaderActivity() {
+      checkpointActiveRead();
+      lastActivityAt = Date.now();
+      updateMaxScroll();
+    }
+
+    function markDirtyForSync() {
+      if (localStorage.getItem(LAST_SYNC_KEY)) {
+        localStorage.setItem(SYNC_DIRTY_KEY, 'true');
+      }
+    }
+
+    function cleanupTracking() {
+      window.removeEventListener('scroll', noteReaderActivity);
+      window.removeEventListener('pointerdown', noteReaderActivity);
+      window.removeEventListener('keydown', noteReaderActivity);
+      window.removeEventListener('touchstart', noteReaderActivity);
+      document.removeEventListener('visibilitychange', checkpointActiveRead);
+      window.removeEventListener('pagehide', recordAbandonIfNeeded);
+      observer.disconnect();
+    }
+
+    function recordAbandonIfNeeded() {
+      const measuredActiveReadMs = checkpointActiveRead();
+      updateMaxScroll();
+      if (
+        finished ||
+        isRead(slug) ||
+        maxScrollPercent <= 0 ||
+        maxScrollPercent >= FINISH_SCROLL_GUARD_PERCENT
+      ) {
+        return;
+      }
+      recordReadAbandonCandidate(getSnapshot(el!), {
+        activeReadMs: measuredActiveReadMs,
+        maxScrollPercent,
+        finishability:
+          measuredActiveReadMs >= 30_000 && maxScrollPercent < 80
+            ? 'abandoned_suspected_boring'
+            : 'abandoned_unknown',
+      });
+      markDirtyForSync();
+    }
+
+    window.addEventListener('scroll', noteReaderActivity, { passive: true });
+    window.addEventListener('pointerdown', noteReaderActivity, { passive: true });
+    window.addEventListener('keydown', noteReaderActivity);
+    window.addEventListener('touchstart', noteReaderActivity, { passive: true });
+    document.addEventListener('visibilitychange', checkpointActiveRead);
+    window.addEventListener('pagehide', recordAbandonIfNeeded);
     updateMaxScroll();
 
     const observer = new IntersectionObserver(
       (entries) => {
         if (entries[0].isIntersecting) {
-          // Bottom of content visible — mark as read
-          import('../lib/reading-tracker').then(({ markAsRead }) => {
-            markAsRead(slug, 'active_scroll_end');
-            recordReadFinish(getSnapshot(el), {
-              method: 'active_scroll_end',
-              activeReadMs: Date.now() - startedAt,
-              maxScrollPercent: Math.max(maxScrollPercent, 100),
-            });
-            if (localStorage.getItem(LAST_SYNC_KEY)) {
-              localStorage.setItem(SYNC_DIRTY_KEY, 'true');
-            }
-            scheduleDebouncedSync();
-            // Update button UI
-            document.querySelectorAll<HTMLElement>('[data-read-button]').forEach((btn) => {
-              if (btn.dataset.slug === slug) {
-                btn.querySelector<HTMLElement>('.rs-icon-unread')!.style.display = 'none';
-                btn.querySelector<HTMLElement>('.rs-icon-read')!.style.display = '';
-                btn.querySelector<HTMLElement>('.rs-label-unread')!.style.display = 'none';
-                btn.querySelector<HTMLElement>('.rs-label-read')!.style.display = '';
-                btn.querySelector<HTMLButtonElement>('.read-status-btn')!.classList.add('is-read');
-              }
-            });
+          // Bottom of content visible — mark as read synchronously enough to avoid pagehide races.
+          finished = true;
+          markAsRead(slug, 'active_scroll_end');
+          recordReadFinish(getSnapshot(el!), {
+            method: 'active_scroll_end',
+            activeReadMs: checkpointActiveRead(),
+            maxScrollPercent: Math.max(maxScrollPercent, 100),
           });
-          window.removeEventListener('scroll', updateMaxScroll);
-          observer.disconnect();
+          markDirtyForSync();
+          scheduleDebouncedSync();
+          // Update button UI
+          document.querySelectorAll<HTMLElement>('[data-read-button]').forEach((btn) => {
+            if (btn.dataset.slug === slug) {
+              btn.querySelector<HTMLElement>('.rs-icon-unread')!.style.display = 'none';
+              btn.querySelector<HTMLElement>('.rs-icon-read')!.style.display = '';
+              btn.querySelector<HTMLElement>('.rs-label-unread')!.style.display = 'none';
+              btn.querySelector<HTMLElement>('.rs-label-read')!.style.display = '';
+              btn.querySelector<HTMLButtonElement>('.read-status-btn')!.classList.add('is-read');
+            }
+          });
+          cleanupTracking();
         }
       },
       { threshold: 1.0, rootMargin: '0px 0px -50px 0px' }

--- a/src/lib/human-signals.ts
+++ b/src/lib/human-signals.ts
@@ -1,8 +1,12 @@
 const SIGNAL_STORAGE_KEY = 'gu-log-human-signals';
 
-export type HumanSignalKind = 'read_finish' | 'share_intent' | 'feedback_comment';
+export type HumanSignalKind =
+  | 'read_finish'
+  | 'read_abandon_candidate'
+  | 'share_intent'
+  | 'feedback_comment';
 export type GuLogLang = 'zh-tw' | 'en';
-export type ReaderTrustTier = 'owner_trusted' | 'guest_reference' | 'unknown';
+export type ReaderTrustTier = 'owner_trusted' | 'owner_approved' | 'guest_reference' | 'unknown';
 export type SignalSyncStatus = 'local_only' | 'synced' | 'sync_failed';
 export type SignalTransport = 'local_storage';
 
@@ -49,18 +53,97 @@ export type ReadFinishEvent = BaseHumanSignalEvent & {
   maxScrollPercent?: number;
 };
 
+export type ReadAbandonCandidateEvent = BaseHumanSignalEvent & {
+  kind: 'read_abandon_candidate';
+  finishability: Extract<FinishabilityState, 'abandoned_suspected_boring' | 'abandoned_unknown'>;
+  confidence: Extract<SignalConfidence, 'low'>;
+  activeReadMs: number;
+  maxScrollPercent: number;
+};
+
 export type ShareTarget = 'native' | 'x' | 'facebook' | 'line' | 'copy_link';
 export type ShareResult = 'attempted' | 'completed' | 'cancelled' | 'failed';
+export type ShareReactionStrength = 'strong';
+export type SharePolarity = 'unknown' | 'positive' | 'useful' | 'ridicule' | 'negative';
 
 export type ShareIntentEvent = BaseHumanSignalEvent & {
   kind: 'share_intent';
   target: ShareTarget;
   result: ShareResult;
   resultConfidence: 'attempted' | 'completed' | 'cancelled' | 'failed';
-  sentiment: 'positive';
+  reactionStrength: ShareReactionStrength;
+  polarity: SharePolarity;
 };
 
-export type HumanSignalEvent = ReadFinishEvent | ShareIntentEvent;
+export type CommentPolarity = 'unknown' | 'positive' | 'negative' | 'rewrite_needed';
+
+export type FeedbackCommentEvent = BaseHumanSignalEvent & {
+  kind: 'feedback_comment';
+  source: 'giscus' | 'first_party';
+  commentId?: string;
+  commentText?: string;
+  polarity: CommentPolarity;
+};
+
+export type HumanSignalEvent =
+  | ReadFinishEvent
+  | ReadAbandonCandidateEvent
+  | ShareIntentEvent
+  | FeedbackCommentEvent;
+
+export type HumanSignalTrustInput = {
+  reader?: string;
+  ownerReader?: string;
+  ownerApproved?: boolean;
+};
+
+export type HumanSignalPacketQuery = {
+  postId: string;
+  pathname: string;
+  postVersion: number | string;
+};
+
+export type HumanSignalTribunalPacketSignal = Readonly<
+  Pick<
+    HumanSignalEvent,
+    | 'eventId'
+    | 'kind'
+    | 'postId'
+    | 'ticketId'
+    | 'lang'
+    | 'pathname'
+    | 'postVersion'
+    | 'contentVersion'
+    | 'occurredAt'
+    | 'reader'
+    | 'readerTrustTier'
+    | 'syncStatus'
+  > & {
+    automationAuthoritative: boolean;
+    finishability?: FinishabilityState;
+    confidence?: SignalConfidence;
+    method?: ReadFinishMethod;
+    activeReadMs?: number;
+    maxScrollPercent?: number;
+    target?: ShareTarget;
+    result?: ShareResult;
+    reactionStrength?: ShareReactionStrength;
+    polarity?: SharePolarity | CommentPolarity;
+    source?: FeedbackCommentEvent['source'];
+    commentId?: string;
+    commentText?: string;
+  }
+>;
+
+export type HumanSignalTribunalPacket = Readonly<{
+  packetSchemaVersion: 1;
+  postId: string;
+  pathname: string;
+  postVersion: number;
+  signals: ReadonlyArray<HumanSignalTribunalPacketSignal>;
+  automationAuthoritativeSignalCount: number;
+  recommendedAutomation: 'none';
+}>;
 
 type HumanSignalStore = {
   version: 1;
@@ -96,6 +179,117 @@ function normalizeSnapshot(snapshot: ArticleVersionSnapshot) {
   };
 }
 
+export function classifyHumanSignalTrustTier(input: HumanSignalTrustInput = {}): ReaderTrustTier {
+  if (input.ownerApproved) {
+    return 'owner_approved';
+  }
+  if (input.reader && input.ownerReader && input.reader === input.ownerReader) {
+    return 'owner_trusted';
+  }
+  if (input.reader) {
+    return 'guest_reference';
+  }
+  return 'unknown';
+}
+
+export function isAutomationAuthoritativeTrustTier(tier: ReaderTrustTier): boolean {
+  return tier === 'owner_trusted' || tier === 'owner_approved';
+}
+
+export function promoteHumanSignalTrustTier<T extends HumanSignalEvent>(
+  event: T,
+  readerTrustTier: ReaderTrustTier,
+  reader?: string
+): T {
+  return {
+    ...event,
+    reader: reader ?? event.reader,
+    readerTrustTier,
+  };
+}
+
+function matchesPacketQuery(event: HumanSignalEvent, query: HumanSignalPacketQuery): boolean {
+  return (
+    event.postId === query.postId &&
+    event.pathname === query.pathname &&
+    event.postVersion === toPositiveInteger(query.postVersion)
+  );
+}
+
+function toTribunalPacketSignal(event: HumanSignalEvent): HumanSignalTribunalPacketSignal {
+  const signal: HumanSignalTribunalPacketSignal = {
+    eventId: event.eventId,
+    kind: event.kind,
+    postId: event.postId,
+    ticketId: event.ticketId,
+    lang: event.lang,
+    pathname: event.pathname,
+    postVersion: event.postVersion,
+    contentVersion: event.contentVersion,
+    occurredAt: event.occurredAt,
+    reader: event.reader,
+    readerTrustTier: event.readerTrustTier,
+    syncStatus: event.syncStatus,
+    automationAuthoritative: isAutomationAuthoritativeTrustTier(event.readerTrustTier),
+    ...(event.kind === 'read_finish'
+      ? {
+          method: event.method,
+          finishability: event.finishability,
+          confidence: event.confidence,
+          activeReadMs: event.activeReadMs,
+          maxScrollPercent: event.maxScrollPercent,
+        }
+      : {}),
+    ...(event.kind === 'read_abandon_candidate'
+      ? {
+          finishability: event.finishability,
+          confidence: event.confidence,
+          activeReadMs: event.activeReadMs,
+          maxScrollPercent: event.maxScrollPercent,
+        }
+      : {}),
+    ...(event.kind === 'share_intent'
+      ? {
+          target: event.target,
+          result: event.result,
+          reactionStrength: event.reactionStrength,
+          polarity: event.polarity,
+        }
+      : {}),
+    ...(event.kind === 'feedback_comment'
+      ? {
+          source: event.source,
+          commentId: event.commentId,
+          commentText: event.commentText,
+          polarity: event.polarity,
+        }
+      : {}),
+  };
+
+  return Object.freeze(signal);
+}
+
+export function buildHumanSignalTribunalPacket(
+  query: HumanSignalPacketQuery,
+  events: readonly HumanSignalEvent[]
+): HumanSignalTribunalPacket {
+  const postVersion = toPositiveInteger(query.postVersion);
+  const signals = Object.freeze(
+    events.filter((event) => matchesPacketQuery(event, query)).map(toTribunalPacketSignal)
+  );
+
+  return Object.freeze({
+    packetSchemaVersion: 1,
+    postId: query.postId,
+    pathname: query.pathname,
+    postVersion,
+    signals,
+    automationAuthoritativeSignalCount: signals.filter((signal) => signal.automationAuthoritative)
+      .length,
+    recommendedAutomation: 'none',
+  });
+}
+
 function getStore(): HumanSignalStore {
   try {
     const raw = localStorage.getItem(SIGNAL_STORAGE_KEY);
@@ -127,8 +321,72 @@ export function getHumanSignalEvents(): HumanSignalEvent[] {
   return [...getStore().events];
 }
 
-export function appendHumanSignalEvent(event: HumanSignalEvent): HumanSignalEvent {
+type EventUpsertOptions = {
+  dedupeKey?: (event: HumanSignalEvent) => string;
+};
+
+function articleVersionKey(event: HumanSignalEvent): string {
+  return [
+    event.kind,
+    event.postId,
+    event.postVersion,
+    event.contentVersion ?? '',
+    event.pathname,
+    event.reader ?? '',
+  ].join('|');
+}
+
+export function getPendingHumanSignalEvents(): HumanSignalEvent[] {
+  return getStore().events.filter((event) => event.syncStatus !== 'synced');
+}
+
+function markHumanSignalEventSyncStatus(eventId: string, syncStatus: SignalSyncStatus): boolean {
   const store = getStore();
+  for (const event of store.events) {
+    if (event.eventId === eventId) {
+      event.syncStatus = syncStatus;
+      store.lastUpdated = nowIso();
+      saveStore(store);
+      return true;
+    }
+  }
+
+  return false;
+}
+
+export function markHumanSignalEventSynced(eventId: string): boolean {
+  return markHumanSignalEventSyncStatus(eventId, 'synced');
+}
+
+export function markHumanSignalEventFailed(eventId: string): boolean {
+  return markHumanSignalEventSyncStatus(eventId, 'sync_failed');
+}
+
+export function appendHumanSignalEvent(
+  event: HumanSignalEvent,
+  options: EventUpsertOptions = {}
+): HumanSignalEvent {
+  const store = getStore();
+  if (options.dedupeKey) {
+    const incomingKey = options.dedupeKey(event);
+    let existingIndex = -1;
+    for (let index = 0; index < store.events.length; index += 1) {
+      if (options.dedupeKey(store.events[index]) === incomingKey) {
+        existingIndex = index;
+        break;
+      }
+    }
+    if (existingIndex >= 0) {
+      const upserted = {
+        ...event,
+        eventId: store.events[existingIndex].eventId,
+      } as HumanSignalEvent;
+      store.events[existingIndex] = upserted;
+      store.lastUpdated = nowIso();
+      saveStore(store);
+      return upserted;
+    }
+  }
   store.events.push(event);
   store.lastUpdated = nowIso();
   saveStore(store);
@@ -192,6 +450,27 @@ export function recordLegacyImportedRead(slug: string, importedAt?: string): Rea
   return appendHumanSignalEvent(event) as ReadFinishEvent;
 }
 
+export function recordReadAbandonCandidate(
+  snapshot: ArticleVersionSnapshot,
+  metrics: {
+    activeReadMs: number;
+    maxScrollPercent: number;
+    finishability?: Extract<FinishabilityState, 'abandoned_suspected_boring' | 'abandoned_unknown'>;
+  }
+): ReadAbandonCandidateEvent {
+  const event: ReadAbandonCandidateEvent = {
+    ...baseEvent('read_abandon_candidate', snapshot),
+    kind: 'read_abandon_candidate',
+    finishability: metrics.finishability || 'abandoned_unknown',
+    confidence: 'low',
+    activeReadMs: metrics.activeReadMs,
+    maxScrollPercent: metrics.maxScrollPercent,
+  };
+  return appendHumanSignalEvent(event, {
+    dedupeKey: articleVersionKey,
+  }) as ReadAbandonCandidateEvent;
+}
+
 export function recordShareIntent(
   snapshot: ArticleVersionSnapshot,
   share: { target: ShareTarget; result: ShareResult }
@@ -202,7 +481,28 @@ export function recordShareIntent(
     target: share.target,
     result: share.result,
     resultConfidence: share.result,
-    sentiment: 'positive',
+    reactionStrength: 'strong',
+    polarity: 'unknown',
   };
   return appendHumanSignalEvent(event) as ShareIntentEvent;
+}
+
+export function recordFeedbackComment(
+  snapshot: ArticleVersionSnapshot,
+  comment: {
+    source: FeedbackCommentEvent['source'];
+    commentId?: string;
+    commentText?: string;
+    polarity?: CommentPolarity;
+  }
+): FeedbackCommentEvent {
+  const event: FeedbackCommentEvent = {
+    ...baseEvent('feedback_comment', snapshot),
+    kind: 'feedback_comment',
+    source: comment.source,
+    commentId: comment.commentId,
+    commentText: comment.commentText,
+    polarity: comment.polarity || 'unknown',
+  };
+  return appendHumanSignalEvent(event) as FeedbackCommentEvent;
 }

--- a/tests/human-signal-ui-contract.test.ts
+++ b/tests/human-signal-ui-contract.test.ts
@@ -22,6 +22,12 @@ describe('human signal UI wiring', () => {
     expect(readStatus).toContain('data-post-version={postVersion}');
     expect(readStatus).toContain('recordManualMarkRead');
     expect(readStatus).toContain('recordReadFinish');
+    expect(readStatus).toContain('recordReadAbandonCandidate');
+    expect(readStatus).toContain('pagehide');
+    expect(readStatus).toContain('document.visibilityState');
+    expect(readStatus).toContain('lastActivityAt');
+    expect(readStatus).toContain('FINISH_SCROLL_GUARD_PERCENT');
+    expect(readStatus).not.toContain('Date.now() - startedAt');
 
     const share = read('src/components/ShareButton.astro');
     expect(share).toContain('data-post-id={postId}');

--- a/tests/human-signals.test.ts
+++ b/tests/human-signals.test.ts
@@ -27,7 +27,6 @@ beforeEach(() => {
 describe('human signals', () => {
   it('records read_finish with article identity, visible version, method, and engagement metrics', async () => {
     const { recordReadFinish, getHumanSignalEvents } = await import('../src/lib/human-signals');
-
     const event = recordReadFinish(
       {
         postId: 'sp-123-20260601-interesting-post.mdx',
@@ -36,13 +35,8 @@ describe('human signals', () => {
         pathname: '/posts/sp-123-20260601-interesting-post/',
         postVersion: '4',
       },
-      {
-        method: 'active_scroll_end',
-        activeReadMs: 45_000,
-        maxScrollPercent: 100,
-      }
+      { method: 'active_scroll_end', activeReadMs: 45_000, maxScrollPercent: 100 }
     );
-
     expect(event).toMatchObject({
       eventSchemaVersion: 1,
       kind: 'read_finish',
@@ -66,14 +60,12 @@ describe('human signals', () => {
 
   it('records manual mark-read separately from high-confidence active finish', async () => {
     const { recordManualMarkRead } = await import('../src/lib/human-signals');
-
     const event = recordManualMarkRead({
       postId: 'sp-1.mdx',
       lang: 'zh-tw',
       pathname: '/posts/sp-1/',
       postVersion: 2,
     });
-
     expect(event).toMatchObject({
       kind: 'read_finish',
       method: 'manual_mark_read',
@@ -83,9 +75,8 @@ describe('human signals', () => {
     });
   });
 
-  it('records share_intent with target, result confidence, and version snapshot', async () => {
+  it('records share_intent as a strong reaction without assuming positive polarity', async () => {
     const { recordShareIntent, getHumanSignalEvents } = await import('../src/lib/human-signals');
-
     const event = recordShareIntent(
       {
         postId: 'en-sp-123-20260601-interesting-post.mdx',
@@ -96,16 +87,306 @@ describe('human signals', () => {
       },
       { target: 'copy_link', result: 'completed' }
     );
-
     expect(event).toMatchObject({
       kind: 'share_intent',
       target: 'copy_link',
       result: 'completed',
       resultConfidence: 'completed',
       postVersion: 7,
-      sentiment: 'positive',
+      reactionStrength: 'strong',
+      polarity: 'unknown',
+    });
+    expect(event).not.toHaveProperty('sentiment', 'positive');
+    expect(getHumanSignalEvents()).toEqual([event]);
+  });
+
+  it('records feedback comments with article identity and version snapshot', async () => {
+    const { recordFeedbackComment, getHumanSignalEvents } =
+      await import('../src/lib/human-signals');
+    const event = recordFeedbackComment(
+      {
+        postId: 'sp-commented.mdx',
+        ticketId: 'SP-COMMENT',
+        lang: 'zh-tw',
+        pathname: '/posts/sp-commented/',
+        postVersion: '9',
+      },
+      {
+        source: 'giscus',
+        commentId: 'discussion-comment-123',
+        commentText: '難看死了',
+        polarity: 'rewrite_needed',
+      }
+    );
+    expect(event).toMatchObject({
+      kind: 'feedback_comment',
+      postId: 'sp-commented.mdx',
+      ticketId: 'SP-COMMENT',
+      pathname: '/posts/sp-commented/',
+      postVersion: 9,
+      source: 'giscus',
+      commentId: 'discussion-comment-123',
+      commentText: '難看死了',
+      polarity: 'rewrite_needed',
+      syncStatus: 'local_only',
     });
     expect(getHumanSignalEvents()).toEqual([event]);
+  });
+
+  it('records abandoned reading as low-confidence suspected boring evidence with engagement metrics', async () => {
+    const { recordReadAbandonCandidate, getHumanSignalEvents } =
+      await import('../src/lib/human-signals');
+    const event = recordReadAbandonCandidate(
+      {
+        postId: 'sp-456-20260602-boring-post.mdx',
+        ticketId: 'SP-456',
+        lang: 'zh-tw',
+        pathname: '/posts/sp-456-20260602-boring-post/',
+        postVersion: 3,
+      },
+      { activeReadMs: 39_000, maxScrollPercent: 38, finishability: 'abandoned_suspected_boring' }
+    );
+    expect(event).toMatchObject({
+      kind: 'read_abandon_candidate',
+      postId: 'sp-456-20260602-boring-post.mdx',
+      ticketId: 'SP-456',
+      postVersion: 3,
+      activeReadMs: 39_000,
+      maxScrollPercent: 38,
+      finishability: 'abandoned_suspected_boring',
+      confidence: 'low',
+      transport: 'local_storage',
+      syncStatus: 'local_only',
+    });
+    expect(event.activeReadMs).toEqual(expect.any(Number));
+    expect(event.maxScrollPercent).toEqual(expect.any(Number));
+    expect(getHumanSignalEvents()).toEqual([event]);
+  });
+
+  it('upserts repeated pagehide abandon candidates for the same article version instead of spamming duplicates', async () => {
+    const { recordReadAbandonCandidate, getHumanSignalEvents } =
+      await import('../src/lib/human-signals');
+    const snapshot = {
+      postId: 'sp-789-20260603-repeated-pagehide.mdx',
+      ticketId: 'SP-789',
+      lang: 'zh-tw' as const,
+      pathname: '/posts/sp-789-20260603-repeated-pagehide/',
+      postVersion: 5,
+    };
+    const first = recordReadAbandonCandidate(snapshot, {
+      activeReadMs: 31_000,
+      maxScrollPercent: 34,
+      finishability: 'abandoned_suspected_boring',
+    });
+    const second = recordReadAbandonCandidate(snapshot, {
+      activeReadMs: 32_500,
+      maxScrollPercent: 36,
+      finishability: 'abandoned_suspected_boring',
+    });
+    expect(getHumanSignalEvents()).toEqual([second]);
+    expect(second.eventId).toBe(first.eventId);
+    expect(second).toMatchObject({
+      kind: 'read_abandon_candidate',
+      postId: snapshot.postId,
+      ticketId: snapshot.ticketId,
+      postVersion: 5,
+      confidence: 'low',
+      activeReadMs: 32_500,
+      maxScrollPercent: 36,
+    });
+  });
+
+  it('keeps abandon candidates for different article versions as separate events', async () => {
+    const { recordReadAbandonCandidate, getHumanSignalEvents } =
+      await import('../src/lib/human-signals');
+    const baseSnapshot = {
+      postId: 'sp-789-20260603-repeated-pagehide.mdx',
+      lang: 'zh-tw' as const,
+      pathname: '/posts/sp-789-20260603-repeated-pagehide/',
+    };
+    const v1 = recordReadAbandonCandidate(
+      { ...baseSnapshot, postVersion: 5 },
+      { activeReadMs: 31_000, maxScrollPercent: 34 }
+    );
+    const v2 = recordReadAbandonCandidate(
+      { ...baseSnapshot, postVersion: 6 },
+      { activeReadMs: 31_000, maxScrollPercent: 34 }
+    );
+    expect(getHumanSignalEvents()).toEqual([v1, v2]);
+  });
+
+  it('lists local-only and failed human-signal events as pending sync work', async () => {
+    const {
+      getPendingHumanSignalEvents,
+      markHumanSignalEventSynced,
+      markHumanSignalEventFailed,
+      recordManualMarkRead,
+      recordShareIntent,
+    } = await import('../src/lib/human-signals');
+    const first = recordManualMarkRead({
+      postId: 'sp-pending-1.mdx',
+      lang: 'zh-tw',
+      pathname: '/posts/sp-pending-1/',
+      postVersion: 1,
+    });
+    const second = recordShareIntent(
+      {
+        postId: 'sp-pending-2.mdx',
+        lang: 'en',
+        pathname: '/en/posts/sp-pending-2/',
+        postVersion: 1,
+      },
+      { target: 'copy_link', result: 'attempted' }
+    );
+    expect(getPendingHumanSignalEvents().map((event) => event.eventId)).toEqual([
+      first.eventId,
+      second.eventId,
+    ]);
+    expect(markHumanSignalEventSynced(first.eventId)).toBe(true);
+    expect(markHumanSignalEventFailed(second.eventId)).toBe(true);
+    expect(getPendingHumanSignalEvents()).toEqual([
+      expect.objectContaining({ eventId: second.eventId, syncStatus: 'sync_failed' }),
+    ]);
+  });
+
+  it('marks human-signal sync status by eventId without changing event semantics', async () => {
+    const {
+      getHumanSignalEvents,
+      markHumanSignalEventFailed,
+      markHumanSignalEventSynced,
+      recordReadFinish,
+    } = await import('../src/lib/human-signals');
+    const event = recordReadFinish(
+      {
+        postId: 'sp-status.mdx',
+        ticketId: 'SP-STATUS',
+        lang: 'zh-tw',
+        pathname: '/posts/sp-status/',
+        postVersion: 2,
+      },
+      { method: 'active_scroll_end', activeReadMs: 10_000, maxScrollPercent: 100 }
+    );
+    const before = { ...event };
+    expect(markHumanSignalEventFailed('missing-event-id')).toBe(false);
+    expect(markHumanSignalEventFailed(event.eventId)).toBe(true);
+    expect(markHumanSignalEventSynced(event.eventId)).toBe(true);
+    expect(getHumanSignalEvents()[0]).toEqual({ ...before, syncStatus: 'synced' });
+  });
+
+  it('treats corrupted human-signal storage as an empty pending queue', async () => {
+    (globalThis as any).localStorage.setItem('gu-log-human-signals', '{not valid json');
+    const { getHumanSignalEvents, getPendingHumanSignalEvents, markHumanSignalEventSynced } =
+      await import('../src/lib/human-signals');
+    expect(getHumanSignalEvents()).toEqual([]);
+    expect(getPendingHumanSignalEvents()).toEqual([]);
+    expect(markHumanSignalEventSynced('missing-event-id')).toBe(false);
+  });
+
+  it('classifies guest and unknown signals as non-authoritative and owner signals as actionable', async () => {
+    const { classifyHumanSignalTrustTier, isAutomationAuthoritativeTrustTier } =
+      await import('../src/lib/human-signals');
+    expect(classifyHumanSignalTrustTier()).toBe('unknown');
+    expect(classifyHumanSignalTrustTier({ reader: 'anonymous' })).toBe('guest_reference');
+    expect(classifyHumanSignalTrustTier({ reader: 'gu-owner', ownerReader: 'gu-owner' })).toBe(
+      'owner_trusted'
+    );
+    expect(classifyHumanSignalTrustTier({ reader: 'editor', ownerApproved: true })).toBe(
+      'owner_approved'
+    );
+    expect(isAutomationAuthoritativeTrustTier('unknown')).toBe(false);
+    expect(isAutomationAuthoritativeTrustTier('guest_reference')).toBe(false);
+    expect(isAutomationAuthoritativeTrustTier('owner_trusted')).toBe(true);
+    expect(isAutomationAuthoritativeTrustTier('owner_approved')).toBe(true);
+  });
+
+  it('promotes a copied event to an owner trust tier without mutating the original event', async () => {
+    const { promoteHumanSignalTrustTier, recordReadFinish } =
+      await import('../src/lib/human-signals');
+    const original = recordReadFinish(
+      { postId: 'sp-99.mdx', lang: 'zh-tw', pathname: '/posts/sp-99/', postVersion: 2 },
+      { method: 'active_scroll_end' }
+    );
+    const promoted = promoteHumanSignalTrustTier(original, 'owner_trusted', 'gu-owner');
+    expect(original.readerTrustTier).toBe('unknown');
+    expect(original.reader).toBeUndefined();
+    expect(promoted).toMatchObject({
+      eventId: original.eventId,
+      readerTrustTier: 'owner_trusted',
+      reader: 'gu-owner',
+    });
+    expect(promoted).not.toBe(original);
+  });
+
+  it('builds a read-only Tribunal packet filtered by post identity and version', async () => {
+    const {
+      buildHumanSignalTribunalPacket,
+      promoteHumanSignalTrustTier,
+      recordReadFinish,
+      recordShareIntent,
+    } = await import('../src/lib/human-signals');
+    const ownerFinish = promoteHumanSignalTrustTier(
+      recordReadFinish(
+        { postId: 'sp-123.mdx', lang: 'zh-tw', pathname: '/posts/sp-123/', postVersion: 4 },
+        { method: 'active_scroll_end', activeReadMs: 61_000, maxScrollPercent: 100 }
+      ),
+      'owner_trusted',
+      'gu-owner'
+    );
+    const guestShare = {
+      ...recordShareIntent(
+        { postId: 'sp-123.mdx', lang: 'zh-tw', pathname: '/posts/sp-123/', postVersion: 4 },
+        { target: 'copy_link', result: 'completed' }
+      ),
+      readerTrustTier: 'guest_reference' as const,
+    };
+    const otherVersion = promoteHumanSignalTrustTier(
+      recordReadFinish(
+        { postId: 'sp-123.mdx', lang: 'zh-tw', pathname: '/posts/sp-123/', postVersion: 3 },
+        { method: 'active_scroll_end' }
+      ),
+      'owner_trusted'
+    );
+    const samePathDifferentPost = promoteHumanSignalTrustTier(
+      recordReadFinish(
+        { postId: 'sp-else.mdx', lang: 'zh-tw', pathname: '/posts/sp-123/', postVersion: 4 },
+        { method: 'active_scroll_end' }
+      ),
+      'owner_trusted'
+    );
+    const packet = buildHumanSignalTribunalPacket(
+      { postId: 'sp-123.mdx', pathname: '/posts/sp-123/', postVersion: 4 },
+      [ownerFinish, guestShare, otherVersion, samePathDifferentPost]
+    );
+    expect(packet).toMatchObject({
+      packetSchemaVersion: 1,
+      postId: 'sp-123.mdx',
+      pathname: '/posts/sp-123/',
+      postVersion: 4,
+      automationAuthoritativeSignalCount: 1,
+      recommendedAutomation: 'none',
+    });
+    expect(packet.signals).toHaveLength(2);
+    expect(packet.signals.map((signal) => signal.eventId)).toEqual([
+      ownerFinish.eventId,
+      guestShare.eventId,
+    ]);
+    expect(packet.signals[0]).toMatchObject({
+      kind: 'read_finish',
+      readerTrustTier: 'owner_trusted',
+      automationAuthoritative: true,
+      finishability: 'finished',
+    });
+    expect(packet.signals[1]).toMatchObject({
+      kind: 'share_intent',
+      readerTrustTier: 'guest_reference',
+      automationAuthoritative: false,
+      reactionStrength: 'strong',
+      polarity: 'unknown',
+    });
+    expect(packet.signals[1]).not.toHaveProperty('preservePositive');
+    expect(packet).not.toHaveProperty('requeueTribunal');
+    expect(Object.isFrozen(packet)).toBe(true);
+    expect(Object.isFrozen(packet.signals)).toBe(true);
   });
 });
 
@@ -119,9 +400,7 @@ describe('reading tracker migration to event-aware store', () => {
         lastUpdated: '2026-06-01T00:00:00.000Z',
       })
     );
-
     const tracker = await import('../src/lib/reading-tracker');
-
     expect(tracker.getReadSlugs().sort()).toEqual(['sp-1', 'sp-2']);
     expect(tracker.getStats()).toMatchObject({ total: 2, version: 2 });
     expect(tracker.getReadRecords()).toEqual(


### PR DESCRIPTION
## Summary
- Hardens human signal active-read tracking to use visibility/recent-activity checkpoints instead of raw dwell time
- Prevents pagehide from recording abandon candidates after near-finish scroll depth
- Adds versioned feedback_comment recorder and tests for comment snapshot semantics
- Keeps Tribunal packet read-only and guest/unknown signals non-authoritative

## Validation
- pnpm exec vitest run tests/human-signals.test.ts tests/human-signal-ui-contract.test.ts tests/reading-tracker.test.ts
- pnpm exec astro check
- pnpm run build
- 3 independent high-bar reviewers: spec/code/e2e all APPROVED