### PR TITLE
fix: move authorship notes to post metadata

### DIFF
--- a/docs/shroomdog-editorial-feedback.md
+++ b/docs/shroomdog-editorial-feedback.md
@@ -340,7 +340,15 @@
 - 修法：保留「agent 做夢 = 把白天工作沉澱成可重用程序」這個核心，刪掉重複解釋和過多分類，讓文章變成短而尖的概念文。只留必要 source capture、Skill vs diary、/dream 應該保守這幾個讀者真正需要的點。
 - Reusable lesson：短 prompt/概念來源不一定需要完整拆解每個 bullet。若核心洞見一句話就能講清楚，文章應該圍繞那個洞見做 mental model，而不是把 source prompt 轉成「逐條說明書」。Tribunal/FreshEyes 若只看懂不看「是否值得讀完」，可能會高估這類長但正確的文章。
 
-
 ## 2026-05-27 — FreshEyes 長度剛好要變成明確 metric
 
 Sprin asked whether Tribunal v7 FreshEyes covers “length should be just right,” then preferred adding one or two FreshEyes metrics and bumping Tribunal version. Durable lesson: FreshEyes should not only ask whether the post is understandable; it must judge whether the length is worth finishing. Add explicit `payoffDensity` and `lengthFit` dimensions, and make them non-compensating so a good hook/readability cannot hide correct-but-too-long filler. Librarian still owns corpus overlap evidence; FreshEyes owns on-page reader fatigue and length/payoff fit.
+
+## 2026-06-09 — AI authorship notes belong with provenance metadata
+
+### Feedback: Do not put inferred model attribution under the title
+
+- ShroomDog feedback：`為什麼是放那麼上面啊 毫無品味`；`鐵定是要放在藍色框框那個位置吧，模型署名的部分`
+- 情境：PR #383 新增舊文作者推定後，把「作者推定」卡片放在 title/source citation 下方、TOC 上方。這讓製作履歷搶走正文開場視覺重心，特別是在手機上看起來像文章最重要的 lead block。
+- 修法：作者推定不是閱讀前資訊，而是 provenance metadata；應該跟 translatedBy pipeline / model 署名收在同一個底部 metadata box，位置在 tags 後、Tribunal Scores 前。Source citation 可以留在文章前方，因為它幫讀者理解正文來源；model attribution 不該打斷 reading flow。
+- Reusable lesson：AI provenance 要透明，但透明不等於放到最搶眼的位置。讀者先讀文章，再看製作履歷；所有 model / harness / authorship inference 類資訊都應服從文章版面節奏，集中在文章尾段 metadata 區。

--- a/src/pages/en/posts/[...slug].astro
+++ b/src/pages/en/posts/[...slug].astro
@@ -127,15 +127,6 @@ const ticketLabel = ticketLabels[ticketPrefix] || '';
       )
     }
 
-    {
-      authorshipNote && (
-        <div class="authorship-note">
-          <strong>Authorship note:</strong>
-          <span>{authorshipNote}</span>
-        </div>
-      )
-    }
-
     <TableOfContents lang="en" headings={headings} maxDepth={isLevelUp ? 2 : 3} />
 
     <div class="post-content">
@@ -158,29 +149,37 @@ const ticketLabel = ticketLabels[ticketPrefix] || '';
     }
 
     {
-      post.data.translatedDate && post.data.translatedBy && (
+      ((post.data.translatedDate && post.data.translatedBy) || authorshipNote) && (
         <div class="translation-info">
-          {post.data.translatedBy.pipeline ? (
-            <>
-              <div>Translated on {post.data.translatedDate}</div>
-              {post.data.translatedBy.pipeline.map((step) => (
-                <div>
-                  {step.role} by {step.model} ({step.harness})
-                </div>
-              ))}
-              {post.data.translatedBy.pipelineUrl && (
-                <div>
-                  <a href={post.data.translatedBy.pipelineUrl} target="_blank" rel="noopener">
-                    View pipeline script →
-                  </a>
-                </div>
-              )}
-            </>
-          ) : (
-            <>
-              Translated on {post.data.translatedDate} by {post.data.translatedBy.model} (
-              {post.data.translatedBy.harness})
-            </>
+          {post.data.translatedDate &&
+            post.data.translatedBy &&
+            (post.data.translatedBy.pipeline ? (
+              <>
+                <div>Translated on {post.data.translatedDate}</div>
+                {post.data.translatedBy.pipeline.map((step) => (
+                  <div>
+                    {step.role} by {step.model} ({step.harness})
+                  </div>
+                ))}
+                {post.data.translatedBy.pipelineUrl && (
+                  <div>
+                    <a href={post.data.translatedBy.pipelineUrl} target="_blank" rel="noopener">
+                      View pipeline script →
+                    </a>
+                  </div>
+                )}
+              </>
+            ) : (
+              <div>
+                Translated on {post.data.translatedDate} by {post.data.translatedBy.model} (
+                {post.data.translatedBy.harness})
+              </div>
+            ))}
+          {authorshipNote && (
+            <div class="authorship-note">
+              <strong>Authorship note:</strong>
+              <span>{authorshipNote}</span>
+            </div>
           )}
         </div>
       )
@@ -361,15 +360,8 @@ const ticketLabel = ticketLabels[ticketPrefix] || '';
     color: var(--color-text-muted);
   }
 
-  .authorship-note {
-    margin: 1rem 0 1.25rem;
-    padding: 0.75rem 1rem;
-    background-color: var(--color-bg-secondary, rgba(0, 0, 0, 0.03));
-    border-left: 3px solid var(--color-accent);
-    border-radius: 6px;
-    font-size: 0.9rem;
-    color: var(--color-text-muted);
-    line-height: 1.6;
+  .translation-info .authorship-note {
+    margin-top: 0.5rem;
   }
 
   .authorship-note strong {

--- a/src/pages/posts/[...slug].astro
+++ b/src/pages/posts/[...slug].astro
@@ -123,15 +123,6 @@ const ticketLabel = ticketLabels[ticketPrefix] || '';
       )
     }
 
-    {
-      authorshipNote && (
-        <div class="authorship-note">
-          <strong>作者推定：</strong>
-          <span>{authorshipNote}</span>
-        </div>
-      )
-    }
-
     <TableOfContents lang="zh-tw" headings={headings} maxDepth={isLevelUp ? 2 : 3} />
 
     <div class="post-content">
@@ -154,29 +145,37 @@ const ticketLabel = ticketLabels[ticketPrefix] || '';
     }
 
     {
-      post.data.translatedDate && post.data.translatedBy && (
+      ((post.data.translatedDate && post.data.translatedBy) || authorshipNote) && (
         <div class="translation-info">
-          {post.data.translatedBy.pipeline ? (
-            <>
-              <div>翻譯於 {post.data.translatedDate}</div>
-              {post.data.translatedBy.pipeline.map((step) => (
-                <div>
-                  {step.role} by {step.model} ({step.harness})
-                </div>
-              ))}
-              {post.data.translatedBy.pipelineUrl && (
-                <div>
-                  <a href={post.data.translatedBy.pipelineUrl} target="_blank" rel="noopener">
-                    View pipeline script →
-                  </a>
-                </div>
-              )}
-            </>
-          ) : (
-            <>
-              翻譯於 {post.data.translatedDate} by {post.data.translatedBy.model} (
-              {post.data.translatedBy.harness})
-            </>
+          {post.data.translatedDate &&
+            post.data.translatedBy &&
+            (post.data.translatedBy.pipeline ? (
+              <>
+                <div>翻譯於 {post.data.translatedDate}</div>
+                {post.data.translatedBy.pipeline.map((step) => (
+                  <div>
+                    {step.role} by {step.model} ({step.harness})
+                  </div>
+                ))}
+                {post.data.translatedBy.pipelineUrl && (
+                  <div>
+                    <a href={post.data.translatedBy.pipelineUrl} target="_blank" rel="noopener">
+                      View pipeline script →
+                    </a>
+                  </div>
+                )}
+              </>
+            ) : (
+              <div>
+                翻譯於 {post.data.translatedDate} by {post.data.translatedBy.model} (
+                {post.data.translatedBy.harness})
+              </div>
+            ))}
+          {authorshipNote && (
+            <div class="authorship-note">
+              <strong>作者推定：</strong>
+              <span>{authorshipNote}</span>
+            </div>
           )}
         </div>
       )
@@ -359,15 +358,8 @@ const ticketLabel = ticketLabels[ticketPrefix] || '';
     color: var(--color-text-muted);
   }
 
-  .authorship-note {
-    margin: 1rem 0 1.25rem;
-    padding: 0.75rem 1rem;
-    background-color: var(--color-bg-secondary, rgba(0, 0, 0, 0.03));
-    border-left: 3px solid var(--color-accent);
-    border-radius: 6px;
-    font-size: 0.9rem;
-    color: var(--color-text-muted);
-    line-height: 1.6;
+  .translation-info .authorship-note {
+    margin-top: 0.5rem;
   }
 
   .authorship-note strong {


### PR DESCRIPTION
## What changed\n\n- Moved inferred authorship notes out of the top-of-post intro area.\n- Rendered authorship notes inside the existing bottom metadata/provenance box, next to translatedBy pipeline attribution.\n- Recorded ShroomDog's UI placement feedback in the editorial feedback corpus.\n\n## Why\n\nThe authorship note is production provenance, not reader-facing setup. Putting it under the title made it compete with the article lead and TOC on mobile. It belongs with model/pipeline attribution near the end of the article.\n\n## Verification\n\n- pnpm run build\n- Static HTML order check for Lv-06 and SP-194\n- Playwright mobile viewport check at 590px width against local Astro preview