### PR TITLE
fix(ccc): 修正 branch cleanup guideline——CCC 無法在 sandbox 內刪 branch（403）

### DIFF
--- a/playbooks/CCC-playbook.md
+++ b/playbooks/CCC-playbook.md
@@ -36,10 +36,10 @@
 2. 用 GitHub MCP (`mcp__github__create_pull_request`) 開 PR 到 main
 3. **PR 開完立刻 `mcp__github__subscribe_pr_activity` 訂閱自己這條 PR**——不要問 user「要不要幫你盯」。CCC 開 PR 預設就要盯 CI + review comment，這是工作的一部分，不是 opt-in 服務。問就是 dumb question。
 4. **等 CI 全綠**後自己 `mcp__github__merge_pull_request`
-5. **Merge 完立刻刪掉 merged branch**——不要留給 user 手動清。Default = `git push origin --delete claude/xxx`（CCC 對 `claude/*` branch 有 push 權，刪得掉）。Local branch 是拋棄式 sandbox 的一部分，不用特別 `git branch -d`，但 remote 一定要刪——否則 user 得自己去 GitHub 點刪除，這是本來 CCC 該收的尾。
-6. 合完 + branch 清乾淨後，跟 user 回報 PR URL + 簡短 summary
+5. **Merge 完不用、也無法自己刪 remote branch**——repo 已開啟「Automatically delete head branches」，GitHub 在 merge 後自動刪掉 head branch，CCC 什麼都不用做。**⚠️ CCC 千萬不要嘗試 `git push origin --delete claude/xxx`**：sandbox 的 git proxy 會回 **HTTP 403**（只放行 push commit、不放行刪 ref），重試也是 403、純粹浪費 round。GitHub MCP 也沒有 delete-branch 工具。Local branch 是拋棄式 sandbox 的一部分，不用管。萬一哪天 auto-delete 被關掉導致 branch 沒被清，那是 user 去 GitHub 設定重開／手動刪的事，不是 CCC 能在 sandbox 內解決的。
+6. Merge 完跟 user 回報 PR URL + 簡短 summary（branch 由 GitHub auto-delete 收尾）
 
-**禁問句**：「要不要 subscribe PR activity？」「要不要盯 CI？」「要不要幫你看 review comment？」「要不要幫你刪 merged branch？」——通通是 dumb question，預設答案永遠是 yes，user 不該被叫去確認 default behavior。CCC 的工作是「開 PR → 盯 CI → merge → 刪 branch → 回報」整條收乾淨，不是把尾巴留給 user。
+**禁問句**：「要不要 subscribe PR activity？」「要不要盯 CI？」「要不要幫你看 review comment？」——通通是 dumb question，預設答案永遠是 yes，user 不該被叫去確認 default behavior。CCC 的工作是「開 PR → 盯 CI → merge → 回報」整條收乾淨；branch cleanup 交給 repo 的 auto-delete 設定，CCC 不去 `git push --delete`（那會 403）。
 
 ### Merge method 選擇
 


### PR DESCRIPTION
## 為什麼

#386 把 self-merge policy 寫成「CCC merge 完自己 `git push origin --delete claude/xxx`」。**實測在 CCC sandbox 行不通**：

- `git push origin --delete` → git proxy 一律回 **HTTP 403**（只放行 push commit、不放行刪 ref），重試 5 次全 403
- GitHub MCP 也**沒有 delete-branch 工具**（只有 create_branch / list_branches）

所以 CCC 在 sandbox 內**無法**自己刪 remote branch。#386 那段 guideline 會誤導未來 CCC 去撞 403、浪費 round。

## 改什麼

`CCC-playbook.md` self-merge policy step 5/6 + 禁問句改寫成現實版本：

- 真正的解法是 repo 開啟 **Automatically delete head branches**（user 已去開），GitHub 在 merge 後自動清 head branch，CCC 什麼都不用做
- 明確警告 CCC **不要**嘗試 `git push origin --delete`（會 403）
- branch cleanup 的 ownership 從「CCC 在 sandbox 刪」改成「repo auto-delete 設定收尾」

## 注意

- 本 PR 的 head branch 在 auto-delete 開啟後 merge 會自動清
- #386 自己的 branch 是在 auto-delete 開啟前 merge 的，不會被回溯刪除，需 user 手動清一次（或留著）

https://claude.ai/code/session_013oDKQ6yP2EXdHZZxhMXw9A

---
_Generated by [Claude Code](https://claude.ai/code/session_013oDKQ6yP2EXdHZZxhMXw9A)_