### PR TITLE
feat(ccc): SessionStart 自動補環境 hook + merge 後自刪 branch guideline

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# .claude/hooks/session-start.sh — auto-provision CCC sandbox at session start
+#
+# 為什麼存在：CCC 每次都是全新 sandbox（fresh clone，node_modules 沒裝、git
+# hooks 沒掛、sp-pipeline 還沒 compile）。以前每個 CCC 開場都要記得手動補，
+# 忘了就踩「hook 沒跑就 commit」這類本該擋掉的問題。這支 hook 在 session 一
+# 開始就把環境補好，未來 CCC 一醒來就能直接開工。
+#
+# 只在 Claude Code on the web（CCC）跑——mac-CC 自己管 local env，不要插手。
+set -uo pipefail
+
+# 非 remote（= mac-CC / local）直接跳過，零干擾。
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+cd "${CLAUDE_PROJECT_DIR:-.}" || exit 0
+
+# --fix 會補 deps（node_modules 缺才裝）+ 掛 git hooks，全程 idempotent。
+# smoke test 任何 check 沒過會 exit 1，但 SessionStart 不該因此卡住 session，
+# 所以吞掉非零 exit——report 已經印出來，agent 開場自己會看到要修什麼。
+bash scripts/ccc-smoke-test.sh --fix || true

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/playbooks/CCC-playbook.md
+++ b/playbooks/CCC-playbook.md
@@ -36,9 +36,10 @@
 2. 用 GitHub MCP (`mcp__github__create_pull_request`) 開 PR 到 main
 3. **PR 開完立刻 `mcp__github__subscribe_pr_activity` 訂閱自己這條 PR**——不要問 user「要不要幫你盯」。CCC 開 PR 預設就要盯 CI + review comment，這是工作的一部分，不是 opt-in 服務。問就是 dumb question。
 4. **等 CI 全綠**後自己 `mcp__github__merge_pull_request`
-5. 合完跟 user 回報 PR URL + 簡短 summary
+5. **Merge 完立刻刪掉 merged branch**——不要留給 user 手動清。Default = `git push origin --delete claude/xxx`（CCC 對 `claude/*` branch 有 push 權，刪得掉）。Local branch 是拋棄式 sandbox 的一部分，不用特別 `git branch -d`，但 remote 一定要刪——否則 user 得自己去 GitHub 點刪除，這是本來 CCC 該收的尾。
+6. 合完 + branch 清乾淨後，跟 user 回報 PR URL + 簡短 summary
 
-**禁問句**：「要不要 subscribe PR activity？」「要不要盯 CI？」「要不要幫你看 review comment？」——通通是 dumb question，預設答案永遠是 yes，user 不該被叫去確認 default behavior。
+**禁問句**：「要不要 subscribe PR activity？」「要不要盯 CI？」「要不要幫你看 review comment？」「要不要幫你刪 merged branch？」——通通是 dumb question，預設答案永遠是 yes，user 不該被叫去確認 default behavior。CCC 的工作是「開 PR → 盯 CI → merge → 刪 branch → 回報」整條收乾淨，不是把尾巴留給 user。
 
 ### Merge method 選擇
 


### PR DESCRIPTION
## 任務

讓未來 CCC 開場 + 收尾更順，少踩 wrinkle。承接 #385（CCC smoke test）。

## 1. self-merge policy 加入「merge 完自己刪 branch」

CCC self-merge 後一直把刪 merged branch 的尾巴留給 user 手動點 GitHub。把 `git push origin --delete claude/xxx` 寫進 `CCC-playbook.md` self-merge policy 第 5 步，並把「要不要幫你刪 branch」列入禁問句。CCC 的工作是「開 PR → 盯 CI → merge → **刪 branch** → 回報」整條收乾淨。

## 2. SessionStart hook 自動補環境

CCC 每次都是全新 sandbox（node_modules 沒裝、git hooks 沒掛）。新增 `.claude/hooks/session-start.sh`，session 一開始跑 `ccc-smoke-test.sh --fix`（裝 deps + 掛 hooks），未來 CCC 一醒來環境就已就緒，不再踩「忘了 setup」。

- 只在 web（`CLAUDE_CODE_REMOTE=true`）跑——**mac-CC 瞬間 no-op、零輸出零干擾**（已驗證）
- 同步模式：保證 deps 在 agent 開工前裝好，不 race
- 吞掉非零 exit：SessionStart 不因 smoke test 沒過卡住 session

## 驗證

- ✅ Hook 在 CCC（`CLAUDE_CODE_REMOTE=true`）跑出 18 passed / 0 failed，環境就緒
- ✅ Hook 在 mac-CC（unset）瞬間 no-op，無任何輸出
- ✅ `--fix` idempotent：node_modules 已存在則跳過 install

## Commits（atomic）

1. `docs(ccc): self-merge policy 加入「merge 完自己刪 branch」`
2. `feat(ccc): SessionStart hook 自動補環境`

## Tribunal

不適用——純 infra / tooling，沒動 `src/content/posts/*.mdx`。

> ⚠️ merge 後 user 之前的偏好：希望 settings.json SessionStart hook 在 merge 進 main 後對未來所有 session 生效（user 已明確同意安裝）。

https://claude.ai/code/session_013oDKQ6yP2EXdHZZxhMXw9A

---
_Generated by [Claude Code](https://claude.ai/code/session_013oDKQ6yP2EXdHZZxhMXw9A)_