### PR TITLE
Mogu Picks 顯示成 MP-，並放大過小的角色 icon

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,6 +161,16 @@ Pipeline 包辦：fetch → eval → dedup → write → review → refine → c
 
 **ShroomDog editorial feedback 一律進 corpus。** 如果 ShroomDog / Sprin 對 gu-log 文章提出用字、敘事、事實查核、語氣、讀者困惑點等回饋，立刻 append 到 `docs/shroomdog-editorial-feedback.md`。不要只存在聊天紀錄、個人 memory、未追蹤 scratch file，或某個 agent 的私人筆記。這份檔案是之後蒸餾進 GU-LOG_WRITER_PROMPT.md 的原始訓練資料，讓 GPT-5.5 / Codex / Claude Code / Iris 共用同一份 gu-log writer prompt。
 
+### 🔚 CCC 收尾鐵則：每個 turn 都要以「可驗收的東西」結束
+
+**CCC（Cloud Claude Code）每一次結束 turn，最後一定要丟給 user 下面三選一**——不准用「我做完了」「等你看看」這種空回合收尾：
+
+1. **Critical design decision 問題**（用 `AskUserQuestion`）：只有當你撞到產品方向、架構、對外承諾、個人品牌調性這種**非 user 不能決定**的岔路時才停下來問。問題本身要把脈絡帶足，讓 user 不用往回捲就能答。
+2. **Preview URL**：改動還沒 merge、要 user 在 branch 上驗收時，去 PR 的 Vercel deployment status / vercel[bot] 留言把 **preview URL** 撈出來貼給 user（格式 `https://gu-log-git-<branch-hash>-sprin-clawds-projects.vercel.app`，用 `mcp__github__pull_request_read` 的 `get_status` / `get_comments` 拿，不要自己猜湊）。
+3. **Prod URL**（`https://gu-log.vercel.app`，或對應的文章/分頁深連結）：已經 merge、Vercel 部署完，要 user 在正式站上驗收時貼這個。
+
+**為什麼**：CCC 跑在沙箱，user 看不到你的 dev server、看不到 diff、不讀 draft（見下面 ShroomDog 那條）。**唯一的驗收介面就是一個可以點開的 URL，或一個只有他能拍板的問題**。沒有這三者之一的收尾 = 把球停在半空，user 得自己去翻 PR 找連結，等於把 friction 甩回去。三選一的判斷順序：有 critical decision 卡著 → 問；沒卡但還沒 merge → 給 preview URL；已 merge 部署完 → 給 prod URL。
+
 ### 🔍 事實查核紀律：AI tooling 的 claim 必須 verify
 
 gu-log 寫的就是 AI / agent / tooling 圈，這個圈子有兩個特性：

--- a/playbooks/CCC-playbook.md
+++ b/playbooks/CCC-playbook.md
@@ -41,7 +41,7 @@
 3. **PR 開完立刻 `mcp__github__subscribe_pr_activity` 訂閱自己這條 PR**——不要問 user「要不要幫你盯」。CCC 開 PR 預設就要盯 CI + review comment，這是工作的一部分，不是 opt-in 服務。問就是 dumb question。
 4. **等 CI 全綠**後自己 `mcp__github__merge_pull_request`
 5. **Merge 完不用、也無法自己刪 remote branch**——repo 已開啟「Automatically delete head branches」，GitHub 在 merge 後自動刪掉 head branch，CCC 什麼都不用做。**⚠️ CCC 千萬不要嘗試 `git push origin --delete claude/xxx`**：sandbox 的 git proxy 會回 **HTTP 403**（只放行 push commit、不放行刪 ref），重試也是 403、純粹浪費 round。GitHub MCP 也沒有 delete-branch 工具。Local branch 是拋棄式 sandbox 的一部分，不用管。萬一哪天 auto-delete 被關掉導致 branch 沒被清，那是 user 去 GitHub 設定重開／手動刪的事，不是 CCC 能在 sandbox 內解決的。
-6. Merge 完跟 user 回報 PR URL + 簡短 summary（branch 由 GitHub auto-delete 收尾）
+6. Merge 完跟 user 回報 PR URL + 簡短 summary（branch 由 GitHub auto-delete 收尾），並依 [`CLAUDE.md` 的「CCC 收尾鐵則」](../CLAUDE.md) 附上**驗收用的 URL**：已 merge 且部署完 → prod URL（`gu-log.vercel.app` 或文章深連結）；還在 branch 上等驗收 → 用 `pull_request_read` 的 `get_status` / `get_comments` 撈 Vercel preview URL。每個 turn 都要以「critical question / preview URL / prod URL」三選一收尾，不留空回合。
 
 **禁問句**：「要不要 subscribe PR activity？」「要不要盯 CI？」「要不要幫你看 review comment？」——通通是 dumb question，預設答案永遠是 yes，user 不該被叫去確認 default behavior。CCC 的工作是「開 PR → 盯 CI → merge → 回報」整條收乾淨；branch cleanup 交給 repo 的 auto-delete 設定，CCC 不去 `git push --delete`（那會 403）。
 

--- a/src/components/TicketBadge.astro
+++ b/src/components/TicketBadge.astro
@@ -27,8 +27,9 @@ const labels: Record<string, string> = {
 };
 
 // Display alias: the SP series is branded "Gu-log Picks" with a GP- ticket,
-// while the underlying slug/URL/ticketId stays SP- (no URL breakage).
-const displayId = ticketId.replace(/^SP-/, 'GP-');
+// and the CP series is branded "Mogu Picks" with an MP- ticket, while the
+// underlying slug/URL/ticketId stays SP-/CP- (no URL breakage).
+const displayId = ticketId.replace(/^SP-/, 'GP-').replace(/^CP-/, 'MP-');
 
 const label = labels[prefix] || '';
 ---

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -138,8 +138,8 @@ const finalDescription = description || t.defaultDescription;
       }
 
       .header-avatar {
-        width: 36px;
-        height: 36px;
+        width: 40px;
+        height: 40px;
         border-radius: 22%;
         vertical-align: middle;
         margin-right: 0.3rem;

--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -255,8 +255,8 @@ const cpPosts = allPosts.filter((p) => p.data.ticketId?.startsWith('CP-')).sort(
 
   .mogu-section-icon,
   .section-icon {
-    width: 24px;
-    height: 24px;
+    width: 38px;
+    height: 38px;
     vertical-align: middle;
     border-radius: 22%;
   }

--- a/src/pages/en/mogu-picks/[...page].astro
+++ b/src/pages/en/mogu-picks/[...page].astro
@@ -59,8 +59,8 @@ const getTimelineStyle = (status: PostStatus) =>
 
 <style>
   .page-icon {
-    width: 32px;
-    height: 32px;
+    width: 44px;
+    height: 44px;
     vertical-align: middle;
     margin-right: 0.5rem;
   }

--- a/src/pages/en/shroomdog-originals/[...page].astro
+++ b/src/pages/en/shroomdog-originals/[...page].astro
@@ -70,6 +70,13 @@ const getTimelineStyle = (status: PostStatus) =>
     color: var(--color-accent);
   }
 
+  .page-icon {
+    width: 44px;
+    height: 44px;
+    vertical-align: middle;
+    margin-right: 0.5rem;
+  }
+
   .page-subtitle {
     color: var(--color-text-muted);
     font-size: 0.9rem;

--- a/src/pages/en/shroomdog-picks/[...page].astro
+++ b/src/pages/en/shroomdog-picks/[...page].astro
@@ -65,8 +65,8 @@ const getTimelineStyle = (status: PostStatus) =>
 
 <style>
   .page-icon {
-    width: 32px;
-    height: 32px;
+    width: 44px;
+    height: 44px;
     vertical-align: middle;
     margin-right: 0.5rem;
   }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -262,8 +262,8 @@ const cpPosts = allPosts.filter((p) => p.data.ticketId?.startsWith('CP-')).sort(
 
   .mogu-section-icon,
   .section-icon {
-    width: 24px;
-    height: 24px;
+    width: 38px;
+    height: 38px;
     vertical-align: middle;
     border-radius: 22%;
   }

--- a/src/pages/mogu-picks/[...page].astro
+++ b/src/pages/mogu-picks/[...page].astro
@@ -64,8 +64,8 @@ const getTimelineStyle = (status: PostStatus) =>
 
 <style>
   .page-icon {
-    width: 32px;
-    height: 32px;
+    width: 44px;
+    height: 44px;
     vertical-align: middle;
     margin-right: 0.5rem;
   }

--- a/src/pages/shroomdog-originals/[...page].astro
+++ b/src/pages/shroomdog-originals/[...page].astro
@@ -69,6 +69,13 @@ const getTimelineStyle = (status: PostStatus) =>
     color: var(--color-heading-sd, var(--color-badge-sd));
   }
 
+  .page-icon {
+    width: 44px;
+    height: 44px;
+    vertical-align: middle;
+    margin-right: 0.5rem;
+  }
+
   .page-subtitle {
     color: var(--color-text-muted);
     font-size: 0.9rem;

--- a/src/pages/shroomdog-picks/[...page].astro
+++ b/src/pages/shroomdog-picks/[...page].astro
@@ -64,8 +64,8 @@ const getTimelineStyle = (status: PostStatus) =>
 
 <style>
   .page-icon {
-    width: 32px;
-    height: 32px;
+    width: 44px;
+    height: 44px;
     vertical-align: middle;
     margin-right: 0.5rem;
   }


### PR DESCRIPTION
## 背景

兩個回報：
1. Mogu Picks 的 ticket badge 還顯示舊的 `CP-` 前綴，應該是 `MP-`。
2. 首頁的 Mogu / Gu-log / ShroomDog 角色 icon 都太小，跟旁邊標題比例失衡，要求找出所有類似問題一起修。

## 改動（atomic commits）

**1. `feat(brand)`：CP 系列顯示層改成 MP-**
- 比照既有的 SP→GP 做法，在 `TicketBadge.astro` 加顯示層 alias：`CP-` → `MP-`。
- 底層 slug / URL / ticketId / 分類過濾邏輯維持 `CP-` 不動，不斷任何網址。
- 涵蓋首頁、封存頁、文章頁、tag 頁所有 badge（全部都走 `TicketBadge`）。

**2. `fix(ui)`：補上 shroomdog-originals 漏掉的 `.page-icon` 規則**
- `shroomdog-originals`（zh + en）封存頁的 h1 用了 `class="page-icon"`，但 style 區塊裡**根本沒定義這條規則**、也沒有 global fallback → 512px 的 ShroomDog icon 以原始尺寸撐爆版面。
- 補上 44px 規則，跟其他封存頁一致。

**3. `style(ui)`：放大角色 icon**
- 首頁 section icon：24 → 38px
- 封存頁標題 icon：32 → 44px
- header logo：36 → 40px
- 資產都是 128/512px 高解析，放大不掉畫質。
- **刻意不動**內文 inline note icon（`MoguNote` / `ShroomDogNote` 20–22px）：它們是跟文字同行的 inline 標記，放大會破壞行高。

## 驗證

- `pnpm run build` ✓（3083 頁）
- `validate-posts.mjs` ✓ / `astro check` 0 errors
- playwright 雙主題截圖確認：首頁 badge 顯示 `MP-307`/`MP-306`…，section icon 比例正常，archive icon 量到 44×44（原本是撐爆的 512px）。
- pre-commit hook 全綠（contrast / eslint / prettier / score gate）

需要 human 決策的地方：icon 放大尺寸（38/44/40px）是依比例選的，若覺得太大／太小可直接講，調整很快。


---
_Generated by [Claude Code](https://claude.ai/code/session_01FgZTqw2Ff4Q2ckjonEV5Y3)_