### PR TITLE
fix(tribunal): unblock in-process judges under root/CCC (#123)

### DIFF
--- a/playbooks/CCC-playbook.md
+++ b/playbooks/CCC-playbook.md
@@ -108,9 +108,9 @@ Vercel build / tribunal / validate-posts / CI 沒過：
 
 **PR 動到 `src/content/posts/*.mdx`（新增 SP/CP/SD/Lv，或實質改寫既有文章）→ 四評審必跑，結果必記錄。沒跑完不開 PR，跑完 FAIL 不 merge。**
 
-**首選**：`scripts/tribunal-batch-runner.sh` 或 `gp-pipeline ralph` 自動跑完四審 + rewrite + 寫 frontmatter scores。
+**首選**：`scripts/tribunal-batch-runner.sh` 或 `gp-pipeline ralph` 自動跑完四審 + rewrite + 寫 frontmatter scores。**這條在 CCC（root sandbox）現在可以原生跑**——`tribunal_claude_exec`（shell judges）和 Go `ClaudeProvider.Run`（pipeline）在 `id -u == 0` 時自動：(1) 用 `acceptEdits` 取代被 CLI 拒絕的 `bypassPermissions`，(2) 補 `--allowed-tools Read,Grep,Glob,Bash,Write,Edit,MultiEdit` 讓 judge Read 文章檔時不會卡 permission prompt，(3) prompt 走 stdin 避免 variadic 旗標吞掉內文。實測 `bash scripts/tribunal.sh --score-only --only-stage vibe <post>` 在 CCC 端到端 PASS（#123）。
 
-**沙箱 fallback**（`gp-pipeline ralph` / `scripts/vibe-scorer.sh` 的 subprocess 在 CCC 沒跑起來時——現在 `id -u` 下已自動 drop `--dangerously-skip-permissions` / `--permission-mode bypassPermissions`，理論上跑得起，但 subprocess 有可能讀 CLAUDE.md 卡在 permission wait；真的卡住再走這條）：**CCC 自己用 `Agent` tool 一次 spawn 四個 subagent 平行跑**，對應 `.claude/agents/`：
+**沙箱 fallback**（只有上面 shell/pipeline 路真的壞掉時才用——例如 quota 用盡、CLI 版本回歸）：**CCC 自己用 `Agent` tool 一次 spawn 四個 subagent 平行跑**，對應 `.claude/agents/`：
 
 - `vibe-opus-scorer.md`（Opus）→ persona / clawdNote / vibe / clarity / narrative
 - `fact-checker.md`（Opus）→ accuracy / fidelity / consistency（要 WebFetch 驗 sourceUrl）
@@ -190,8 +190,8 @@ tools/sp-pipeline/gp-pipeline run <url> --force
 
 不是因為沒網路、也不是因為 auth 不到——2026-04-23 實測：
 - **Auth OK**：CCC 有 `CLAUDE_CODE_OAUTH_TOKEN_FILE_DESCRIPTOR`，`claude -p` subprocess 可以認證完成並回應
-- **`--permission-mode bypassPermissions` / `--dangerously-skip-permissions` 在 root 會被 CLI 直接拒**。`gp-pipeline` 的 `ClaudeProvider.Run` 和 shell judges（tribunal-all-claude.sh / vibe-scorer.sh）已經都在 `id -u == 0` 時自動把這 flag drop 掉，所以這層不再是 blocker
-- **但 drop 掉 bypass flag 之後，subprocess 會用 default permission mode** → 讀 CLAUDE.md、auto-discover cwd、試圖做 context-aware 的事；短 prompt（例如 doctor 的 1-token canary）容易被誤判成「我該去幫你改 repo」然後卡在 permission wait，30s 後 timeout。長的 creative prompt（write / review / refine）比較不會，因為 task is the prompt, not the repo
+- **`--permission-mode bypassPermissions` / `--dangerously-skip-permissions` 在 root 會被 CLI 直接拒**。`gp-pipeline` 的 `ClaudeProvider.Run` 和 shell judges（`tribunal-helpers.sh` 的 `tribunal_claude_exec`，`vibe-scorer.sh` / `tribunal-all-claude.sh` 現在只是 → `tribunal.sh` 的 deprecated wrapper）都在 `id -u == 0` 時自動把這 flag 換成 `acceptEdits`，所以這層不再是 blocker
+- **`acceptEdits` 只自動核准 edit，judge / stage 要 Read 文章檔時還是會卡 permission prompt**（`</dev/null`/stdin 無 TTY → 靜默 hang，原本 #123 的 30s timeout 就是這個）。修法：root 下同時補 `--allowed-tools Read,Grep,Glob,Bash,Write,Edit,MultiEdit`，把 judge 會用到的工具顯式 allowlist 掉（等於用比 bypassPermissions 更窄的清單複製「不 prompt」行為）；prompt 一律走 stdin，避免 variadic 的 `--allowed-tools` 把 prompt 內文當成 tool 規則吞掉。修完實測單篇 vibe stage 在 CCC PASS（composite=8）
 - **Long creative generation 本身還會踩 stream idle timeout**（見本檔下方「Stream idle timeout 應對」那一節）
 
 真正要 fallback 的時候怎麼走：

--- a/scripts/tribunal-helpers.sh
+++ b/scripts/tribunal-helpers.sh
@@ -479,19 +479,34 @@ $REPO_ROOT
 $user_prompt
 PROMPT
 )"
-  local model timeout_sec claude_cmd perm
+  local model timeout_sec claude_cmd
   model="$(tribunal_claude_agent_model "$agent_name")"
   timeout_sec="${TRIBUNAL_CODEX_TIMEOUT_SEC:-3600}"
   claude_cmd="$(tribunal_claude_cmd)" || return 127
+  # Permission handling differs by uid:
+  #  - non-root (mac/VPS): bypassPermissions never prompts — judge runs free.
+  #  - root (CCC sandbox): claude *rejects* bypassPermissions, so we fall back to
+  #    acceptEdits. But acceptEdits only auto-approves *edits*; the judge task
+  #    passes the post as a PATH (not inlined), so the judge must Read it — which
+  #    prompts for permission and then hangs forever against the </dev/null
+  #    stdin. We therefore pre-approve the read/search/compute/write tools a judge
+  #    actually uses via --allowed-tools, reproducing the non-root "never prompt"
+  #    behavior with an explicit, narrower allowlist (no MCP, no network). Tools
+  #    are comma-joined into a single arg so the variadic flag can't swallow the
+  #    trailing "$prompt" positional.
+  #    --allowed-tools is variadic, so we must NOT leave a trailing positional
+  #    after it or the flag swallows the prompt text as bogus tool rules. Feed
+  #    the prompt on stdin (claude -p reads stdin when no positional prompt is
+  #    given) so the allowlist token is the last arg with nothing to consume.
+  local -a perm_args
   if [ "$(id -u)" = "0" ]; then
-    perm="acceptEdits"
+    perm_args=(--permission-mode acceptEdits --allowed-tools "Read,Grep,Glob,Bash,Write,Edit,MultiEdit")
   else
-    perm="bypassPermissions"
+    perm_args=(--permission-mode bypassPermissions)
   fi
   (
     cd "$work_dir"
-    exec </dev/null
-    timeout "$timeout_sec" "$claude_cmd" -p --model "$model" --permission-mode "$perm" "$prompt"
+    printf '%s' "$prompt" | timeout "$timeout_sec" "$claude_cmd" -p --model "$model" "${perm_args[@]}"
   )
 }
 

--- a/tools/sp-pipeline/internal/llm/claude.go
+++ b/tools/sp-pipeline/internal/llm/claude.go
@@ -83,7 +83,18 @@ func (c *ClaudeProvider) Run(ctx context.Context, prompt string, opts RunOptions
 	if os.Geteuid() != 0 {
 		args = append(args, "--permission-mode", "bypassPermissions")
 	} else {
-		args = append(args, "--permission-mode", "acceptEdits")
+		// Root (CCC): bypassPermissions is rejected, so fall back to
+		// acceptEdits. acceptEdits only auto-approves *edits*, so any stage
+		// that Reads a file would hit a permission prompt and hang forever on
+		// the non-interactive stdin. Pre-approve the read/search/compute/write
+		// tools a stage can use via --allowed-tools — the explicit, narrower
+		// equivalent of the non-root bypassPermissions "never prompt" behavior.
+		// Prompt goes on stdin (below), so this trailing variadic flag has no
+		// positional to swallow.
+		args = append(args,
+			"--permission-mode", "acceptEdits",
+			"--allowed-tools", "Read,Grep,Glob,Bash,Write,Edit,MultiEdit",
+		)
 	}
 	res, err := runner.RunWithOptions(ctx, runner.Options{
 		Name:    "claude",


### PR DESCRIPTION
Fixes #123

## TL;DR

#123 的硬 blocker（root + `bypassPermissions` 被 CLI 秒拒）其實在後續重構（`66e18d7`）已修；但修法只把 flag 換成 `acceptEdits`，留下一個**更隱蔽的 hang**：judge 要 Read 文章檔時跳 permission prompt、在 `</dev/null` 無 TTY 下靜默卡死（這就是 #123 原本看到的 30s timeout 換了個樣子）。這個 PR 補完最後一哩，讓 in-process tribunal 在 CCC **原生跑得起來**。

## 根因

tribunal judge 的任務是「Score this post: `<絕對路徑>`」——文章是**路徑不是 inline**，judge 必須 `Read` 它。
- `bypassPermissions`（非 root）→ 什麼都不 prompt ✅
- root 下 CLI 拒 `bypassPermissions` → fallback `acceptEdits`，但它**只自動核准 edit**。Write score JSON 過，**Read 文章 → prompt → hang** ❌

## 修法（3 commit）

| commit | 內容 |
|---|---|
| `fix(tribunal)` | `tribunal_claude_exec` 在 `id -u == 0` 時，除 `acceptEdits` 外補 `--allowed-tools Read,Grep,Glob,Bash,Write,Edit,MultiEdit`（用比 bypassPermissions 更窄的顯式 allowlist 複製「不 prompt」行為）；prompt 改走 **stdin**，避免 variadic 的 `--allowed-tools` 把 prompt 內文吞成 tool 規則 |
| `fix(sp-pipeline)` | Go `ClaudeProvider.Run` 同根因 hardening：root 下補一樣的 allowlist（prompt 本來就走 stdin），防 pipeline stage 讀檔時 hang |
| `docs(ccc-playbook)` | in-process tribunal 從「理論上跑得起、可能卡」改成「已修、實證可跑」；Agent-tool 四 subagent 降為真正的 last-resort fallback；更新過期腳本名 |

## 實測（在 CCC root sandbox）

```
$ bash scripts/tribunal.sh --score-only --only-stage vibe sp-219-...mdx
  Provider: codex absent — using Claude fallback (CCC sandbox)
  === Stage VibeScorer (claude-opus-4-6[1m]) ===
  VibeScorer result: composite=8 agent_verdict=PASS
  PASS: VibeScorer passed on attempt 1
EXIT=0   # ~2.5 min（正常 Opus 延遲，不再 hang）
```

修前同一指令 → 360s timeout（Read 卡 permission）。修後端到端 PASS。

- `go build ./... && go test ./internal/llm/` 綠、`gp-pipeline doctor` healthy
- `bash -n` 語法檢查過、pre-commit / pre-push 全綠（無 `--no-verify`）

## 為什麼這樣修而不是改 sandbox infra

issue 列了 5 個方向；這條（顯式 allowlist）是最 portable、不動 container infra、對非-root 零影響的解。`acceptEdits` 已是 CLI 在 root 下唯一放行的非互動模式，補 allowlist 把它從「只能寫」擴成「judge 該用的都能用」，等於在 CLI 允許的範圍內重建 bypassPermissions 的非互動性。


---
_Generated by [Claude Code](https://claude.ai/code/session_01XBQmQoyKbcJKTAnmpsghrC)_