### PR TITLE
fix(tribunal): progress ledger runner_label 改成 provider-aware

### DIFF
--- a/scripts/tests/test-tribunal-safety-contract.sh
+++ b/scripts/tests/test-tribunal-safety-contract.sh
@@ -98,6 +98,24 @@ if [ -n "$unpinned_agents" ]; then
 fi
 pass "Tribunal model pinning: codex stays GPT-5.5, claude is the CCC fallback"
 
+# The internal progress ledger runner_label must be provider-aware too, sharing
+# the same resolver as the frontmatter model_id. A refactor must not regress it
+# back to a static codex-gpt-5.5-medium string (that would mislabel CCC Claude
+# runs as codex in calibration/audit data).
+if ! grep -q 'tribunal_runner_label()' "$HELPERS"; then
+  fail "tribunal_runner_label provider-aware helper is missing"
+fi
+if ! grep -q 'codex-%s-medium' "$HELPERS"; then
+  fail "tribunal_runner_label codex path no longer reproduces codex-gpt-5.5-medium"
+fi
+if ! grep -q 'runner_label="$(tribunal_runner_label' "$TRIBUNAL"; then
+  fail "Tribunal progress runner_label is not resolved through tribunal_runner_label"
+fi
+if grep -Eq 'codex-gpt-5\.5-medium:(factCheck|librarian|freshEyes|vibe)' "$TRIBUNAL"; then
+  fail "STAGES still hardcodes a static codex-gpt-5.5-medium runner_label column"
+fi
+pass "Progress ledger runner_label is provider-aware (codex/claude), not a static codex string"
+
 if ! grep -q 'temporary directory' "$CODEX_WRITER" || ! grep -q 'surgical editor' "$CODEX_WRITER"; then
   fail "Codex tribunal writer prompt lacks GPT-5.5 temp-dir/surgical-edit guardrails"
 fi

--- a/scripts/tribunal-helpers.sh
+++ b/scripts/tribunal-helpers.sh
@@ -419,6 +419,31 @@ tribunal_llm_model_id() {
   esac
 }
 
+# Provider-aware runner label stamped into the internal progress ledger
+# (.score-loop/state/tribunal-progress.json), the stage log lines, and the
+# runner-error records. Shares the exact same provider resolution as the
+# frontmatter model_id (tribunal_llm_provider + tribunal_llm_model_id) so a
+# Claude-scored run is recorded as Claude internally instead of being
+# mislabelled as the codex GPT-5.5 runner — no second provider-detection path.
+#
+# - codex  → codex-gpt-5.5-medium  (byte-for-byte unchanged so VPS/mac
+#            calibration history stays continuous)
+# - claude → the judge's declared Claude build, symmetric to the frontmatter
+#            model_id (e.g. claude-opus-4-6[1m])
+tribunal_runner_label() {
+  local agent_name="${1:-}"
+  local model
+  model="$(tribunal_llm_model_id "$agent_name")"
+  case "$(tribunal_llm_provider 2>/dev/null)" in
+    claude)
+      printf '%s\n' "$model"
+      ;;
+    *)
+      printf 'codex-%s-medium\n' "$model"
+      ;;
+  esac
+}
+
 # Claude equivalent of tribunal_codex_exec: inlines the .claude/agents/<name>.md
 # rubric (its YAML frontmatter is the persona/pass-bar contract) and runs
 # `claude -p` non-interactively. Under root (CCC) claude rejects

--- a/scripts/tribunal.sh
+++ b/scripts/tribunal.sh
@@ -612,7 +612,7 @@ PY
 }
 
 # ─── Run One Tribunal Stage ───────────────────────────────────────────────────
-# Args: stage_key, agent_name, validate_name, label, max_loops, runner_label, post_file
+# Args: stage_key, agent_name, validate_name, label, max_loops, post_file
 # Returns: 0 = stage passed, 1 = stage failed (max loops exhausted)
 run_stage() {
   local stage_key="$1"    # progress key: librarian, factChecker, freshEyes, vibe
@@ -620,9 +620,8 @@ run_stage() {
   local validate_name="$3" # validate name: librarian, fact-checker, fresh-eyes, vibe-opus-scorer
   local label="$4"        # human label: Librarian, FactChecker, FreshEyes, VibeScorer
   local max_loops="$5"    # 2 or 3
-  local runner_label="$6"  # Codex runner label for logging/progress/frontmatter
-  local post_file="$7"
-  local fm_judge_key="${8:-}" # frontmatter scores key: librarian, factCheck, freshEyes, vibe
+  local post_file="$6"
+  local fm_judge_key="${7:-}" # frontmatter scores key: librarian, factCheck, freshEyes, vibe
 
   local post_path="$ROOT_DIR/src/content/posts/$post_file"
 
@@ -633,6 +632,14 @@ run_stage() {
   # recorded honestly rather than mislabelled GPT-5.5.
   local model_id
   model_id="$(tribunal_llm_model_id "$agent_name")"
+
+  # Provider-aware runner label for the progress ledger / stage logs /
+  # runner-error records. Derived from the same provider resolution as model_id
+  # (not a static codex-gpt-5.5-medium string) so the internal ledger matches
+  # the reader-visible frontmatter: codex stays codex-gpt-5.5-medium, the CCC
+  # Claude fallback records the judge's Claude build instead of lying GPT-5.5.
+  local runner_label
+  runner_label="$(tribunal_runner_label "$agent_name")"
 
   # ── Crash resume: skip already-passed stages ──
   local existing_status
@@ -1001,17 +1008,19 @@ if [ "$TRIBUNAL_PROVIDER" != "codex" ]; then
 fi
 
 # ─── Tribunal v8 Sequential Loop ──────────────────────────────────────────────
-# Format: stage_key:agent_name:validate_name:label:max_loops:runner_label:fm_judge_key
+# Format: stage_key:agent_name:validate_name:label:max_loops:fm_judge_key
 # fm_judge_key = frontmatter scores key (used by frontmatter-scores.mjs)
+# The runner_label is no longer a static column here: run_stage resolves it
+# provider-aware via tribunal_runner_label so codex/claude are labelled honestly.
 declare -a STAGES=(
-  "factChecker:fact-checker:fact-checker:FactChecker:2:codex-gpt-5.5-medium:factCheck"
-  "librarian:librarian:librarian:Librarian:2:codex-gpt-5.5-medium:librarian"
-  "freshEyes:fresh-eyes:fresh-eyes:FreshEyes:2:codex-gpt-5.5-medium:freshEyes"
-  "vibe:vibe-opus-scorer:vibe-opus-scorer:VibeScorer:3:codex-gpt-5.5-medium:vibe"
+  "factChecker:fact-checker:fact-checker:FactChecker:2:factCheck"
+  "librarian:librarian:librarian:Librarian:2:librarian"
+  "freshEyes:fresh-eyes:fresh-eyes:FreshEyes:2:freshEyes"
+  "vibe:vibe-opus-scorer:vibe-opus-scorer:VibeScorer:3:vibe"
 )
 
 for stage_def in "${STAGES[@]}"; do
-  IFS=':' read -r stage_key agent_name validate_name label max_loops runner_label fm_judge_key <<< "$stage_def"
+  IFS=':' read -r stage_key agent_name validate_name label max_loops fm_judge_key <<< "$stage_def"
 
   if [ -n "$ONLY_STAGE" ] && [ "$stage_key" != "$ONLY_STAGE" ]; then
     tlog "  Skipping stage '$label' due to --only-stage=$ONLY_STAGE."
@@ -1021,7 +1030,7 @@ for stage_def in "${STAGES[@]}"; do
   stage_rc=0
   run_stage \
     "$stage_key" "$agent_name" "$validate_name" "$label" \
-    "$max_loops" "$runner_label" "$POST_FILE" "$fm_judge_key" || stage_rc=$?
+    "$max_loops" "$POST_FILE" "$fm_judge_key" || stage_rc=$?
   if [ "$stage_rc" -eq 70 ]; then
     tlog "=== RUNNER ERROR at stage: $label ==="
     commit_progress "tribunal(${POST_FILE%.mdx}): RUNNER_ERROR at $label stage"


### PR DESCRIPTION
Fixes #405

## 問題

PR #403 把 **reader-visible frontmatter** 的 `model` 欄做成 provider-aware（`tribunal_llm_model_id` 動態解析：codex→`gpt-5.5`、claude→per-agent build），但**內部 progress ledger 還沒跟上**：`scripts/tribunal.sh` 的 `STAGES` 把每個 stage 的 `runner_label` 寫死成 `codex-gpt-5.5-medium`，而 `write_stage_progress` 把這個 label 當成 `model` 欄寫進 `.score-loop/state/tribunal-progress.json`。

結果：claude 在 CCC 跑 tribunal 時，frontmatter 誠實標 claude、但 progress ledger 仍記 `codex-gpt-5.5-medium`。內外不一致——之後拿 ledger 做 calibration 分析或稽核，會把 claude-scored 的 run 誤算成 codex run。

## 做法

新增 `tribunal_runner_label()` helper（`scripts/tribunal-helpers.sh`），跟 frontmatter `model_id` **共用同一套 provider 判定**（`tribunal_llm_provider` + `tribunal_llm_model_id`），不長第二套邏輯：

- **codex** → `codex-gpt-5.5-medium`（byte-for-byte 不變，VPS/mac calibration 連續性）
- **claude** → 判官宣告的 Claude build（與 frontmatter `model_id` 對稱，例如 `claude-opus-4-6[1m]`）

`STAGES` 移除靜態 `runner_label` 欄（從 7 欄縮成 6 欄），`run_stage` 內部在 resolve `model_id` 旁邊一起 resolve `runner_label`。`runner_label` 同時餵 stage log（`=== Stage X (label) ===`）、progress、runner-error 記錄，全部跟著一致。

`scripts/tests/test-tribunal-safety-contract.sh` 加 4 條斷言鎖住 provider-aware 行為（helper 存在、codex 仍重建 `codex-gpt-5.5-medium`、`run_stage` 走 helper、STAGES 不再有靜態欄），防止 refactor 退回靜態字串。PR #403 既有的 model-pin 契約（codex pin gpt-5.5 + provider-aware resolver）原封不動。

## 硬約束對照

- ✅ codex 在時 progress ledger byte-for-byte 不變（stub 驗證見下）
- ✅ 跟 PR #403 frontmatter `model_id` 同一個解析來源，無第二套 provider 判定
- ✅ safety-contract 斷言更新，沒回退 model-pin 契約
- ✅ 全程無 `--no-verify`，pre-commit / pre-push 全綠

## 驗收實測（CCC 沙箱，codex 缺席 → claude fallback）

跑 `bash scripts/tribunal.sh --score-only --only-stage vibe sp-1-20260128-demo.mdx`，progress ledger 該文 vibe stage 記：

```json
{
  "status": "in_progress",
  "score": null,
  "model": "claude-opus-4-6[1m]",
  "attempts": 1,
  "tribunalVersion": 8
}
```

`model` 是誠實的 **claude** build，不再是 `codex-gpt-5.5-medium`。（`model` 欄在每次 `write_stage_progress`（in_progress/pass/fail）都用同一個 `$runner_label`；為省 quota 在 in_progress 寫入後就停掉判官。）

stage log 也同步：`=== Stage VibeScorer (claude-opus-4-6[1m]) | max_loops=3 ===`

helper 兩條路直測：

| provider | `tribunal_runner_label` 輸出 |
|---|---|
| claude (本沙箱真實) | `claude-opus-4-6[1m]` |
| codex (stub) | `codex-gpt-5.5-medium`（4 個 stage 全一致，byte-for-byte） |

## 測試

- `test-tribunal-safety-contract.sh` ✅（含新斷言）
- `test-tribunal-runner-error-guard.sh` ✅（codex fixture 仍對齊）
- `test-tribunal-progress-ledger-migration.sh` ✅

---
_Generated by [Claude Code](https://claude.ai/code/session_01JnRHDHxfCwTiA7ysNAShNy)_