### PR TITLE
chore(quality): rebaseline bundle budget + local pre-push warning-only

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -53,13 +53,18 @@ if [ $? -ne 0 ]; then
   exit 1
 fi
 
-# 2. Bundle budget check (check-only; must not write git working tree files)
-#    Blocking budgets fail the push; trend alerts are warnings only.
-echo "📦 Checking bundle budgets (blocking + trend monitor)..."
-node scripts/bundle-budget-check.mjs
-if [ $? -ne 0 ]; then
-  echo "❌ Blocking bundle budget violation detected! Push aborted."
-  exit 1
+# 2. Bundle budget check (LOCAL = warning-only; CI is the blocking authority)
+#    Local dist can be stale/incremental, which inflates the aggregate JS+CSS
+#    sum and produces false blocks. The CI `bundle-budget` job runs the same
+#    check against a clean build artifact and IS allowed to fail the PR (see #396).
+#    Do NOT re-add `exit 1` here — that reintroduces the false-block that forced
+#    --no-verify on every push.
+echo "📦 Checking bundle budgets (local: warning-only; CI enforces on a clean build)..."
+if ! node scripts/bundle-budget-check.mjs; then
+  echo "⚠️  Local bundle budget check flagged a violation — NOT blocking the push."
+  echo "   Likely a stale/incremental dist false positive. CI checks a clean build."
+  echo "   If CI's bundle-budget job also fails, shrink the bundle or rebaseline"
+  echo "   quality/bundle-budget.json."
 fi
 
 # 2. Coverage ratchet (only if tests can run quickly)

--- a/quality/bundle-budget.json
+++ b/quality/bundle-budget.json
@@ -2,29 +2,29 @@
   "version": 2,
   "blocking": {
     "global": {
-      "jsMaxKB": 80,
-      "cssMaxKB": 65,
+      "jsMaxKB": 90,
+      "cssMaxKB": 120,
       "singleFileMaxKB": 300
     }
   },
   "trend": {
     "global": {
       "totalKB": {
-        "warnAtKB": 140000,
-        "criticalAtKB": 180000,
+        "warnAtKB": 200000,
+        "criticalAtKB": 240000,
         "growth": {
-          "warnPct": 3,
-          "criticalPct": 8,
-          "minDeltaKB": 250
+          "warnPct": 5,
+          "criticalPct": 12,
+          "minDeltaKB": 2000
         }
       },
       "htmlKB": {
-        "warnAtKB": 130000,
-        "criticalAtKB": 170000,
+        "warnAtKB": 185000,
+        "criticalAtKB": 220000,
         "growth": {
-          "warnPct": 3,
-          "criticalPct": 8,
-          "minDeltaKB": 250
+          "warnPct": 5,
+          "criticalPct": 12,
+          "minDeltaKB": 2000
         }
       }
     },
@@ -85,5 +85,5 @@
       }
     }
   },
-  "comment": "Level 5 / Plan C: JS-CSS budgets are blocking; HTML/total and key routes are trend monitors (non-blocking alerts)."
+  "comment": "Level 5 / Plan C: JS-CSS budgets are blocking; HTML/total and key routes are trend monitors (non-blocking alerts). Rebaselined 2026-06-12 (#396): clean build at 3087 routes was JS 52KB / CSS 64.91KB (CSS razor-thin vs old 65 cap, blocking every CSS change); aggregate KB scales with content count, so headroom set for ~2 quarters of growth. CI bundle-budget job (clean dist artifact) is the blocking authority; local pre-push is warning-only because incremental/stale dist inflates the JS-CSS sum and produces false blocks."
 }

--- a/quality/bundle-size-history.json
+++ b/quality/bundle-size-history.json
@@ -1131,5 +1131,28 @@
     "otherKB": 10558.96,
     "fileCount": 2809,
     "passed": true
+  },
+  {
+    "date": "2026-06-12T11:39:43.745Z",
+    "totalKB": 174682.81,
+    "jsKB": 52.49,
+    "cssKB": 64.91,
+    "htmlKB": 155255.55,
+    "imgKB": 1752.39,
+    "otherKB": 17557.46,
+    "fileCount": 4181,
+    "routeCount": 3087,
+    "routes": {
+      "/": 40.69,
+      "/en/": 36.85,
+      "/clawd-picks/": 0.32,
+      "/en/clawd-picks/": 0.34,
+      "/shroomdog-picks/": 46.48,
+      "/level-up/": 34.98
+    },
+    "blockingPassed": true,
+    "trendWarningCount": 0,
+    "trendCriticalCount": 2,
+    "passed": true
   }
 ]

--- a/scripts/bundle-budget-check.mjs
+++ b/scripts/bundle-budget-check.mjs
@@ -240,6 +240,17 @@ const trendWarningCount = trendAlerts.filter((a) => a.severity === 'warning').le
 
 // 6. Optional: append to history only in --record mode
 if (isRecordMode) {
+  // Only persist the routes that are actually trend-monitored. Recording all
+  // ~3000 dist routes balloons the committed history file by ~150 KB per
+  // nightly entry; the route trend rules only ever read the keys below.
+  const monitoredRoutes = Object.keys(budget.trend?.routes ?? {});
+  const allRoutes = sizes.routes ?? {};
+  const recordedRoutes = Object.fromEntries(
+    monitoredRoutes
+      .filter((routePath) => routePath in allRoutes)
+      .map((routePath) => [routePath, allRoutes[routePath]])
+  );
+
   const historyEntry = {
     date: new Date().toISOString(),
     totalKB: sizes.totalKB,
@@ -250,7 +261,7 @@ if (isRecordMode) {
     otherKB: sizes.otherKB,
     fileCount: sizes.fileCount,
     routeCount: sizes.routeCount,
-    routes: sizes.routes ?? {},
+    routes: recordedRoutes,
     blockingPassed: blockingViolations.length === 0,
     trendWarningCount,
     trendCriticalCount,

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -53,13 +53,18 @@ if [ $? -ne 0 ]; then
   exit 1
 fi
 
-# 2. Bundle budget check (check-only; must not write git working tree files)
-#    Blocking budgets fail the push; trend alerts are warnings only.
-echo "📦 Checking bundle budgets (blocking + trend monitor)..."
-node scripts/bundle-budget-check.mjs
-if [ $? -ne 0 ]; then
-  echo "❌ Blocking bundle budget violation detected! Push aborted."
-  exit 1
+# 2. Bundle budget check (LOCAL = warning-only; CI is the blocking authority)
+#    Local dist can be stale/incremental, which inflates the aggregate JS+CSS
+#    sum and produces false blocks. The CI `bundle-budget` job runs the same
+#    check against a clean build artifact and IS allowed to fail the PR (see #396).
+#    Do NOT re-add `exit 1` here — that reintroduces the false-block that forced
+#    --no-verify on every push.
+echo "📦 Checking bundle budgets (local: warning-only; CI enforces on a clean build)..."
+if ! node scripts/bundle-budget-check.mjs; then
+  echo "⚠️  Local bundle budget check flagged a violation — NOT blocking the push."
+  echo "   Likely a stale/incremental dist false positive. CI checks a clean build."
+  echo "   If CI's bundle-budget job also fails, shrink the bundle or rebaseline"
+  echo "   quality/bundle-budget.json."
 fi
 
 # 2. Coverage ratchet (only if tests can run quickly)

--- a/tests/hooks-integration.test.ts
+++ b/tests/hooks-integration.test.ts
@@ -94,8 +94,8 @@ describe('pre-push: PENDING ticketId guard (Step 0)', () => {
       encoding: 'utf-8',
     });
     // Should not crash on PENDING gate (it only checks pushes targeting main).
-    // The bundle-budget step at the end may exit non-zero in environments
-    // without the metric files; we just assert PENDING gate didn't fire.
+    // The bundle-budget step is warning-only locally (#396) so it won't fail the
+    // hook; we just assert the PENDING gate didn't fire.
     expect(r.stdout + r.stderr).not.toMatch(/PENDING ticketId in commits/);
   });
 


### PR DESCRIPTION
Fixes #396

## 問題（三層）

1. **CSS 預算貼地**：clean 3087-route build 的 CSS 是 **64.91 KB**，blocking 上限卻是 **65 KB** — 只剩 0.09 KB headroom，任何 CSS 改動都爆 gate，逼出 `--no-verify`（違反 repo 第一鐵則）。
2. **本機 dirty dist 誤報**：aggregate JS+CSS sum 會被殘留的舊 hash 檔灌大。issue 看到的 CSS 129.83 KB 正是 stale/incremental dist 造成的假性超標，不是真的 bloat（clean build 重跑只有 64.91）。
3. **history 基準停在 2026-03-24**：趨勢 % 全失真 — 三個月累積的成長被當成一次 critical 跳變（+74%）。

## 改動（3 個 atomic commit）

| commit | 做什麼 |
|---|---|
| `rebaseline thresholds` | blocking JS 80→90、CSS 65→**120**（clean 值 + ~2 季成長空間）；total/html trend 門檻與 growth delta 一併上調，讓 monitor 只對真實跳變報警 |
| `refresh history baseline` | 用 `--record` 補一筆 clean-build 基準，趨勢監測恢復意義。**順手修**：原本 `--record` 會把全部 ~3000 條 route 寫進 history（每筆 +150 KB），改成只存 6 條被監控的 route（history 檔 175 KB → 23 KB） |
| `pre-push warning-only` | 本機 pre-push 的 bundle 檢查改成 **warning-only**（不再 `exit 1`），因為本機 dist 狀態不可靠。CI 的 `bundle-budget` job 抓 **clean build artifact** 跑同一支檢查、**維持 blocking** → gate 沒被拿掉,只是移到 build 乾淨的地方 |

對應 issue 的三條建議：重訂預算 ✅、`--record` 更新基準 ✅、CI 用乾淨 build 把關 + 本機 warning-only ✅。

## 實測

```
clean build (3087 routes) → JS 52.49 KB / CSS 64.91 KB
node scripts/bundle-budget-check.mjs
  ✅ Blocking budgets passed (JS/CSS + single-file checks).
  ✅ Trend monitors: no warnings.   (record 新基準後成長率歸零)
```

- `pnpm exec vitest run tests/hooks-integration.test.ts` → 6 passed
- pre-push 實跑：bundle 步驟印 warning-only 訊息、不 abort，push 通過
- 兩份 hook（`.githooks/pre-push` + `scripts/hooks/pre-push`）保持一致，drift guard 過；active `.git/hooks/pre-push` 已重新 sync 成 canonical

## 設計權衡

- 沒有把 gate「關掉」。CI（clean build）仍是 blocking authority；只把本機那層不可靠的 blocking 降成 warning，符合 issue 的建議方向。
- aggregate JS+CSS sum 會隨內容量線性成長(本質上不是使用者單頁下載量)，但這次採務實做法：保留 aggregate blocking + 給足 headroom + trend monitor 預警,沒有重寫成 per-page 量度(那是更大的 scope，且非 issue 必需)。


---
_Generated by [Claude Code](https://claude.ai/code/session_01XBQmQoyKbcJKTAnmpsghrC)_