### PR TITLE
tribunal(fresh-eyes): readability 抓未解釋的行銷/PM 縮寫（jingjing 全大寫盲區）

### DIFF
--- a/.claude/agents/fresh-eyes.md
+++ b/.claude/agents/fresh-eyes.md
@@ -38,7 +38,7 @@ Would you finish reading? Would you share it?
 - **Boring stretches** — where you started skimming
 - **Dead sentences** — sentences with neither information nor intrigue. If a sentence only repeats source metadata, throat-clears, or says "this article discusses..." without adding value, flag it hard.
 - **Confusion points** — where you had to re-read or Google something
-- **Unexplained jargon** — terms you didn't know and weren't explained
+- **Unexplained jargon** — terms you didn't know and weren't explained. This includes marketing/PM/business acronyms outside your domain (CTA, MVP, ICP, TAM, ARR…): one unexplained one caps readability at 7, several at 6. (API/SDK/CLI/MCP are fine — those you know.)
 - **Best moment** — the one thing that made you go "oh that's good"
 
 ## Rules

--- a/.codex/agents/fresh-eyes.toml
+++ b/.codex/agents/fresh-eyes.toml
@@ -27,6 +27,10 @@ recap-heavy to deserve an easy 8/8.
 
 Fresh Eyes v8 MUST score exactly these dimensions:
 - readability: can a smart impatient beginner follow the article without rereading?
+  An unexplained marketing/PM/business acronym the persona may not know (CTA, MVP,
+  ICP, TAM, ARR, CAC…) is a readability snag — cap readability at 7 for one, 6 for
+  several. check-jingjing.mjs auto-allows any ≤6-char all-caps token as an acronym,
+  so the lint never catches these; Fresh Eyes must. (API/SDK/CLI/MCP are fine.)
 - firstImpression: does the opening create enough momentum to keep reading?
 - payoffDensity: does every 3–5 paragraphs deliver a new fact, judgment, image,
   tension, or useful framing? Low score if sections feel like correct filler.

--- a/scripts/vibe-scoring-standard.md
+++ b/scripts/vibe-scoring-standard.md
@@ -235,6 +235,8 @@ Clawd/gu-log opinions, interpretation, jokes, and source-meta commentary belong 
 | 4 | Get the gist but multiple confusing paragraphs. Would not share. |
 | 2 | Lost in jargon. Gave up halfway. |
 
+**Unexplained-acronym rule:** an unexplained marketing / PM / business acronym the 3-month-engineer persona may not know (CTA, MVP, ICP, TAM, ARR, CAC, …) is a readability snag — cap `readability` at 7 for one, 6 if several. Note `scripts/check-jingjing.mjs` auto-allows any ≤6-char all-caps token as an "acronym," so the deterministic 晶晶體 lint will never catch these — Fresh Eyes is the judge that has to. (Universally-understood tech acronyms like API/SDK/CLI/MCP are fine; this is about jargon outside the reader's domain.)
+
 ### firstImpression — Would You Finish? Would You Share?
 
 | Score | Description |


### PR DESCRIPTION
## 為什麼

SP-220 的 ClawdNote 用了「CTA」這個行銷縮寫，ShroomDog 在 prod 上讀到才抓到（`CTA? what is that?`）。`scripts/check-jingjing.mjs:491` 對「≤6 字元的全大寫 token」一律當 acronym 放行，所以 CTA/MVP/ICP/TAM 這類冷門縮寫術語**永遠不會被晶晶體 lint 攔**。

Fresh Eyes 的 persona 正是「怕 jargon 的 3 個月工程師」，`readability` 維度本來就管「能不能不迷路讀完」——讓它接手這條最對位。

## 改了什麼（一句話規則，不 bump 版本）

未解釋的行銷/PM/商管縮寫（CTA/MVP/ICP/TAM/ARR/CAC…）算 readability 扣分：1 個 cap 7、多個 cap 6。通用技術縮寫（API/SDK/CLI/MCP）不算。

三處同步（避免 drift）：
- `scripts/vibe-scoring-standard.md` — SSOT readability 維度
- `.codex/agents/fresh-eyes.toml` — **active runtime**（GPT-5.5 實際讀的）
- `.claude/agents/fresh-eyes.md` — legacy 參考

**不 bump tribunal v8→v9**：這是釐清既有 readability 維度，不是新增維度/改 pass-bar（ShroomDog 拍板）。

## 取捨紀錄

gu-log 慣例是「同類 lesson 重複 3 次才升級成正式 rubric 規則」，這是第 1 次出現；ShroomDog 評估 persona 對位太乾淨 + 改動極小 + lint 永久盲區，決定提前升級。lesson 已記在 `docs/shroomdog-editorial-feedback.md`（2026-06-10 條目）。

https://claude.ai/code/session_01KrGNSisMXGEpKfQjiyfzJm

---
_Generated by [Claude Code](https://claude.ai/code/session_01KrGNSisMXGEpKfQjiyfzJm)_