### PR TITLE
chore(ccc): SessionStart 背景非同步補 Playwright chromium

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -16,7 +16,8 @@ fi
 
 cd "${CLAUDE_PROJECT_DIR:-.}" || exit 0
 
-# --fix 會補 deps（node_modules 缺才裝）+ 掛 git hooks，全程 idempotent。
+# --fix 會補 deps（node_modules 缺才裝）+ 掛 git hooks + 背景非同步下載
+# Playwright chromium（CCC sandbox 不預裝，~100MB，不擋開場），全程 idempotent。
 # smoke test 任何 check 沒過會 exit 1，但 SessionStart 不該因此卡住 session，
 # 所以吞掉非零 exit——report 已經印出來，agent 開場自己會看到要修什麼。
 bash scripts/ccc-smoke-test.sh --fix || true

--- a/playbooks/CCC-playbook.md
+++ b/playbooks/CCC-playbook.md
@@ -330,6 +330,21 @@ git log --oneline -5              # 看 branch 最近在幹嘛
 
 然後看 task description 決定要做什麼。
 
+### Fresh-env friction：系統性收斂，不要每個 session 重踩
+
+**CCC 每次都是全新 sandbox（fresh clone，啥都沒裝）。任何「每個 session 都會重複踩」的環境 friction，正確解法是把它收進 SessionStart hook（`.claude/hooks/session-start.sh` → `scripts/ccc-smoke-test.sh --fix`），不是這個 session 手動補一次了事。** 手動補 = 下個 CCC 在新 sandbox 又從零踩一次，等於把 friction 留給下一個 agent——違反「絕不甩鍋給下個 session」最高原則。
+
+判斷準則：**friction 是不是「換個 sandbox 還會再發生」？** 是 → 進 hook。只發生在這個 task 的一次性問題（某篇文章 frontmatter 寫錯）→ 當場修就好，不用進 hook。
+
+收進 hook 的兩種模式：
+
+- **同步補**（快、且開工前就需要）：deps（`pnpm install`）、git hooks（`setup-hooks`）、sp-pipeline 自編譯。放 `--fix` 區塊直接跑完，smoke test 順便驗。
+- **非同步背景補**（慢、下載大、不是開工就馬上要）：Playwright chromium binary（~100MB，uiux-auditor / playwright-cli / verify 才要）。`--fix` 用 `nohup … & disown` 丟背景，**不擋 session 開場**，等真的要截圖時通常已下載好。Smoke test 另開一個 optional readiness check（warn 不擋 exit）回報「裝好了 / 還在下載 / 沒裝」，讓 agent 知道現在能不能截圖。
+
+  Playwright 就是這個模式的範本（2026-06-12 加）：`ccc-smoke-test.sh --fix` 在 `CLAUDE_CODE_REMOTE=true` 時，偵測 `${PLAYWRIGHT_BROWSERS_PATH:-~/.cache/ms-playwright}` 沒有 chromium 快取就背景下載，idempotent（已裝或已在下載就跳過），只在 CCC 跑（mac-CC 自己管 local Playwright）。所以「Playwright 沒裝」這個 friction 對之後的 CCC 不該再發生——醒來時背景已經在補了。
+
+**鐵則：撞到新的 recurring env friction → 在同一個 PR 把它收進 hook，當場消滅，別只修這次。** 這跟 CLAUDE.md「主任務踩到的 bug 順手修在同一個 PR」是同一條精神，只是套用在環境層：hook 是 CCC fresh-env friction 的 SSOT，能進 hook 的就別留在 per-session 手動步驟。
+
 ## 不確定時找誰
 
 - **技術決策不確定**：用 `AskUserQuestion` 問 user，但要先把問題想清楚、給選項

--- a/scripts/ccc-smoke-test.sh
+++ b/scripts/ccc-smoke-test.sh
@@ -73,6 +73,28 @@ if $FIX; then
   fi
   bash scripts/setup-hooks.sh >/tmp/ccc-smoke-hooks.log 2>&1 \
     && pass "setup-hooks" || fail "setup-hooks" "see /tmp/ccc-smoke-hooks.log"
+
+  # Playwright chromium：CCC sandbox 不預裝瀏覽器 binary（npm 的 playwright 套件
+  # 有，但 ~/.cache/ms-playwright 是空的），uiux-auditor / playwright-cli / verify
+  # 第一次要截圖就卡「Executable doesn't exist」。在背景非同步補下載（~100MB），
+  # 不擋 session 開場；等真的要截圖時通常已經裝好。只在 CCC（remote）跑——mac-CC
+  # 自己管 local Playwright，不要在 user 的 Mac 偷下載。Idempotent：已有 chromium
+  # 快取就跳過，不重複下載。
+  if [ "${CLAUDE_CODE_REMOTE:-}" = "true" ]; then
+    PW_CACHE="${PLAYWRIGHT_BROWSERS_PATH:-$HOME/.cache/ms-playwright}"
+    if ls "$PW_CACHE"/chromium-* >/dev/null 2>&1; then
+      pass "Playwright chromium 已存在，跳過下載"
+    elif pgrep -f "playwright install chromium" >/dev/null 2>&1; then
+      pass "Playwright chromium 已有背景下載在跑，不重複觸發"
+    elif [ -x node_modules/.bin/playwright ]; then
+      nohup node_modules/.bin/playwright install chromium \
+        >/tmp/ccc-playwright-install.log 2>&1 &
+      disown 2>/dev/null || true
+      pass "Playwright chromium 背景下載中 (pid $!; log: /tmp/ccc-playwright-install.log)"
+    else
+      warn "Playwright bin 不在 node_modules" "pnpm install 完成後重跑 --fix 會補"
+    fi
+  fi
 fi
 
 # ── 1. 身份 ───────────────────────────────────────────────────────
@@ -167,9 +189,23 @@ else
   fail "sp-pipeline doctor 失敗 (exit $?)" "see /tmp/ccc-smoke-doctor.log"
 fi
 
-# ── 9. 慢 gate（--full 才跑）─────────────────────────────────────
+# ── 9. Playwright browser（optional，給 UI 工作用）────────────────
+# uiux-auditor / playwright-cli / verify 需要 chromium binary。CCC sandbox 不
+# 預裝，--fix 會在背景補下載。這裡只回報狀態（warn 不擋 exit），讓 agent 開場
+# 就知道現在能不能截圖、還是要再等一下背景下載。
+section "9. Playwright browser"
+PW_CACHE="${PLAYWRIGHT_BROWSERS_PATH:-$HOME/.cache/ms-playwright}"
+if ls "$PW_CACHE"/chromium-* >/dev/null 2>&1; then
+  pass "chromium 已裝 ($PW_CACHE)"
+elif pgrep -f "playwright install chromium" >/dev/null 2>&1; then
+  warn "chromium 背景下載中" "稍候再用 uiux-auditor / playwright-cli；log: /tmp/ccc-playwright-install.log"
+else
+  warn "chromium 未裝" "UI 工作前先跑 'node_modules/.bin/playwright install chromium'（或 --fix 在 CCC 會自動背景補）"
+fi
+
+# ── 10. 慢 gate（--full 才跑）────────────────────────────────────
 if $FULL; then
-  section "9. 慢 gate (--full)"
+  section "10. 慢 gate (--full)"
   if [ -d node_modules ]; then
     pnpm run lint >/tmp/ccc-smoke-lint.log 2>&1 \
       && pass "eslint" || fail "eslint" "see /tmp/ccc-smoke-lint.log"


### PR DESCRIPTION
## 為什麼

CCC 每次都是全新 sandbox，Playwright 瀏覽器 binary 沒預裝（npm 的 `playwright` 套件有，但 `~/.cache/ms-playwright` 是空的）。`uiux-auditor` / `playwright-cli` / `verify` 第一次要截圖就卡「Executable doesn't exist」——這個 friction **每個 CCC session 都會重踩一次**（這個 session 寫 SP-222 時就踩到了）。

正確解法不是「這個 session 手動 `npx playwright install chromium` 一次了事」（下個 sandbox 又從零踩），而是收進 SessionStart hook，讓它對之後的 CCC 不再發生。

## 改了什麼

- **`scripts/ccc-smoke-test.sh` `--fix`**：`CLAUDE_CODE_REMOTE=true` 時偵測 `${PLAYWRIGHT_BROWSERS_PATH:-~/.cache/ms-playwright}` 沒有 chromium 快取 → `nohup … & disown` 背景下載（~100MB），**不擋 session 開場**。Idempotent：已裝或已有背景下載在跑就跳過。只在 CCC 跑——mac-CC 自己管 local Playwright，不在 user 的 Mac 偷下載。
- **新增 optional readiness check（section 9）**：warn 不擋 exit，回報「裝好了 / 背景下載中 / 沒裝」，讓 agent 開場就知道現在能不能截圖。
- **`CCC-playbook.md`**：新增「Fresh-env friction：系統性收進 hook」原則——recurring env friction 進 hook（同步補 vs 非同步背景補兩種模式），一次性問題當場修。把 Playwright 當範本。
- **`session-start.sh`**：註解同步更新。

## 驗證

- `bash -n` 語法過、pre-commit 全綠。
- 模擬 CCC + chromium 已存在 → 正確走「跳過下載」分支，不誤觸發。
- readiness check 正確處理 `PLAYWRIGHT_BROWSERS_PATH` override。

https://claude.ai/code/session_01K4ZrmYXoDRTLjmP98suuJ4

---
_Generated by [Claude Code](https://claude.ai/code/session_01K4ZrmYXoDRTLjmP98suuJ4)_