### PR TITLE
feat(sp-pipeline): doctor --probe-llm 在 codex 缺席時 fallback 到 claude

### DIFF
--- a/tools/sp-pipeline/cmd/sp-pipeline/doctor.go
+++ b/tools/sp-pipeline/cmd/sp-pipeline/doctor.go
@@ -43,6 +43,11 @@ type fileCheck struct {
 
 // requiredBinaries and optionalBinaries mirror sp-pipeline.sh's
 // check_required_tools list, split by whether a missing entry is fatal.
+//
+// codex is optional rather than required because the pipeline falls back to
+// `claude` when no codex binary is on PATH (the CCC / Claude Code on the web
+// sandbox). A box with codex absent but claude present is still healthy, so a
+// missing codex must never flip overall health to failed — see ProbeChain.
 var (
 	requiredBinaries = []string{"git", "bash", "node", "python3", "curl"}
 	optionalBinaries = []string{"codex", "jq", "make", "pnpm"}
@@ -138,7 +143,7 @@ func runDoctor(ctx context.Context, state *rootState, probeLLM bool) error {
 		// should complete in a few seconds.
 		probeCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 		defer cancel()
-		disp, err := llm.NewDispatcher(state.log, llm.DefaultProbeChain()...)
+		disp, err := llm.NewDispatcher(state.log, llm.ProbeChain()...)
 		if err == nil {
 			report.LLMProbes = disp.Probe(probeCtx)
 		} else {

--- a/tools/sp-pipeline/internal/llm/defaults.go
+++ b/tools/sp-pipeline/internal/llm/defaults.go
@@ -18,6 +18,25 @@ func DefaultProbeChain() []Provider {
 	}
 }
 
+// ProbeChain returns the providers `doctor --probe-llm` should canary. It is
+// the symmetric counterpart to WritingChain for the health-check path: codex
+// GPT-5.5 is probed wherever it exists, and only when no codex binary is on
+// PATH — the CCC / Claude Code on the web sandbox case, where only `claude`
+// ships — is a Claude Opus probe appended so doctor reports the provider the
+// pipeline would actually use instead of a misleading codex "missing".
+//
+// Claude is appended ONLY when codex is absent, mirroring WritingChain's
+// invariant: codex present → Claude is never probed, so VPS/mac doctor output
+// is byte-for-byte unchanged. DefaultProbeChain() stays codex-only for callers
+// that want to probe codex explicitly.
+func ProbeChain() []Provider {
+	chain := DefaultProbeChain()
+	if anyAvailable(chain) {
+		return chain
+	}
+	return append(chain, NewClaudeOpus())
+}
+
 // WritingChain returns the provider chain the pipeline actually dispatches
 // through (eval / write / review / refine). Codex GPT-5.5 is the primary
 // everywhere it exists. When no codex binary is on PATH — the CCC / Claude

--- a/tools/sp-pipeline/internal/llm/fallback_test.go
+++ b/tools/sp-pipeline/internal/llm/fallback_test.go
@@ -54,6 +54,31 @@ func TestWritingChainKeepsCodexPrimary(t *testing.T) {
 	}
 }
 
+func TestProbeChainKeepsCodexPrimary(t *testing.T) {
+	// ProbeChain mirrors WritingChain's invariant for the doctor --probe-llm
+	// path: codex is always primary so VPS/mac probe output is unchanged; the
+	// only difference is an optional trailing Claude probe when codex is absent
+	// (the CCC sandbox case). It must never be claude-only or place claude
+	// before codex.
+	chain := ProbeChain()
+	if len(chain) == 0 {
+		t.Fatal("ProbeChain returned an empty chain")
+	}
+	if chain[0].Name() != "codex-gpt-5.5" {
+		t.Fatalf("ProbeChain primary = %q, want codex-gpt-5.5", chain[0].Name())
+	}
+	switch len(chain) {
+	case 1:
+		// codex-only — fine.
+	case 2:
+		if _, ok := chain[1].(*ClaudeProvider); !ok {
+			t.Fatalf("ProbeChain fallback = %T, want *ClaudeProvider", chain[1])
+		}
+	default:
+		t.Fatalf("ProbeChain length = %d, want 1 or 2", len(chain))
+	}
+}
+
 func TestEffectiveStampLabels(t *testing.T) {
 	// EffectiveStamp never invents an unknown label; it returns one of the two
 	// known provider identities. We can't force PATH here, so we just assert


### PR DESCRIPTION
## 背景

PR #403（issue #402）讓 `gp-pipeline` 的 run / tribunal 路徑在 CCC 沙箱（PATH 只有 `claude`、沒有 `codex`）自動 fallback 到 claude，但 `doctor --probe-llm` 沒跟上：它的 probe chain 寫死 `DefaultProbeChain()`（codex-only），所以 CCC 跑健檢只看到 codex `missing`，讓使用者誤以為 pipeline 壞了——其實 run 路徑是好的，只有這個探針沒 fallback。

Fixes #404

## 改動

- `internal/llm/defaults.go`：新增 `ProbeChain()`，對稱於 PR #403 的 `WritingChain()`。codex 在 PATH 上 → 維持 codex-only（VPS/mac 行為 byte-for-byte 不變）；偵測不到 codex → append `NewClaudeOpus()` 探針。`DefaultProbeChain()` 維持原樣不動，給想顯式只探 codex 的呼叫者。
- `cmd/sp-pipeline/doctor.go`：probe 改用 `ProbeChain()`；補註解說明 codex 列 optional 是因為 CCC 用 claude fallback，「codex missing 但 claude 在」不該報不健康。
- `internal/llm/fallback_test.go`：新增 `TestProbeChainKeepsCodexPrimary`，鎖定 ProbeChain 永遠 codex-primary、最多尾巴一個 claude（比照 `TestWritingChainKeepsCodexPrimary`）。

## 硬約束對照

- ✅ codex 在時 probe chain 不含 claude（對稱 WritingChain 不變式，unit test 鎖定）
- ✅ codex missing 但 claude 在 → overall health 仍 healthy（codex 是 optional binary，LLM probe 失敗本來就不影響 exit code）
- ✅ 補了 unit test
- ✅ 沒用 `--no-verify`，pre-commit 全綠

## 驗收（CCC 沙箱實測）

```
llm probes:
  x codex-gpt-5.5      GPT-5.5                binary not on PATH
  + claude-claude-opus-4-6[1m] Opus 4.6               ok

[OK] doctor: environment looks healthy
```

claude probe 回報 `ok`、overall 為 `healthy`。codex 仍誠實顯示為缺席的 optional primary（與上面 binaries 區一致），這正是 WritingChain 的對稱語意：dispatcher 依序探整條 chain，codex 探不到、claude 補上。


---
_Generated by [Claude Code](https://claude.ai/code/session_01BAjYj4aU3f5XPGFNkwzUpV)_