### PR TITLE
feat: show inferred authorship note for Lv-06

### DIFF
--- a/src/data/post-authorship-notes.json
+++ b/src/data/post-authorship-notes.json
@@ -1,0 +1,10 @@
+{
+  "levelup-20260218-06-openclaw-memory-skills-automation": {
+    "zh-tw": "Clawd Bot 初稿；ShroomClawd + Claude Opus 4.6 Ralph refinement。依據 git history 與 2026-03-20 OPUS46_TRIED_3_TIMES commit 推定。",
+    "en": "Initial draft by Clawd Bot; Ralph refinement by ShroomClawd + Claude Opus 4.6, based on git history and the 2026-03-20 OPUS46_TRIED_3_TIMES commit."
+  },
+  "en-levelup-20260218-06-openclaw-memory-skills-automation": {
+    "zh-tw": "Clawd Bot 初稿；ShroomClawd + Claude Opus 4.6 Ralph refinement。依據 git history 與 2026-03-20 OPUS46_TRIED_3_TIMES commit 推定。",
+    "en": "Initial draft by Clawd Bot; Ralph refinement by ShroomClawd + Claude Opus 4.6, based on git history and the 2026-03-20 OPUS46_TRIED_3_TIMES commit."
+  }
+}

--- a/src/pages/api/feed.json.ts
+++ b/src/pages/api/feed.json.ts
@@ -1,5 +1,6 @@
 import type { APIContext } from 'astro';
 import { getCollection } from 'astro:content';
+import { getPostAuthorshipNote } from '../../utils/post-authorship-notes';
 import { getPublishedPosts } from '../../utils/post-status';
 
 /**
@@ -11,7 +12,7 @@ import { getPublishedPosts } from '../../utils/post-status';
  *
  * Fields per article:
  *   slug, ticketId, prefix, title, summary, tags, lang,
- *   originalDate, translatedDate, source, sourceUrl,
+ *   originalDate, translatedDate, source, sourceUrl, authorshipNote,
  *   translatedBy (model info), url (relative link)
  */
 export async function GET(_context: APIContext) {
@@ -37,6 +38,7 @@ export async function GET(_context: APIContext) {
       translatedDate: post.data.translatedDate || null,
       source: post.data.source,
       sourceUrl: post.data.sourceUrl,
+      authorshipNote: getPostAuthorshipNote(post.id, post.data.lang),
       translatedBy: post.data.translatedBy
         ? {
             model: post.data.translatedBy.model,

--- a/src/pages/api/posts/[slug].json.ts
+++ b/src/pages/api/posts/[slug].json.ts
@@ -1,5 +1,6 @@
 import type { APIContext } from 'astro';
 import { getCollection, type CollectionEntry } from 'astro:content';
+import { getPostAuthorshipNote } from '../../../utils/post-authorship-notes';
 
 /**
  * Individual article endpoint for gu-log iOS app.
@@ -44,6 +45,7 @@ export async function GET(_context: APIContext) {
       translatedDate: post.data.translatedDate || null,
       source: post.data.source,
       sourceUrl: post.data.sourceUrl,
+      authorshipNote: getPostAuthorshipNote(post.id, post.data.lang),
       translatedBy: post.data.translatedBy || null,
       headings,
       // Raw body: everything after the frontmatter closing ---

--- a/src/pages/en/posts/[...slug].astro
+++ b/src/pages/en/posts/[...slug].astro
@@ -15,6 +15,7 @@ import ShareButton from '../../../components/ShareButton.astro';
 import AiPopup from '../../../components/AiPopup.astro';
 import ReadStatusButton from '../../../components/ReadStatusButton.astro';
 import AiJudgeScore from '../../../components/AiJudgeScore.astro';
+import { getPostAuthorshipNote } from '../../../utils/post-authorship-notes';
 import {
   getLocalizedPostUrl,
   getNavigablePosts,
@@ -49,6 +50,7 @@ const sourceCitationLabel =
 
 const postVersion = getPostVersion(post.id);
 const postReaderRevision = getPostReaderRevision(post.id);
+const authorshipNote = getPostAuthorshipNote(post.id, 'en');
 const postStatus = resolvePostStatus(post, allPosts);
 const navigablePosts = getNavigablePosts(allPosts, post);
 
@@ -121,6 +123,15 @@ const ticketLabel = ticketLabels[ticketPrefix] || '';
           <a href={post.data.sourceUrl} target="_blank" rel="noopener">
             {post.data.source}
           </a>
+        </div>
+      )
+    }
+
+    {
+      authorshipNote && (
+        <div class="authorship-note">
+          <strong>Authorship note:</strong>
+          <span>{authorshipNote}</span>
         </div>
       )
     }
@@ -348,6 +359,21 @@ const ticketLabel = ticketLabels[ticketPrefix] || '';
     border-radius: 6px;
     font-size: 0.85rem;
     color: var(--color-text-muted);
+  }
+
+  .authorship-note {
+    margin: 1rem 0 1.25rem;
+    padding: 0.75rem 1rem;
+    background-color: var(--color-bg-secondary, rgba(0, 0, 0, 0.03));
+    border-left: 3px solid var(--color-accent);
+    border-radius: 6px;
+    font-size: 0.9rem;
+    color: var(--color-text-muted);
+    line-height: 1.6;
+  }
+
+  .authorship-note strong {
+    color: var(--color-text);
   }
 
   .post-version-info {

--- a/src/pages/posts/[...slug].astro
+++ b/src/pages/posts/[...slug].astro
@@ -16,6 +16,7 @@ import LoginCta from '../../components/LoginCta.astro';
 import AiPopup from '../../components/AiPopup.astro';
 import ReadStatusButton from '../../components/ReadStatusButton.astro';
 import AiJudgeScore from '../../components/AiJudgeScore.astro';
+import { getPostAuthorshipNote } from '../../utils/post-authorship-notes';
 import { getLocalizedPostUrl, getNavigablePosts, resolvePostStatus } from '../../utils/post-status';
 
 export async function getStaticPaths() {
@@ -45,6 +46,7 @@ const sourceCitationLabel = isShroomDogOriginal && isChatGptShareSource ? '靈�
 
 const postVersion = getPostVersion(post.id);
 const postReaderRevision = getPostReaderRevision(post.id);
+const authorshipNote = getPostAuthorshipNote(post.id, 'zh-tw');
 const postStatus = resolvePostStatus(post, allPosts);
 const navigablePosts = getNavigablePosts(allPosts, post);
 
@@ -117,6 +119,15 @@ const ticketLabel = ticketLabels[ticketPrefix] || '';
           <a href={post.data.sourceUrl} target="_blank" rel="noopener">
             {post.data.source}
           </a>
+        </div>
+      )
+    }
+
+    {
+      authorshipNote && (
+        <div class="authorship-note">
+          <strong>作者推定：</strong>
+          <span>{authorshipNote}</span>
         </div>
       )
     }
@@ -346,6 +357,21 @@ const ticketLabel = ticketLabels[ticketPrefix] || '';
     border-radius: 6px;
     font-size: 0.85rem;
     color: var(--color-text-muted);
+  }
+
+  .authorship-note {
+    margin: 1rem 0 1.25rem;
+    padding: 0.75rem 1rem;
+    background-color: var(--color-bg-secondary, rgba(0, 0, 0, 0.03));
+    border-left: 3px solid var(--color-accent);
+    border-radius: 6px;
+    font-size: 0.9rem;
+    color: var(--color-text-muted);
+    line-height: 1.6;
+  }
+
+  .authorship-note strong {
+    color: var(--color-text);
   }
 
   .post-version-info {

--- a/src/utils/post-authorship-notes.ts
+++ b/src/utils/post-authorship-notes.ts
@@ -1,0 +1,14 @@
+import notes from '../data/post-authorship-notes.json';
+
+type Lang = 'zh-tw' | 'en';
+type AuthorshipNotes = Record<string, Partial<Record<Lang, string>>>;
+
+const authorshipNotes = notes as AuthorshipNotes;
+
+function postKey(postId: string): string {
+  return postId.replace(/\.mdx$/, '');
+}
+
+export function getPostAuthorshipNote(postId: string, lang: Lang): string | null {
+  return authorshipNotes[postKey(postId)]?.[lang] ?? null;
+}


### PR DESCRIPTION
Adds a small visible/API authorship note for Lv-06 without modifying the MDX body.\n\nImplementation:\n- keeps Lv-06 content files untouched\n- stores inferred authorship in an external metadata map\n- renders a compact note on zh/en post pages\n- exposes authorshipNote in the post/feed JSON APIs\n\nLocal verification:\n- node scripts/validate-posts.mjs\n- pnpm exec astro check\n- pnpm run build\n- local dist HTML/API contains the note for zh/en Lv-06