### PR TITLE
fix(SP-220): en cross-ref 連結改用 /en/posts/en- 路由（修 main 壞連結）

### DIFF
--- a/src/content/posts/en-sp-220-20260610-loop-engineering.mdx
+++ b/src/content/posts/en-sp-220-20260610-loop-engineering.mdx
@@ -46,7 +46,7 @@ The new way hands that loop off. Instead of telling an agent to "build a landing
 The difference in one line: a prompt gives the agent an instruction. A loop gives the agent a job.
 
 <ClawdNote summary="Simon Willison said this in February — the value here isn't being first, it's the clean map (with an ad sewn in)">
-This thesis isn't new. [Simon Willison](/en/glossary#simon-willison) said almost exactly this back in February — the new skill isn't writing prompts, it's "designing agentic loops" that brute-force their way through any coding problem (gu-log translated it [here](/posts/en-clawd-picks-20260203-simonw-agentic-loops)). The value of this piece isn't being first — it's pulling scattered ideas into one clean map. And the map is genuinely good… good enough that a sponsored ad is sewn into the middle of it, and you almost don't notice the seam.
+This thesis isn't new. [Simon Willison](/en/glossary#simon-willison) said almost exactly this back in February — the new skill isn't writing prompts, it's "designing agentic loops" that brute-force their way through any coding problem (gu-log translated it [here](/en/posts/en-clawd-picks-20260203-simonw-agentic-loops)). The value of this piece isn't being first — it's pulling scattered ideas into one clean map. And the map is genuinely good… good enough that a sponsored ad is sewn into the middle of it, and you almost don't notice the seam.
 </ClawdNote>
 
 ---
@@ -163,7 +163,7 @@ The bluntest contrast: a prompt engineer says "write me a function"; a loop engi
 Same tools, completely different mindset. Prompt engineers ask AI for output; loop engineers design systems that produce verified outcomes. The highest-paid AI engineers of 2026 aren't writing prettier English sentences — they're writing the logic that governs how an agent discovers, plans, checks its own work, and knows when it's done.
 
 <ClawdNote summary="'Prompt engineer' as a title is past its freshness date — the value moved up to designing feedback and stop conditions.">
-The buried message in that contrast is a little brutal: "prompt engineering" as a job title is past its freshness date. Not that writing prompts is useless — every step inside a loop is still held up by a prompt — but if your entire skill is "make English sentences flow better," the agent will soon do that itself. What holds value is the layer above: designing feedback, designing stop conditions, designing who-verifies-whom. This echoes another piece gu-log translated — Anthropic defines Claude's real steering wheel as "making a human understand what it just did," not the prompt itself ([Claude Code's Real Steering Wheel](/posts/en-cp-305-20260604-trq212-claude-stay-in-loop)). The steering wheel moved up a layer.
+The buried message in that contrast is a little brutal: "prompt engineering" as a job title is past its freshness date. Not that writing prompts is useless — every step inside a loop is still held up by a prompt — but if your entire skill is "make English sentences flow better," the agent will soon do that itself. What holds value is the layer above: designing feedback, designing stop conditions, designing who-verifies-whom. This echoes another piece gu-log translated — Anthropic defines Claude's real steering wheel as "making a human understand what it just did," not the prompt itself ([Claude Code's Real Steering Wheel](/en/posts/en-cp-305-20260604-trq212-claude-stay-in-loop)). The steering wheel moved up a layer.
 </ClawdNote>
 
 ---


### PR DESCRIPTION
## 什麼壞了

SP-220 merge 後，`internal-links` CI（`check-links.mjs`，比 content-integrity 的 link test 嚴）抓到 en-sp-220 兩條 broken cross-ref：

- `/posts/en-clawd-picks-20260203-simonw-agentic-loops`
- `/posts/en-cp-305-20260604-trq212-claude-stay-in-loop`

en 文章路由在 `/en/` 底下（同 `/en/glossary`），正確格式是 **`/en/posts/en-<slug>`**，不是 `/posts/en-`。PR #391 的 required gate（`ci-passed`）沒含這個 job，所以照樣 auto-merge 了，main 一度帶兩條壞連結 → 緊急修。

## 修法

兩條改成 `/en/posts/en-...`。本地 `links:check --internal-only` 已綠（5452 OK / 0 broken）。

## 順帶記錄的 gap

`tests/content-integrity.spec.ts` 的 internal-link test 沒擋這個（它的解析比 `check-links.mjs` 寬鬆），所以本地 pre-commit 沒攔到。這次先把連結修對；content-integrity 要不要對齊 check-links 的嚴格度是另一個獨立議題，不混進這個 hotfix。

https://claude.ai/code/session_01KrGNSisMXGEpKfQjiyfzJm

---
_Generated by [Claude Code](https://claude.ai/code/session_01KrGNSisMXGEpKfQjiyfzJm)_