### PR TITLE
feat: 兩層品質門檻 — 自動 gate floor≥3 + sub-8 首頁隔離/badge

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -70,20 +70,25 @@ fi
 echo "✓ No duplicate ticketIds"
 echo ""
 
-# ─── Step 0.1: Score gate — staged posts must have vibe scores ────
+# ─── Step 0.1: Score gate — staged posts must clear the score FLOOR ────
 # Only checks zh-tw primary posts (not en- translations).
 # Minimum: scores.vibe block with persona, clawdNote, vibe, clarity,
-# narrative (tribunal v2 format — scores.ralph was the v1 shape and
-# has been superseded; src/content/config.ts schema only declares
-# scores.vibe / librarian / factCheck / freshEyes).
+# narrative AND composite >= 3 (the FLOOR, not the editorial PASS bar).
 #
-# Scope: only enforced on newly ADDED posts (git diff-filter=A). Edits to
-# existing posts are trusted — typo fixes from humans, small rewordings,
-# and Edit with AI flows (`ai: edit <file>` commits produced by the
-# /ai/edit/confirm endpoint on gu-log-api) must not be blocked just
-# because some older post was committed without a score. Full rewrites
-# still get rescored because the tribunal v2 writer agent lands a fresh
-# scores.vibe block before it commits.
+# Philosophy (2026-06-10): the automated gate is a floor, not the ≥8 PASS
+# bar. A post may ship with a sub-8 score — it gets a visible "refining"
+# badge and is held out of the homepage until a background tribunal lifts
+# it to ≥8 (see CLAUDE.md §自動 gate 是 floor). But nothing garbage
+# (composite < 3) or score-less reaches main. The floor check is
+# scripts/score-floor-check.mjs.
+#
+# Scope: enforced on (a) newly ADDED zh-tw posts, and (b) MODIFIED zh-tw
+# posts whose READER-VISIBLE content changed (full rewrites). A rewrite is
+# a "modification" in git's eyes, so the old added-only gate let rewrites
+# slip through unscored (this is how #388 shipped with only 1 of 4 judges).
+# reader_visible_changed() compares the staged vs HEAD reader revision so a
+# backend-only edit (adding a scores block, fixing source/translatedBy)
+# does NOT trigger a rescore — only changes a reader would actually see.
 #
 # Exemption: posts whose ONLY diff vs HEAD is dedup/series housekeeping
 # (status: deprecated, deprecatedReason, deprecatedBy, series.*) skip the
@@ -106,13 +111,34 @@ fi
 if [ "$IS_MERGE_COMMIT" = "1" ]; then
     echo "📊 Score gate: merge commit detected — skipping (content was gated on source branches)"
 else
-    echo "📊 Score gate: checking staged posts for scores.vibe..."
+    echo "📊 Score gate: checking staged posts against score floor (composite >= 3)..."
 fi
 SCORE_MISSING=""
-# Only newly added zh-tw posts are subject to the score gate. Modifications
-# (Edit with AI, typo fixes, housekeeping) flow through is_metadata_only_diff
-# and the rewriter agent's own scoring, so we don't re-gate them here.
+# Newly ADDED zh-tw posts always go through the gate.
 STAGED_ZH_POSTS=$(git diff --cached -M --name-only --diff-filter=A -- "$POSTS_DIR"/*.mdx 2>/dev/null | grep -v '/en-' | sed '/^$/d' || true)
+# MODIFIED zh-tw posts go through the gate too, but only when their
+# reader-visible content changed (full rewrites) — see reader_visible_changed.
+STAGED_ZH_MODIFIED=$(git diff --cached -M --name-only --diff-filter=M -- "$POSTS_DIR"/*.mdx 2>/dev/null | grep -v '/en-' | sed '/^$/d' || true)
+
+# reader_visible_changed FILE → 0 (true) when the staged version's reader-facing
+# content (reader-visible frontmatter + body) differs from HEAD's. Backend-only
+# frontmatter (scores, translatedBy, pipeline, …) is excluded by the shared
+# hash, so adding a scores block alone is NOT a reader-visible change.
+reader_visible_changed() {
+    local file="$1"
+    # No HEAD version → brand-new content → treat as changed.
+    if ! git cat-file -e "HEAD:$file" 2>/dev/null; then
+        return 0
+    fi
+    local head_rev staged_rev
+    head_rev=$(git show "HEAD:$file" 2>/dev/null | node "$REPO_ROOT/scripts/reader-revision-of-stdin.mjs" 2>/dev/null || echo "ERR")
+    staged_rev=$(git show ":$file" 2>/dev/null | node "$REPO_ROOT/scripts/reader-revision-of-stdin.mjs" 2>/dev/null || echo "ERR")
+    # On any compute error, fail safe → gate it.
+    if [ "$head_rev" = "ERR" ] || [ "$staged_rev" = "ERR" ]; then
+        return 0
+    fi
+    [ "$head_rev" != "$staged_rev" ]
+}
 
 is_metadata_only_diff() {
     local file="$1"
@@ -201,17 +227,34 @@ is_existing_ticket_post_addition() {
     printf '%s\n' "$existing_paths" | grep -vx "$file" >/dev/null 2>&1
 }
 
-if [ -z "$STAGED_ZH_POSTS" ]; then
+GATE_CANDIDATES=$(printf '%s\n%s\n' "$STAGED_ZH_POSTS" "$STAGED_ZH_MODIFIED" | sed '/^$/d' | sort -u)
+
+if [ -z "$GATE_CANDIDATES" ]; then
     echo "✓ No zh-tw posts staged"
 elif [ "$IS_MERGE_COMMIT" = "1" ]; then
     : # already printed the skip message above
 else
-    for file in $STAGED_ZH_POSTS; do
+    for file in $GATE_CANDIDATES; do
         FULL_PATH="$REPO_ROOT/$file"
         if [ ! -f "$FULL_PATH" ]; then continue; fi
 
+        # Modifications: only gate when reader-visible content changed (full
+        # rewrites). Added files have no HEAD version and always gate.
+        if git cat-file -e "HEAD:$file" 2>/dev/null; then
+            if ! reader_visible_changed "$file"; then
+                continue
+            fi
+        fi
+
         # Skip the gate if this is a metadata-only housekeeping edit.
         if is_metadata_only_diff "$file"; then
+            continue
+        fi
+
+        # Skip internal-link maintenance (glossary / cross-ref links) — same
+        # exemption the pronoun check uses, so adding /glossary# links to a
+        # grandfathered post doesn't force a rescore.
+        if is_internal_post_link_only_diff "$file"; then
             continue
         fi
 
@@ -226,44 +269,31 @@ else
             continue
         fi
 
-        # Check scores.vibe block with the 5 tribunal v2 dimensions.
-        # Matches both "^  vibe:" (nested under scores) and inline value
-        # styles; requires persona/clawdNote/vibe/clarity/narrative to
-        # appear within the block's first ~8 lines.
-        if ! grep -q "^  vibe:" "$FULL_PATH" 2>/dev/null; then
+        # Floor gate: scores.vibe present + complete (5 dims) + composite >= 3.
+        # Sub-8 is allowed (badged + held off the homepage); garbage (<3) and
+        # score-less posts are blocked. See scripts/score-floor-check.mjs.
+        if ! FLOOR_MSG=$(node "$REPO_ROOT/scripts/score-floor-check.mjs" "$FULL_PATH" 3 2>&1); then
             BASENAME=$(basename "$file")
-            SCORE_MISSING="$SCORE_MISSING  ⚠️  $BASENAME — missing scores.vibe\n"
-        else
-            # The "vibe:" key appears twice in a complete block (once as
-            # the block header, once as the internal "vibe" dimension),
-            # so HAS_VIBE must be ≥ 2.
-            BLOCK=$(grep -A8 "^  vibe:" "$FULL_PATH")
-            HAS_PERSONA=$(printf '%s\n' "$BLOCK" | grep -c "persona:" 2>/dev/null || echo 0)
-            HAS_CLAWD=$(printf '%s\n' "$BLOCK" | grep -c "clawdNote:" 2>/dev/null || echo 0)
-            HAS_VIBE=$(printf '%s\n' "$BLOCK" | grep -c "vibe:" 2>/dev/null || echo 0)
-            HAS_CLARITY=$(printf '%s\n' "$BLOCK" | grep -c "clarity:" 2>/dev/null || echo 0)
-            HAS_NARRATIVE=$(printf '%s\n' "$BLOCK" | grep -c "narrative:" 2>/dev/null || echo 0)
-            if [ "$HAS_PERSONA" -eq 0 ] || [ "$HAS_CLAWD" -eq 0 ] || [ "$HAS_VIBE" -lt 2 ] || [ "$HAS_CLARITY" -eq 0 ] || [ "$HAS_NARRATIVE" -eq 0 ]; then
-                BASENAME=$(basename "$file")
-                SCORE_MISSING="$SCORE_MISSING  ⚠️  $BASENAME — scores.vibe incomplete (need persona, clawdNote, vibe, clarity, narrative)\n"
-            fi
+            SCORE_MISSING="$SCORE_MISSING  ⚠️  $BASENAME — ${FLOOR_MSG}\n"
         fi
     done
 fi
 
 if [ -n "$SCORE_MISSING" ]; then
     echo ""
-    echo "❌ SCORE GATE FAILED — posts missing tribunal v2 scores.vibe:"
+    echo "❌ SCORE GATE FAILED — staged zh-tw posts below the score floor:"
     printf "$SCORE_MISSING"
     echo ""
-    echo "Every new zh-tw post must have a scores.vibe block before committing."
-    echo "Run tribunal v2, or manually score with:"
+    echo "Every new or rewritten zh-tw post needs a scores.vibe block with"
+    echo "composite >= 3 (the floor — NOT the ≥8 PASS bar; sub-8 may ship but"
+    echo "gets a 'refining' badge and is held off the homepage). Run the"
+    echo "tribunal, or score manually with:"
     echo "  node scripts/frontmatter-scores.mjs write <file> vibe '<json>'"
     echo ""
     echo "To bypass in emergency: git commit --no-verify"
     exit 1
 fi
-echo "✓ All staged posts have scores.vibe"
+echo "✓ All staged zh-tw posts clear the score floor (composite >= 3)"
 echo ""
 
 # ─── Step 0.15: Pronoun clarity check (你/我 ban in zh-tw body) ───

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,43 +9,37 @@
 
 **任何 Claude Code instance 進到這個 repo，第一件事必須跑 `./scripts/detect-env.sh` 確認自己的身份**，再讀對應的 playbook（`playbooks/mac-CC-playbook.md` 或 `playbooks/CCC-playbook.md`）。沒搞清楚身份就動手 = 用錯 SOP（mac-CC 跟 CCC 的 scope ceiling、merge policy、失敗處理都不一樣）。沒有例外，不能跳。
 
-### 🎯 Vibe FAIL ≠ 可以 ship（必須 iterate 到過分數才能 merge）
+### 🎯 兩層品質門檻：floor ≥3 才能 ship，PASS ≥8 才上首頁（2026-06-10 起）
 
-把 vibe FAIL 的 score 寫進 frontmatter **不等於完成任務**。Score gate 的 schema 容忍 FAIL（只檢查 block 存在），但 gu-log 的內容標準不容忍——FAIL 的東西就是品質沒到，ship 出去 = 拉低整個站的水準。
+gu-log 的品質把關**分兩層**，不要再把它當成「沒過 8 就不准 commit」的單一硬門檻：
 
-**硬規則**：
+| 層 | 門檻 | 誰擋 | 沒過會怎樣 |
+|---|---|---|---|
+| **Floor（自動 gate）** | scores.vibe 在 + 5 維齊 + **composite ≥ 3** | pre-commit hook（`scripts/score-floor-check.mjs`） | **擋 commit**。garbage(<3) 跟無分數一律進不了 main |
+| **PASS（編輯標準）** | composite ≥ 8 AND 一維 ≥ 9 AND 沒有維 < 8 | UI / 首頁過濾，不是 commit blocker | sub-8 **照樣 ship**，但加「精修中」badge + **不上首頁/featured**，等背景 tribunal 拉到 ≥8 才上 |
 
-- 任何新增的 SP / CP / SD / Lv 文章，vibe scorer 給 FAIL 一律**不准 commit + 不准 push**，必須 iterate 到 **composite ≥ 8 AND 至少一維 ≥ 9 AND 沒有任何維 < 8**（Pass bar 同 `scripts/vibe-scoring-standard.md`）
-- 實作上，呼叫 `tribunal-writer` subagent 重寫文章 → 重跑 `vibe-scorer.sh` → 沒過再來一輪。**最多 3 輪**，3 輪沒過就停下來向 user 報告（可能是 prompt 結構問題，writer agent 修不動，需要人工或重設角度）
-- 已存在於 main 的歷史文章不溯及既往（grandfathered），但**新文章一律以 PASS 為門檻**
+**白話**：
 
-**為什麼這條這麼硬**：
+- **≥3 就能 commit、能 ship**。一篇 5/10 的文章不會被 hook 擋——它會帶著 tribunal 分數公開顯示（讀者看得到 good/bad 長怎樣，這是 gu-log 的透明度賣點），但**不會出現在首頁**，會被 `getIndexPosts()` 過濾掉，並掛上「精修中」badge。
+- **首頁/featured 只放 ≥8 的**。背景 tribunal（有 quota 時跑）把 sub-8 重寫拉到 ≥8，分數一過門檻就自動上首頁。
+- **<3 或沒分數一律擋**。那是 garbage（SP-110 那種無聊到 cringe），連當反面教材都不值得公開。
+- **歷史文章 grandfathered**：沒有 scores block 的舊文不受影響（照常顯示在首頁），但**一旦 reader-visible 內容被改寫（不是純連結維護），就會觸發 floor gate**，要補一個 ≥3 的 scores.vibe 才能 commit。
 
-- 多放一篇 FAIL 文章，整站平均品質就下來。讀者不分新舊，看到一篇水的就降低對 gu-log 的信任
-- "velocity > stability" 是針對**基礎建設**（pipeline、hook、infra），不是針對**內容品質**。內容品質沒到就是沒到，沒有 velocity 跟 stability 的 trade-off
-- Tribunal 裝置存在的目的就是擋這件事——把 score 寫進 frontmatter 後因為「gate 過了」就 commit，等於把 tribunal 變成了 rubber stamp。Tribunal 是 reviewer 不是 logger
-- Decorative persona trap、ClawdNote opinion deficit、linear documentation walkthrough 這些 vibe scorer 抓的問題，rewriter 改 1-2 輪通常就能把 score 從 6 拉到 8+。3 輪都沒過再說
+**所以「把 FAIL score 寫進 frontmatter」現在是 OK 的**——只要 ≥3。它不再等於「假裝完成」，因為 badge + 首頁隔離會誠實地把它標成「還沒到 featured 水準」。Tribunal 仍然是 reviewer 不是 logger：**有 quota 就該把 sub-8 往 ≥8 推**，但這是背景精修的工作，不是 ship 的硬前提。
 
-**反例 vs 正例**：
+**還是要做的事（只是不再 block ship）**：
 
-```
-❌ 反例（這個 PR 自己踩過的）：
-   1. 跑 vibe-scorer 拿到 6/10 FAIL
-   2. 把 score JSON 塞進 frontmatter
-   3. commit + push，理由「velocity > stability、gate 過了」
-   4. 一篇 FAIL 文章 ship 到 main
+- 寫新文章時，仍然先跑 tribunal / `vibe-score` skill 拿到真分數塞進 frontmatter（≥3 才能 commit）。
+- 分數 6-7 又剛好有 quota → 呼叫 `tribunal-writer` subagent 重寫修 reasons 點出的維度 → 重跑 → 最多 3 輪，能拉到 ≥8 就上首頁。拉不動就先帶 sub-8 badge ship，排進背景 tribunal 佇列。
+- **不要為了過 floor 把分數灌水**。score-floor-check 只看 composite ≥3，但灌一個假的 8 進去比誠實標 5 更糟——badge 機制的前提是分數誠實。
 
-✅ 正例：
-   1. 跑 vibe-scorer 拿到 6/10 FAIL
-   2. 看 reasons：「decorative persona trap、5/6 ClawdNote 沒 stance」
-   3. 呼叫 tribunal-writer subagent，把 reasons + scoring standard 餵給它，
-      要求它重寫文章修這幾個維度
-   4. 重跑 vibe-scorer
-   5. 過 → 把 PASS score 塞進 frontmatter、commit、push
-   6. 沒過 → 再來一輪，最多 3 輪。3 輪後仍 FAIL → 停下來向 user 報告
-```
+**為什麼改成這樣**：
 
-實作介面：mac-CC 有 `bash scripts/tribunal-batch-runner.sh`、CCC 可以呼叫 `tribunal-writer` agent（`.claude/agents/tribunal-writer.md`）+ `vibe-scorer.sh` loop。
+- 單一硬門檻（沒過 8 不准 ship）會讓 velocity 卡死在「每篇都要 iterate 到 8」。改成 floor + 透明 badge 後，velocity 回來了，品質靠「公開分數 + 首頁只放 ≥8 + 背景精修」維持，而不是靠 block。
+- gu-log 寫的就是 AI 品質，**把 AI 自評分數攤在陽光下、連 sub-8 的也誠實標記**，本身就是這個 blog 的調性。
+- 背景 tribunal 可以排程慢慢把存量往上拉，不用塞在 ship 的關鍵路徑上。
+
+實作介面：自動 gate = `scripts/score-floor-check.mjs`（pre-commit 呼叫）；首頁過濾 = `getIndexPosts()`（`src/utils/post-status.ts`）；badge = `Sub8RefiningBanner.astro`；composite 計算 = `src/utils/tribunal-scores.ts`。重寫 loop：mac-CC 有 `bash scripts/tribunal-batch-runner.sh`、CCC 可以呼叫 `tribunal-writer` agent + `vibe-scorer.sh`。
 
 ### 🚫 絕對不准 `--no-verify`（hook 失敗 = 修 hook 或修 code，不准跳）
 

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -70,20 +70,25 @@ fi
 echo "✓ No duplicate ticketIds"
 echo ""
 
-# ─── Step 0.1: Score gate — staged posts must have vibe scores ────
+# ─── Step 0.1: Score gate — staged posts must clear the score FLOOR ────
 # Only checks zh-tw primary posts (not en- translations).
 # Minimum: scores.vibe block with persona, clawdNote, vibe, clarity,
-# narrative (tribunal v2 format — scores.ralph was the v1 shape and
-# has been superseded; src/content/config.ts schema only declares
-# scores.vibe / librarian / factCheck / freshEyes).
+# narrative AND composite >= 3 (the FLOOR, not the editorial PASS bar).
 #
-# Scope: only enforced on newly ADDED posts (git diff-filter=A). Edits to
-# existing posts are trusted — typo fixes from humans, small rewordings,
-# and Edit with AI flows (`ai: edit <file>` commits produced by the
-# /ai/edit/confirm endpoint on gu-log-api) must not be blocked just
-# because some older post was committed without a score. Full rewrites
-# still get rescored because the tribunal v2 writer agent lands a fresh
-# scores.vibe block before it commits.
+# Philosophy (2026-06-10): the automated gate is a floor, not the ≥8 PASS
+# bar. A post may ship with a sub-8 score — it gets a visible "refining"
+# badge and is held out of the homepage until a background tribunal lifts
+# it to ≥8 (see CLAUDE.md §自動 gate 是 floor). But nothing garbage
+# (composite < 3) or score-less reaches main. The floor check is
+# scripts/score-floor-check.mjs.
+#
+# Scope: enforced on (a) newly ADDED zh-tw posts, and (b) MODIFIED zh-tw
+# posts whose READER-VISIBLE content changed (full rewrites). A rewrite is
+# a "modification" in git's eyes, so the old added-only gate let rewrites
+# slip through unscored (this is how #388 shipped with only 1 of 4 judges).
+# reader_visible_changed() compares the staged vs HEAD reader revision so a
+# backend-only edit (adding a scores block, fixing source/translatedBy)
+# does NOT trigger a rescore — only changes a reader would actually see.
 #
 # Exemption: posts whose ONLY diff vs HEAD is dedup/series housekeeping
 # (status: deprecated, deprecatedReason, deprecatedBy, series.*) skip the
@@ -106,13 +111,34 @@ fi
 if [ "$IS_MERGE_COMMIT" = "1" ]; then
     echo "📊 Score gate: merge commit detected — skipping (content was gated on source branches)"
 else
-    echo "📊 Score gate: checking staged posts for scores.vibe..."
+    echo "📊 Score gate: checking staged posts against score floor (composite >= 3)..."
 fi
 SCORE_MISSING=""
-# Only newly added zh-tw posts are subject to the score gate. Modifications
-# (Edit with AI, typo fixes, housekeeping) flow through is_metadata_only_diff
-# and the rewriter agent's own scoring, so we don't re-gate them here.
+# Newly ADDED zh-tw posts always go through the gate.
 STAGED_ZH_POSTS=$(git diff --cached -M --name-only --diff-filter=A -- "$POSTS_DIR"/*.mdx 2>/dev/null | grep -v '/en-' | sed '/^$/d' || true)
+# MODIFIED zh-tw posts go through the gate too, but only when their
+# reader-visible content changed (full rewrites) — see reader_visible_changed.
+STAGED_ZH_MODIFIED=$(git diff --cached -M --name-only --diff-filter=M -- "$POSTS_DIR"/*.mdx 2>/dev/null | grep -v '/en-' | sed '/^$/d' || true)
+
+# reader_visible_changed FILE → 0 (true) when the staged version's reader-facing
+# content (reader-visible frontmatter + body) differs from HEAD's. Backend-only
+# frontmatter (scores, translatedBy, pipeline, …) is excluded by the shared
+# hash, so adding a scores block alone is NOT a reader-visible change.
+reader_visible_changed() {
+    local file="$1"
+    # No HEAD version → brand-new content → treat as changed.
+    if ! git cat-file -e "HEAD:$file" 2>/dev/null; then
+        return 0
+    fi
+    local head_rev staged_rev
+    head_rev=$(git show "HEAD:$file" 2>/dev/null | node "$REPO_ROOT/scripts/reader-revision-of-stdin.mjs" 2>/dev/null || echo "ERR")
+    staged_rev=$(git show ":$file" 2>/dev/null | node "$REPO_ROOT/scripts/reader-revision-of-stdin.mjs" 2>/dev/null || echo "ERR")
+    # On any compute error, fail safe → gate it.
+    if [ "$head_rev" = "ERR" ] || [ "$staged_rev" = "ERR" ]; then
+        return 0
+    fi
+    [ "$head_rev" != "$staged_rev" ]
+}
 
 is_metadata_only_diff() {
     local file="$1"
@@ -201,17 +227,34 @@ is_existing_ticket_post_addition() {
     printf '%s\n' "$existing_paths" | grep -vx "$file" >/dev/null 2>&1
 }
 
-if [ -z "$STAGED_ZH_POSTS" ]; then
+GATE_CANDIDATES=$(printf '%s\n%s\n' "$STAGED_ZH_POSTS" "$STAGED_ZH_MODIFIED" | sed '/^$/d' | sort -u)
+
+if [ -z "$GATE_CANDIDATES" ]; then
     echo "✓ No zh-tw posts staged"
 elif [ "$IS_MERGE_COMMIT" = "1" ]; then
     : # already printed the skip message above
 else
-    for file in $STAGED_ZH_POSTS; do
+    for file in $GATE_CANDIDATES; do
         FULL_PATH="$REPO_ROOT/$file"
         if [ ! -f "$FULL_PATH" ]; then continue; fi
 
+        # Modifications: only gate when reader-visible content changed (full
+        # rewrites). Added files have no HEAD version and always gate.
+        if git cat-file -e "HEAD:$file" 2>/dev/null; then
+            if ! reader_visible_changed "$file"; then
+                continue
+            fi
+        fi
+
         # Skip the gate if this is a metadata-only housekeeping edit.
         if is_metadata_only_diff "$file"; then
+            continue
+        fi
+
+        # Skip internal-link maintenance (glossary / cross-ref links) — same
+        # exemption the pronoun check uses, so adding /glossary# links to a
+        # grandfathered post doesn't force a rescore.
+        if is_internal_post_link_only_diff "$file"; then
             continue
         fi
 
@@ -226,44 +269,31 @@ else
             continue
         fi
 
-        # Check scores.vibe block with the 5 tribunal v2 dimensions.
-        # Matches both "^  vibe:" (nested under scores) and inline value
-        # styles; requires persona/clawdNote/vibe/clarity/narrative to
-        # appear within the block's first ~8 lines.
-        if ! grep -q "^  vibe:" "$FULL_PATH" 2>/dev/null; then
+        # Floor gate: scores.vibe present + complete (5 dims) + composite >= 3.
+        # Sub-8 is allowed (badged + held off the homepage); garbage (<3) and
+        # score-less posts are blocked. See scripts/score-floor-check.mjs.
+        if ! FLOOR_MSG=$(node "$REPO_ROOT/scripts/score-floor-check.mjs" "$FULL_PATH" 3 2>&1); then
             BASENAME=$(basename "$file")
-            SCORE_MISSING="$SCORE_MISSING  ⚠️  $BASENAME — missing scores.vibe\n"
-        else
-            # The "vibe:" key appears twice in a complete block (once as
-            # the block header, once as the internal "vibe" dimension),
-            # so HAS_VIBE must be ≥ 2.
-            BLOCK=$(grep -A8 "^  vibe:" "$FULL_PATH")
-            HAS_PERSONA=$(printf '%s\n' "$BLOCK" | grep -c "persona:" 2>/dev/null || echo 0)
-            HAS_CLAWD=$(printf '%s\n' "$BLOCK" | grep -c "clawdNote:" 2>/dev/null || echo 0)
-            HAS_VIBE=$(printf '%s\n' "$BLOCK" | grep -c "vibe:" 2>/dev/null || echo 0)
-            HAS_CLARITY=$(printf '%s\n' "$BLOCK" | grep -c "clarity:" 2>/dev/null || echo 0)
-            HAS_NARRATIVE=$(printf '%s\n' "$BLOCK" | grep -c "narrative:" 2>/dev/null || echo 0)
-            if [ "$HAS_PERSONA" -eq 0 ] || [ "$HAS_CLAWD" -eq 0 ] || [ "$HAS_VIBE" -lt 2 ] || [ "$HAS_CLARITY" -eq 0 ] || [ "$HAS_NARRATIVE" -eq 0 ]; then
-                BASENAME=$(basename "$file")
-                SCORE_MISSING="$SCORE_MISSING  ⚠️  $BASENAME — scores.vibe incomplete (need persona, clawdNote, vibe, clarity, narrative)\n"
-            fi
+            SCORE_MISSING="$SCORE_MISSING  ⚠️  $BASENAME — ${FLOOR_MSG}\n"
         fi
     done
 fi
 
 if [ -n "$SCORE_MISSING" ]; then
     echo ""
-    echo "❌ SCORE GATE FAILED — posts missing tribunal v2 scores.vibe:"
+    echo "❌ SCORE GATE FAILED — staged zh-tw posts below the score floor:"
     printf "$SCORE_MISSING"
     echo ""
-    echo "Every new zh-tw post must have a scores.vibe block before committing."
-    echo "Run tribunal v2, or manually score with:"
+    echo "Every new or rewritten zh-tw post needs a scores.vibe block with"
+    echo "composite >= 3 (the floor — NOT the ≥8 PASS bar; sub-8 may ship but"
+    echo "gets a 'refining' badge and is held off the homepage). Run the"
+    echo "tribunal, or score manually with:"
     echo "  node scripts/frontmatter-scores.mjs write <file> vibe '<json>'"
     echo ""
     echo "To bypass in emergency: git commit --no-verify"
     exit 1
 fi
-echo "✓ All staged posts have scores.vibe"
+echo "✓ All staged zh-tw posts clear the score floor (composite >= 3)"
 echo ""
 
 # ─── Step 0.15: Pronoun clarity check (你/我 ban in zh-tw body) ───

--- a/scripts/reader-revision-of-stdin.mjs
+++ b/scripts/reader-revision-of-stdin.mjs
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+/**
+ * Read post content from stdin, print its reader-facing revision hash.
+ *
+ * Thin wrapper around computeReaderRevisionFromContent so the pre-commit
+ * score gate can compare the staged vs HEAD reader-visible content of a post
+ * without reimplementing the hashing. Backend-only frontmatter (scores,
+ * translatedBy, pipeline, …) is excluded by the shared helper, so adding a
+ * scores block does NOT count as a reader-visible change.
+ */
+import { computeReaderRevisionFromContent } from './build-reader-revision-manifest.mjs';
+
+let data = '';
+process.stdin.setEncoding('utf-8');
+process.stdin.on('data', (chunk) => {
+  data += chunk;
+});
+process.stdin.on('end', () => {
+  process.stdout.write(computeReaderRevisionFromContent(data));
+});

--- a/scripts/score-floor-check.mjs
+++ b/scripts/score-floor-check.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+/**
+ * Score floor gate for the pre-commit hook.
+ *
+ * gu-log's automated gate is a FLOOR, not the editorial bar. A post may ship
+ * with a sub-8 tribunal score (it gets a visible "refining" badge and is held
+ * out of the homepage until a background tribunal lifts it to >=8), but it must
+ * carry a real scores.vibe block whose composite clears the floor — nothing
+ * structurally broken or garbage (composite < FLOOR) reaches main.
+ *
+ * Usage: node scripts/score-floor-check.mjs <file> [floor=3]
+ *   exit 0 → has a complete scores.vibe block with composite >= floor
+ *   exit 1 → missing / incomplete / below floor (reason on stderr)
+ *   exit 2 → usage / read error
+ */
+import { readFileSync } from 'node:fs';
+import yaml from 'yaml';
+
+const [, , filePath, floorArg] = process.argv;
+const FLOOR = Number.isFinite(Number(floorArg)) ? Number(floorArg) : 3;
+
+if (!filePath) {
+  console.error('usage: score-floor-check.mjs <file> [floor]');
+  process.exit(2);
+}
+
+let content;
+try {
+  content = readFileSync(filePath, 'utf-8');
+} catch {
+  console.error(`cannot read ${filePath}`);
+  process.exit(2);
+}
+
+const match = content.match(/^---\n([\s\S]*?)\n---/);
+if (!match) {
+  console.error('no frontmatter');
+  process.exit(1);
+}
+
+let frontmatter;
+try {
+  frontmatter = yaml.parse(match[1]) ?? {};
+} catch {
+  console.error('frontmatter parse error');
+  process.exit(1);
+}
+
+const vibe = frontmatter?.scores?.vibe;
+if (!vibe) {
+  console.error('missing scores.vibe');
+  process.exit(1);
+}
+
+const dims = ['persona', 'clawdNote', 'vibe', 'clarity', 'narrative'];
+const missing = dims.filter((d) => typeof vibe[d] !== 'number');
+if (missing.length) {
+  console.error(`scores.vibe incomplete (missing: ${missing.join(', ')})`);
+  process.exit(1);
+}
+
+const composite =
+  typeof vibe.score === 'number'
+    ? vibe.score
+    : Math.floor(dims.reduce((sum, d) => sum + vibe[d], 0) / dims.length);
+
+if (composite < FLOOR) {
+  console.error(`scores.vibe composite ${composite} < floor ${FLOOR} — iterate before shipping`);
+  process.exit(1);
+}
+
+console.log(`scores.vibe composite ${composite} >= floor ${FLOOR}`);
+process.exit(0);

--- a/src/components/Sub8RefiningBanner.astro
+++ b/src/components/Sub8RefiningBanner.astro
@@ -1,0 +1,102 @@
+---
+/**
+ * Sub8RefiningBanner — shown on posts whose tribunal composite is below the
+ * featured bar (<8). It is NOT an error: the post ships at its own URL and
+ * shows its real AI-judge scores, but is held off the homepage until a
+ * background tribunal rewrites it up to >=8. See CLAUDE.md §兩層品質門檻.
+ */
+
+interface Props {
+  composite: number; // overall tribunal composite, 0-10
+  lang?: 'zh-tw' | 'en';
+}
+
+const { composite, lang = 'zh-tw' } = Astro.props;
+
+const labels = {
+  'zh-tw': {
+    title: '這篇還在精修中 ✍️',
+    body: `tribunal 給的分數還沒到 gu-log 的 featured 門檻（≥8），所以暫時不上首頁。背景 tribunal 之後會把它重寫拉高，分數過了就自動上架。`,
+    scoreLabel: '目前綜合分數',
+    cta: '下面是 AI judge 目前打的分數，覺得哪裡可以更好？留言告訴我們 (>w<)',
+  },
+  en: {
+    title: 'This one is still being refined ✍️',
+    body: `Its tribunal score has not yet reached gu-log's featured bar (>=8), so it is kept off the homepage for now. A background tribunal will rewrite it upward, and it goes live once it clears the bar.`,
+    scoreLabel: 'Current composite',
+    cta: 'The AI-judge scores below are where it stands now. See a way to make it better? Drop a comment (>w<)',
+  },
+} as const;
+
+const t = labels[lang];
+---
+
+<div class="sub8-refining-banner" role="note" aria-live="polite">
+  <div class="banner-header">
+    <span class="banner-title">{t.title}</span>
+    <span class="banner-score" aria-label={t.scoreLabel}>{t.scoreLabel}: {composite}/10</span>
+  </div>
+  <div class="banner-body">
+    <p class="banner-text">{t.body}</p>
+    <p class="banner-cta">{t.cta}</p>
+  </div>
+</div>
+
+<style>
+  .sub8-refining-banner {
+    margin: 1rem 0 1.5rem;
+    padding: 0;
+    border-radius: 8px;
+    border: 1px solid color-mix(in srgb, var(--color-accent) 35%, transparent);
+    border-left: 4px solid var(--color-accent);
+    background: color-mix(in srgb, var(--color-accent) 7%, transparent);
+    overflow: hidden;
+  }
+
+  .banner-header {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 0.5rem;
+    padding: 0.65rem 1rem;
+    border-bottom: 1px solid color-mix(in srgb, var(--color-accent) 20%, transparent);
+    background: color-mix(in srgb, var(--color-accent) 10%, transparent);
+  }
+
+  .banner-title {
+    font-size: 0.9rem;
+    font-weight: 700;
+    color: var(--color-accent);
+    letter-spacing: 0.01em;
+  }
+
+  .banner-score {
+    font-size: 0.8rem;
+    font-weight: 600;
+    /* --color-accent (same as title): neither --color-text nor
+       --color-text-muted clears AA on the 10% accent header tint in BOTH
+       themes (muted fails dark ~4.1, text fails light ~4.4). Accent passes
+       both (dark 5.05, light 4.90); 0.8rem keeps it visually secondary. */
+    color: var(--color-accent);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .banner-body {
+    padding: 0.85rem 1rem;
+  }
+
+  .banner-text {
+    margin: 0 0 0.5rem;
+    font-size: 0.9rem;
+    color: var(--color-text);
+    line-height: 1.6;
+  }
+
+  .banner-cta {
+    margin: 0;
+    font-size: 0.88rem;
+    color: var(--color-text-muted);
+    line-height: 1.6;
+  }
+</style>

--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -4,10 +4,11 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
 import Toggle from '../../components/Toggle.astro';
 import TicketBadge from '../../components/TicketBadge.astro';
 import PostStatusLabel from '../../components/PostStatusLabel.astro';
-import { getListablePosts, getPostStatus, type PostStatus } from '../../utils/post-status';
+import { getIndexPosts, getPostStatus, type PostStatus } from '../../utils/post-status';
 
 const allPostsFull = await getCollection('posts');
-const allPosts = getListablePosts(allPostsFull, 'en');
+// Homepage excludes sub-8 posts (held off until a background tribunal lifts them).
+const allPosts = getIndexPosts(allPostsFull, 'en');
 
 // Helper: extract number from ticketId (e.g., "CP-11" → 11)
 const getTicketNumber = (ticketId: string | undefined) => {

--- a/src/pages/en/posts/[...slug].astro
+++ b/src/pages/en/posts/[...slug].astro
@@ -9,6 +9,8 @@ import RelatedArticles from '../../../components/RelatedArticles.astro';
 import PostStatusBanner from '../../../components/PostStatusBanner.astro';
 import Stage0WarnBanner from '../../../components/Stage0WarnBanner.astro';
 import Stage4DegradedBanner from '../../../components/Stage4DegradedBanner.astro';
+import Sub8RefiningBanner from '../../../components/Sub8RefiningBanner.astro';
+import { computeOverallComposite, isBelowPublishBar } from '../../../utils/tribunal-scores';
 import TicketBadge from '../../../components/TicketBadge.astro';
 import Giscus from '../../../components/Giscus.astro';
 import ShareButton from '../../../components/ShareButton.astro';
@@ -113,6 +115,12 @@ const ticketLabel = ticketLabels[ticketPrefix] || '';
     {
       post.data.stage4Scores?.isDegraded && (
         <Stage4DegradedBanner stage4Scores={post.data.stage4Scores} lang="en" />
+      )
+    }
+
+    {
+      isBelowPublishBar(post.data.scores) && (
+        <Sub8RefiningBanner composite={computeOverallComposite(post.data.scores) ?? 0} lang="en" />
       )
     }
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,10 +4,11 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 import Toggle from '../components/Toggle.astro';
 import TicketBadge from '../components/TicketBadge.astro';
 import PostStatusLabel from '../components/PostStatusLabel.astro';
-import { getListablePosts, getPostStatus, type PostStatus } from '../utils/post-status';
+import { getIndexPosts, getPostStatus, type PostStatus } from '../utils/post-status';
 
 const allPostsFull = await getCollection('posts');
-const allPosts = getListablePosts(allPostsFull, 'zh-tw');
+// Homepage excludes sub-8 posts (held off until a background tribunal lifts them).
+const allPosts = getIndexPosts(allPostsFull, 'zh-tw');
 
 // Helper: extract number from ticketId (e.g., "CP-11" → 11)
 const getTicketNumber = (ticketId: string | undefined) => {

--- a/src/pages/posts/[...slug].astro
+++ b/src/pages/posts/[...slug].astro
@@ -9,6 +9,8 @@ import RelatedArticles from '../../components/RelatedArticles.astro';
 import PostStatusBanner from '../../components/PostStatusBanner.astro';
 import Stage0WarnBanner from '../../components/Stage0WarnBanner.astro';
 import Stage4DegradedBanner from '../../components/Stage4DegradedBanner.astro';
+import Sub8RefiningBanner from '../../components/Sub8RefiningBanner.astro';
+import { computeOverallComposite, isBelowPublishBar } from '../../utils/tribunal-scores';
 import TicketBadge from '../../components/TicketBadge.astro';
 import Giscus from '../../components/Giscus.astro';
 import ShareButton from '../../components/ShareButton.astro';
@@ -109,6 +111,15 @@ const ticketLabel = ticketLabels[ticketPrefix] || '';
     {
       post.data.stage4Scores?.isDegraded && (
         <Stage4DegradedBanner stage4Scores={post.data.stage4Scores} lang="zh-tw" />
+      )
+    }
+
+    {
+      isBelowPublishBar(post.data.scores) && (
+        <Sub8RefiningBanner
+          composite={computeOverallComposite(post.data.scores) ?? 0}
+          lang="zh-tw"
+        />
       )
     }
 

--- a/src/utils/post-status.ts
+++ b/src/utils/post-status.ts
@@ -1,4 +1,5 @@
 import type { CollectionEntry } from 'astro:content';
+import { isBelowPublishBar } from './tribunal-scores';
 
 type PostEntry = CollectionEntry<'posts'>;
 type PostLang = PostEntry['data']['lang'];
@@ -17,7 +18,11 @@ function normalizeStatus(status?: string): PostStatus {
   return status === 'deprecated' || status === 'retired' ? status : 'published';
 }
 
-function findPostByTicketId(posts: PostEntry[], ticketId?: string, lang?: PostLang): PostEntry | undefined {
+function findPostByTicketId(
+  posts: PostEntry[],
+  ticketId?: string,
+  lang?: PostLang
+): PostEntry | undefined {
   if (!ticketId) {
     return undefined;
   }
@@ -67,9 +72,9 @@ export function resolvePostStatus(post: PostEntry, posts: PostEntry[]): Resolved
   const status = normalizeStatus(sourcePost.data.status);
   const replacementTicketId = status === 'deprecated' ? sourcePost.data.deprecatedBy : undefined;
   const replacementPost = replacementTicketId
-    ? findPostByTicketId(posts, replacementTicketId, post.data.lang) ??
+    ? (findPostByTicketId(posts, replacementTicketId, post.data.lang) ??
       findPostByTicketId(posts, replacementTicketId, sourcePost.data.lang) ??
-      findPostByTicketId(posts, replacementTicketId)
+      findPostByTicketId(posts, replacementTicketId))
     : undefined;
 
   return {
@@ -77,7 +82,8 @@ export function resolvePostStatus(post: PostEntry, posts: PostEntry[]): Resolved
     sourcePost,
     replacementPost,
     replacementTicketId,
-    reason: status === 'deprecated' ? sourcePost.data.deprecatedReason : sourcePost.data.retiredReason,
+    reason:
+      status === 'deprecated' ? sourcePost.data.deprecatedReason : sourcePost.data.retiredReason,
     retiredAt: sourcePost.data.retiredAt,
   };
 }
@@ -99,8 +105,19 @@ export function getPublishedPosts(posts: PostEntry[], lang?: PostLang): PostEntr
 export function getListablePosts(posts: PostEntry[], lang?: PostLang): PostEntry[] {
   return posts.filter(
     (post) =>
-      (!lang || post.data.lang === lang) && resolvePostStatus(post, posts).status !== 'deprecated',
+      (!lang || post.data.lang === lang) && resolvePostStatus(post, posts).status !== 'deprecated'
   );
+}
+
+/**
+ * Homepage / featured post list: listable posts MINUS those that have a real
+ * tribunal score below the publish bar (<8). Sub-8 posts still build at their
+ * own URL and carry a "refining" badge, but are held off the homepage until a
+ * background tribunal lifts them to >=8. Grandfathered (un-scored) posts are
+ * unaffected — they stay on the homepage.
+ */
+export function getIndexPosts(posts: PostEntry[], lang?: PostLang): PostEntry[] {
+  return getListablePosts(posts, lang).filter((post) => !isBelowPublishBar(post.data.scores));
 }
 
 export function getNavigablePosts(posts: PostEntry[], currentPost: PostEntry): PostEntry[] {

--- a/src/utils/tribunal-scores.ts
+++ b/src/utils/tribunal-scores.ts
@@ -1,0 +1,50 @@
+import type { CollectionEntry } from 'astro:content';
+
+type PostScores = NonNullable<CollectionEntry<'posts'>['data']['scores']>;
+
+/** Judges whose composite `.score` counts toward the overall tribunal score. */
+const JUDGES = ['vibe', 'factCheck', 'librarian', 'freshEyes'] as const;
+
+/** Featured / homepage publish bar. Posts below this ship, but are badged
+ * "refining" and held off the homepage until a background tribunal lifts them. */
+export const PUBLISH_BAR = 8;
+
+/** A post is "evaluated" once it carries a numeric vibe composite. */
+export function hasTribunalScore(scores?: PostScores): boolean {
+  return typeof scores?.vibe?.score === 'number';
+}
+
+/** Composite `.score` of every judge that is present (vibe + any of the others). */
+function presentJudgeScores(scores?: PostScores): number[] {
+  if (!scores) return [];
+  const out: number[] = [];
+  for (const judge of JUDGES) {
+    const score = scores[judge]?.score;
+    if (typeof score === 'number') out.push(score);
+  }
+  return out;
+}
+
+/** Overall tribunal composite = floor(avg of present judge composites), or
+ * null when the post has not been scored. */
+export function computeOverallComposite(scores?: PostScores): number | null {
+  const vals = presentJudgeScores(scores);
+  if (vals.length === 0) return null;
+  return Math.floor(vals.reduce((sum, n) => sum + n, 0) / vals.length);
+}
+
+/** Meets the featured bar: scored AND every present judge composite >= 8. */
+export function meetsPublishBar(scores?: PostScores): boolean {
+  if (!hasTribunalScore(scores)) return false;
+  const vals = presentJudgeScores(scores);
+  return vals.length > 0 && vals.every((score) => score >= PUBLISH_BAR);
+}
+
+/**
+ * Below the featured bar: the post HAS a real tribunal score but does not
+ * meet it. Score-less grandfathered posts are NOT below bar — they are
+ * "unevaluated", so they stay on the homepage untouched.
+ */
+export function isBelowPublishBar(scores?: PostScores): boolean {
+  return hasTribunalScore(scores) && !meetsPublishBar(scores);
+}


### PR DESCRIPTION
## 背景

承 #388 / #389：user 拍板把品質把關改成**兩層**——自動 gate 是 floor（≥3），編輯標準（≥8）改成 UI 層的「公開分數 + 首頁隔離 + 背景精修」。同時修掉 #388 暴露的漏洞：**全文重寫既有檔案會繞過 score gate**。

## 三塊（各 atomic commit）

### A. hook floor ≥3 + reader-visible 重寫也納入 gate
- 自動 gate 改成 **floor：scores.vibe 在 + 5 維齊 + composite ≥ 3**（`scripts/score-floor-check.mjs`）。sub-8 允許 ship，garbage(<3)/無分數擋掉。
- 把**修改既有 zh-tw 文章**也納入 gate，但只在 **reader-visible 內容變了**才觸發（`reader_visible_changed` 比對 staged vs HEAD reader revision）。backend-only 改動 + 純內部連結維護都豁免。
- 手測：reader-visible 無 score→擋、backend-only→放行、composite 2→擋、8→過。

### B. CLAUDE.md 品質門檻改兩層
舊「FAIL 不准 commit、必須 iterate 到 ≥8」→ floor(≥3 才能 ship) + PASS(≥8 才上首頁，sub-8 帶 badge + 首頁隔離 + 背景精修)。

### C. sub-8 首頁隔離 + 「精修中」badge
- `src/utils/tribunal-scores.ts`：`computeOverallComposite`/`meetsPublishBar`/`isBelowPublishBar`。關鍵：沒分數的 grandfathered 舊文「不算 below bar」（照常顯示），只有「有分數且任一 judge <8」才算 sub-8。
- `getIndexPosts()`：首頁濾掉 sub-8，zh/en 首頁改用。
- `Sub8RefiningBanner.astro`：sub-8 文章頁顯示「精修中」+ 綜合分數；文章仍 build、仍顯示 AI judge 分數。

**影響面**：70 篇有分數的文章 0 篇 sub-8，對現有內容零影響，純 forward-looking。

## 品質 gate
- ✅ astro check 0 errors、build 3051 頁無錯
- ✅ uiux-auditor 兩主題 PASS：title/score(accent) dark 5.05 / light 4.90、body 8.06/4.72，無硬編 hex。

tribunal version 不因換 Claude judge 而 bump（runtime model 歸 `model` 欄位，version 追蹤 rubric）。

https://claude.ai/code/session_014v3VkoZ5hPjwLbHzK8CBBF

---
_Generated by [Claude Code](https://claude.ai/code/session_014v3VkoZ5hPjwLbHzK8CBBF)_