### PR TITLE
feat(sp-pipeline): route Mac writer through Opus alias

### DIFF
--- a/playbooks/CCC-playbook.md
+++ b/playbooks/CCC-playbook.md
@@ -197,23 +197,24 @@ tools/sp-pipeline/gp-pipeline run <url> --force
 真正要 fallback 的時候怎麼走：
 
 1. `gp-pipeline fetch <url>` 先把 source 抓下來（這步幾乎不會炸）
-2. 單獨跑 prompt：`claude -p --model "claude-opus-4-6[1m]" "<prompt>"` 模擬 write / review / refine 各階段（**在 CCC root 下不要加 `--permission-mode` 也不要加 `--dangerously-skip-permissions`，會被擋**）
+2. 單獨跑 prompt：`claude -p --model opus "<prompt>"` 模擬 write / refine 階段（**在 CCC root 下不要加 `--permission-mode` 也不要加 `--dangerously-skip-permissions`，會被擋**）。review / eval / tribunal judges 仍走 Codex GPT-5.5；只有沒有 `codex` 的 CCC fallback 才用 Claude。
 3. tribunal 改用本 playbook「Tribunal 必跑規則」那段的 4 個 subagent 平行跑
 
-**`--model` 一定要帶 `claude-opus-4-6[1m]`**——不能用 `opus` alias（會跑到 4.7）。理由見下一段。
+**SP writer 在 Mac pipeline 使用 `opus` alias**，讓 Anthropic 更新 Opus 時自動跟上。pipeline 會從 Claude Code JSON metadata 讀回實際 model，frontmatter 寫具體版本（例如 `Opus 4.8`），不是把 alias 原樣端給讀者。
 
-### 模型鎖定（SP writer + Vibe scorer 不准用 4.7）
+### 模型路由（Mac writer + Codex judges）
 
-Maintainer 明確拒絕 Opus 4.7 的寫作聲音 + vibe 評分校準。因此：
+2026-06-13 更新：Claude 在 VM/CCC 上不作為主要 runtime；VM 是 Codex GPT-5.5 的地盤。Mac pipeline 的分工如下：
 
-- **SP writer**（`tools/sp-pipeline/internal/llm/claude.go` 的 `ClaudeOpusPinned`）→ 鎖 `claude-opus-4-6[1m]`
+- **SP writer / refine**（`tools/sp-pipeline/internal/llm/claude.go` 的 `ClaudeOpusAlias`）→ `opus` alias，runtime metadata 記錄實際版本
+- **Eval / review / tribunal judges** → `codex exec --model gpt-5.5`，完整版 GPT，不走 mini
 - **Vibe Scorer**（`.claude/agents/vibe-opus-scorer.md`）→ 鎖 `claude-opus-4-6[1m]`
-- **Tribunal Writer**（`.claude/agents/tribunal-writer.md`）→ 鎖 `claude-opus-4-6[1m]`
+- **Tribunal Writer legacy agent**（`.claude/agents/tribunal-writer.md`）→ 鎖 `claude-opus-4-6[1m]`，只當 legacy / fallback calibration，不是 Codex runtime selector
 - **Fact Checker**（`.claude/agents/fact-checker.md`）→ 用 `opus` alias（追最新，fact-check 要 reasoning 強的，沒有 voice 問題）
 - **Librarian**（`.claude/agents/librarian.md`）→ `claude-opus-4-7`
 - **Fresh Eyes**（`.claude/agents/fresh-eyes.md`）→ `claude-opus-4-7`
 
-修這些檔案之前先讀 frontmatter 上方的 PIN 註解。要改 pin 需要 user 明確同意。
+修 `.claude/agents` 這些 legacy calibration 檔之前先讀 frontmatter 上方的 PIN 註解；它們不是 active Codex runtime model selection。
 
 ## 文章寫作 SOP（省 token 版）
 

--- a/scripts/tribunal-helpers.sh
+++ b/scripts/tribunal-helpers.sh
@@ -364,9 +364,9 @@ tribunal_claude_cmd() {
 }
 
 # Resolve the active tribunal LLM provider: "codex" when present (the
-# maintained runtime), else "claude" (CCC fallback). Returns 1 when neither
-# binary is on PATH. Codex always wins when both exist, mirroring the Go
-# pipeline's WritingChain so the two runtimes agree on who ran.
+# maintained judge runtime), else "claude" (CCC fallback). Returns 1 when
+# neither binary is on PATH. Codex always wins when both exist; this intentionally
+# mirrors the Go pipeline's JudgeChain, not the Opus writer chain.
 tribunal_llm_provider() {
   if tribunal_codex_cmd >/dev/null 2>&1; then
     printf 'codex\n'
@@ -381,7 +381,7 @@ tribunal_llm_provider() {
 
 # Parse the `model:` field from a .claude/agents/<name>.md spec so each judge
 # runs on its declared Claude build (vibe/fact-checker on opus, etc.). Falls
-# back to the pinned SP writer Opus when the field is absent.
+# back to the legacy Opus scorer/writer calibration model when the field is absent.
 tribunal_claude_agent_model() {
   local agent_name="$1"
   if [ -z "${REPO_ROOT:-}" ]; then

--- a/tools/sp-pipeline/cmd/sp-pipeline/eval.go
+++ b/tools/sp-pipeline/cmd/sp-pipeline/eval.go
@@ -59,7 +59,7 @@ compares the two verdicts:
 	cmd.Flags().StringVar(&sourcePath, "source", "", "path to source-tweet.md (required)")
 	cmd.Flags().StringVar(&workDir, "work-dir", "", "work directory for eval output files (defaults to parent dir of --source)")
 	cmd.Flags().BoolVar(&force, "force", false, "skip the gate and exit 0 without calling the LLM")
-	cmd.Flags().BoolVar(&opusOnly, "opus", false, "deprecated compatibility flag; Codex remains the default provider")
+	cmd.Flags().BoolVar(&opusOnly, "opus", false, "deprecated compatibility flag; eval always uses the Codex judge chain")
 	_ = cmd.MarkFlagRequired("source")
 	return cmd
 }
@@ -85,7 +85,7 @@ func runEval(ctx context.Context, state *rootState, sourcePath, workDir string, 
 		return fmt.Errorf("eval: mkdir %s: %w", workDir, err)
 	}
 
-	disp, err := buildDispatcher(state, opusOnly)
+	disp, err := buildDispatcherForRole(state, dispatcherJudge, opusOnly)
 	if err != nil {
 		return err
 	}
@@ -94,6 +94,7 @@ func runEval(ctx context.Context, state *rootState, sourcePath, workDir string, 
 	s.Cfg = state.cfg
 	s.Log = state.log
 	s.Dispatcher = disp
+	s.JudgeDispatcher = disp
 	s.SourcePath = absSource
 	s.WorkDir = workDir
 	s.Force = force

--- a/tools/sp-pipeline/cmd/sp-pipeline/llm_helper.go
+++ b/tools/sp-pipeline/cmd/sp-pipeline/llm_helper.go
@@ -6,18 +6,22 @@ import (
 	"github.com/chitienhsiehwork-ai/gu-log/tools/sp-pipeline/internal/llm"
 )
 
-// buildDispatcher returns a Dispatcher honoring the --fake-provider flag.
-// When the flag is set, the dispatcher is a single FakeProvider loaded
-// from JSON. Otherwise it is llm.WritingChain(): Codex GPT-5.5 as the
-// primary, plus an auto-detected Claude Opus fallback when no codex binary is
-// on PATH (the CCC sandbox case). The old Opus-primary/Gemini-assisted
-// pipeline is intentionally not the default — Codex stays primary wherever it
-// exists; Claude only enters the chain when codex is absent.
-//
-// The opusOnly parameter is kept for CLI compatibility, but no longer changes
-// provider routing: the Claude fallback is driven by codex availability, not
-// by this flag.
+type dispatcherRole string
+
+const (
+	dispatcherWriter dispatcherRole = "writer"
+	dispatcherJudge  dispatcherRole = "judge"
+)
+
+// buildDispatcher returns a role-specific Dispatcher honoring the
+// --fake-provider flag. Writers use Claude Opus alias on Macs where Claude Code
+// is installed, falling back to full Codex GPT-5.5 only when Claude is absent.
+// Judges use full Codex GPT-5.5, never mini.
 func buildDispatcher(state *rootState, opusOnly bool) (*llm.Dispatcher, error) {
+	return buildDispatcherForRole(state, dispatcherWriter, opusOnly)
+}
+
+func buildDispatcherForRole(state *rootState, role dispatcherRole, opusOnly bool) (*llm.Dispatcher, error) {
 	if state.fakeProviderPath != "" {
 		fake, err := llm.LoadFakeFromJSON(state.fakeProviderPath)
 		if err != nil {
@@ -25,7 +29,13 @@ func buildDispatcher(state *rootState, opusOnly bool) (*llm.Dispatcher, error) {
 		}
 		return llm.NewDispatcher(state.log, fake)
 	}
-	providers := llm.WritingChain()
+	var providers []llm.Provider
+	switch role {
+	case dispatcherJudge:
+		providers = llm.JudgeChain()
+	default:
+		providers = llm.WritingChain()
+	}
 	_ = opusOnly
 	return llm.NewDispatcher(state.log, providers...)
 }

--- a/tools/sp-pipeline/cmd/sp-pipeline/refine.go
+++ b/tools/sp-pipeline/cmd/sp-pipeline/refine.go
@@ -47,7 +47,7 @@ contents — the LLM reads them from --work-dir.`,
 	cmd.Flags().StringVar(&reviewPath, "review", "", "path to review.md (defaults to <work-dir>/review.md)")
 	cmd.Flags().StringVar(&workDir, "work-dir", "", "work directory (defaults to dirname of --draft)")
 	cmd.Flags().StringVar(&ticketID, "ticket-id", "PENDING", "ticketId for the refine prompt header")
-	cmd.Flags().BoolVar(&opusOnly, "opus", false, "deprecated compatibility flag; Codex remains the default provider")
+	cmd.Flags().BoolVar(&opusOnly, "opus", false, "deprecated compatibility flag; writer routing is automatic")
 	cmd.Flags().StringVar(&angle, "angle", "", "optional narrative angle to preserve while refining")
 	_ = cmd.MarkFlagRequired("draft")
 	return cmd
@@ -80,7 +80,7 @@ func runRefine(ctx context.Context, state *rootState, draftPath, reviewPath, wor
 		state.log.Warn("refine: review.md not found at %s — LLM will refine blind", reviewPath)
 	}
 
-	disp, err := buildDispatcher(state, opusOnly)
+	disp, err := buildDispatcherForRole(state, dispatcherWriter, opusOnly)
 	if err != nil {
 		return err
 	}
@@ -89,6 +89,7 @@ func runRefine(ctx context.Context, state *rootState, draftPath, reviewPath, wor
 	s.Cfg = state.cfg
 	s.Log = state.log
 	s.Dispatcher = disp
+	s.WriterDispatcher = disp
 	s.WorkDir = workDir
 	s.PromptTicketID = ticketID
 	s.Angle = angle

--- a/tools/sp-pipeline/cmd/sp-pipeline/review.go
+++ b/tools/sp-pipeline/cmd/sp-pipeline/review.go
@@ -46,7 +46,7 @@ pipeline runs ` + "`codex exec`" + ` in (cd $WORK_DIR && …).`,
 	cmd.Flags().StringVar(&draftPath, "draft", "", "path to draft-v1.mdx (required; its parent is used as work-dir when --work-dir is empty)")
 	cmd.Flags().StringVar(&workDir, "work-dir", "", "work directory where review.md should land (defaults to dirname of --draft)")
 	cmd.Flags().StringVar(&ticketID, "ticket-id", "PENDING", "ticketId for the review prompt header")
-	cmd.Flags().BoolVar(&opusOnly, "opus", false, "deprecated compatibility flag; Codex remains the default provider")
+	cmd.Flags().BoolVar(&opusOnly, "opus", false, "deprecated compatibility flag; review always uses the Codex judge chain")
 	_ = cmd.MarkFlagRequired("draft")
 	return cmd
 }
@@ -68,7 +68,7 @@ func runReview(ctx context.Context, state *rootState, draftPath, workDir, ticket
 		return err
 	}
 
-	disp, err := buildDispatcher(state, opusOnly)
+	disp, err := buildDispatcherForRole(state, dispatcherJudge, opusOnly)
 	if err != nil {
 		return err
 	}
@@ -77,6 +77,7 @@ func runReview(ctx context.Context, state *rootState, draftPath, workDir, ticket
 	s.Cfg = state.cfg
 	s.Log = state.log
 	s.Dispatcher = disp
+	s.JudgeDispatcher = disp
 	s.WorkDir = workDir
 	s.PromptTicketID = ticketID
 

--- a/tools/sp-pipeline/cmd/sp-pipeline/run.go
+++ b/tools/sp-pipeline/cmd/sp-pipeline/run.go
@@ -116,7 +116,7 @@ canned responses for regression tests.`,
 	cmd.Flags().StringVar(&fromStep, "from-step", "", "resume from step: setup/fetch/eval/dedup/write/review/refine/ralph/deploy")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "stop before the deploy step")
 	cmd.Flags().BoolVar(&force, "force", false, "skip the eval gate (still runs everything else)")
-	cmd.Flags().BoolVar(&opusOnly, "opus", false, "deprecated compatibility flag; Codex remains the default provider")
+	cmd.Flags().BoolVar(&opusOnly, "opus", false, "deprecated compatibility flag; role routing is automatic")
 	cmd.Flags().IntVar(&ralphBar, "bar", 8, "ralph quality bar (advisory — tribunal has its own internal bar)")
 	cmd.Flags().StringVar(&existingFile, "file", "", "resume from an existing file in src/content/posts/")
 	cmd.Flags().StringVar(&prefix, "prefix", "SP", "ticket prefix (SP / CP / SD / Lv)")
@@ -159,7 +159,11 @@ func runRun(ctx context.Context, state *rootState, opts runOpts) error {
 		return fmt.Errorf("run: tweet URL is required when not resuming via --file + --from-step")
 	}
 
-	disp, err := buildDispatcher(state, opts.OpusOnly)
+	writerDisp, err := buildDispatcherForRole(state, dispatcherWriter, opts.OpusOnly)
+	if err != nil {
+		return err
+	}
+	judgeDisp, err := buildDispatcherForRole(state, dispatcherJudge, opts.OpusOnly)
 	if err != nil {
 		return err
 	}
@@ -167,7 +171,9 @@ func runRun(ctx context.Context, state *rootState, opts runOpts) error {
 	s := pipeline.NewState()
 	s.Cfg = state.cfg
 	s.Log = state.log
-	s.Dispatcher = disp
+	s.Dispatcher = writerDisp
+	s.WriterDispatcher = writerDisp
+	s.JudgeDispatcher = judgeDisp
 	s.Counter = counter.New(state.cfg.CounterFile, "")
 	s.TweetURL = opts.TweetURL
 	s.Prefix = opts.Prefix

--- a/tools/sp-pipeline/cmd/sp-pipeline/write.go
+++ b/tools/sp-pipeline/cmd/sp-pipeline/write.go
@@ -75,7 +75,7 @@ set these from the upstream fetch + counter steps.`,
 	cmd.Flags().StringVar(&tweetURL, "tweet-url", "", "canonical source URL")
 	cmd.Flags().StringVar(&prefix, "prefix", "SP", "ticket prefix (SP / CP / SD / Lv) — controls first tag")
 	cmd.Flags().StringVar(&translatedDate, "translated-date", "", "YYYY-MM-DD of the translation run (defaults to today)")
-	cmd.Flags().BoolVar(&opusOnly, "opus", false, "deprecated compatibility flag; Codex remains the default provider")
+	cmd.Flags().BoolVar(&opusOnly, "opus", false, "deprecated compatibility flag; writer routing is automatic")
 	cmd.Flags().StringVar(&angle, "angle", "", "optional narrative angle to make the article spine")
 	cmd.Flags().StringVar(&sourceLabel, "source-label", "", "override the `source:` frontmatter line")
 	cmd.Flags().BoolVar(&sourceIsX, "source-is-x", true, "treat --author as an X handle when auto-rendering source")
@@ -116,7 +116,7 @@ func runWrite(ctx context.Context, state *rootState, opts writeOpts) error {
 		return fmt.Errorf("write: mkdir %s: %w", workDir, err)
 	}
 
-	disp, err := buildDispatcher(state, opts.OpusOnly)
+	disp, err := buildDispatcherForRole(state, dispatcherWriter, opts.OpusOnly)
 	if err != nil {
 		return err
 	}
@@ -125,6 +125,7 @@ func runWrite(ctx context.Context, state *rootState, opts writeOpts) error {
 	s.Cfg = state.cfg
 	s.Log = state.log
 	s.Dispatcher = disp
+	s.WriterDispatcher = disp
 	s.SourcePath = absSource
 	s.WorkDir = workDir
 	s.PromptTicketID = opts.TicketID

--- a/tools/sp-pipeline/internal/llm/claude.go
+++ b/tools/sp-pipeline/internal/llm/claude.go
@@ -2,6 +2,7 @@ package llm
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"strings"
 
@@ -23,26 +24,20 @@ import (
 //     and it returns a "please approve the permission" message instead of
 //     the JSON/MDX the parser expects.
 type ClaudeProvider struct {
-	// ModelFlag is the value passed to --model. For Opus we pin the exact
-	// build ("claude-opus-4-6[1m]") rather than the "opus" alias — see the
-	// PIN note below. Sonnet/Haiku may use aliases since only the Opus
-	// writing voice is taste-locked.
-	ModelFlag string
+	// ModelFlag is the value passed to --model. Opus intentionally uses the
+	// "opus" alias so the Mac writer follows Anthropic's current Opus line.
+	ModelFlag   string
+	actualModel ModelID
 }
 
-// Pinned model IDs. SP writer uses Opus 4.6 because the maintainer has
-// explicitly rejected Opus 4.7's writing voice and vibe-scoring calibration;
-// "opus" alias auto-upgrades to the latest and would silently break that.
-// DO NOT change ClaudeOpusPinned to the "opus" alias without owner sign-off.
-// Keep this in sync with Claude Code agent frontmatter. Codex tribunal runtime
-// has its own project-scoped configs under .codex/agents/*.toml.
+// ClaudeOpusAlias follows Anthropic's current Opus model for the Mac writing
+// path. Runtime JSON metadata is used to stamp the concrete resolved version.
 const (
-	ClaudeOpusPinned = "claude-opus-4-6[1m]"
+	ClaudeOpusAlias = "opus"
 )
 
-// NewClaudeOpus returns a ClaudeProvider wired to the pinned Claude Opus
-// build (see ClaudeOpusPinned).
-func NewClaudeOpus() *ClaudeProvider { return &ClaudeProvider{ModelFlag: ClaudeOpusPinned} }
+// NewClaudeOpus returns a ClaudeProvider wired to the Opus alias.
+func NewClaudeOpus() *ClaudeProvider { return &ClaudeProvider{ModelFlag: ClaudeOpusAlias} }
 
 // NewClaudeSonnet returns a ClaudeProvider wired to Claude Sonnet.
 func NewClaudeSonnet() *ClaudeProvider { return &ClaudeProvider{ModelFlag: "sonnet"} }
@@ -61,11 +56,21 @@ func (c *ClaudeProvider) Model() ModelID {
 		return ModelClaudeSonnet
 	case "haiku":
 		return ModelClaudeHaiku
-	case ClaudeOpusPinned, "opus":
+	case ClaudeOpusAlias:
 		return ModelClaudeOpus
 	default:
 		return ModelClaudeOpus
 	}
+}
+
+// ActualModel returns the concrete model reported by Claude Code JSON output
+// when available. Before the first run, or when older CLIs omit the field, it
+// falls back to the configured selector.
+func (c *ClaudeProvider) ActualModel() ModelID {
+	if c.actualModel != "" {
+		return c.actualModel
+	}
+	return c.Model()
 }
 
 // Available implements Provider.
@@ -79,6 +84,7 @@ func (c *ClaudeProvider) Run(ctx context.Context, prompt string, opts RunOptions
 	args := []string{
 		"-p",
 		"--model", c.modelFlag(),
+		"--output-format", "json",
 	}
 	if os.Geteuid() != 0 {
 		args = append(args, "--permission-mode", "bypassPermissions")
@@ -105,12 +111,32 @@ func (c *ClaudeProvider) Run(ctx context.Context, prompt string, opts RunOptions
 	if err != nil {
 		return "", err
 	}
-	return strings.TrimRight(string(res.Stdout), "\n"), nil
+	out := strings.TrimRight(string(res.Stdout), "\n")
+	if parsed, ok := parseClaudeJSON(out); ok {
+		if parsed.Model != "" {
+			c.actualModel = ModelID(parsed.Model)
+		}
+		return strings.TrimRight(parsed.Result, "\n"), nil
+	}
+	return out, nil
 }
 
 func (c *ClaudeProvider) modelFlag() string {
 	if c.ModelFlag == "" {
-		return ClaudeOpusPinned
+		return ClaudeOpusAlias
 	}
 	return c.ModelFlag
+}
+
+type claudeJSONOutput struct {
+	Result string `json:"result"`
+	Model  string `json:"model"`
+}
+
+func parseClaudeJSON(out string) (claudeJSONOutput, bool) {
+	var parsed claudeJSONOutput
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		return parsed, false
+	}
+	return parsed, parsed.Result != "" || parsed.Model != ""
 }

--- a/tools/sp-pipeline/internal/llm/codex.go
+++ b/tools/sp-pipeline/internal/llm/codex.go
@@ -53,6 +53,10 @@ func (c *CodexProvider) Model() ModelID {
 	}
 }
 
+// ActualModel returns the explicit Codex model passed to the CLI. Codex does
+// not use a moving alias here: gpt-5.5 is the current full recommended model.
+func (c *CodexProvider) ActualModel() ModelID { return c.Model() }
+
 // Available implements Provider.
 func (c *CodexProvider) Available() bool {
 	_, err := runner.LookPath("codex")

--- a/tools/sp-pipeline/internal/llm/codex_test.go
+++ b/tools/sp-pipeline/internal/llm/codex_test.go
@@ -84,13 +84,13 @@ printf 'codex-ok\n' > "$out"
 	}
 }
 
-func TestDefaultChainsAreCodexGPT55Only(t *testing.T) {
+func TestDefaultJudgeAndProbeChainsAreCodexGPT55(t *testing.T) {
 	for name, tc := range map[string]struct {
 		chain  []Provider
 		effort string
 	}{
-		"writing": {chain: DefaultWritingChain(), effort: "low"},
-		"probe":   {chain: DefaultProbeChain(), effort: "medium"},
+		"judge": {chain: DefaultJudgeChain(), effort: "medium"},
+		"probe": {chain: DefaultProbeChain(), effort: "medium"},
 	} {
 		chain := tc.chain
 		if len(chain) != 1 {
@@ -109,5 +109,18 @@ func TestDefaultChainsAreCodexGPT55Only(t *testing.T) {
 		if got := codex.reasoningEffort(); got != tc.effort {
 			t.Fatalf("%s effort = %q, want %q", name, got, tc.effort)
 		}
+	}
+}
+
+func TestDefaultWritingChainUsesClaudeOpusAlias(t *testing.T) {
+	chain := DefaultWritingChain()
+	if len(chain) != 1 {
+		t.Fatalf("writing chain length = %d, want 1", len(chain))
+	}
+	if chain[0].Name() != "claude-opus" {
+		t.Fatalf("writing provider = %q, want claude-opus", chain[0].Name())
+	}
+	if chain[0].Model() != ModelClaudeOpus {
+		t.Fatalf("writing model = %q, want %q", chain[0].Model(), ModelClaudeOpus)
 	}
 }

--- a/tools/sp-pipeline/internal/llm/defaults.go
+++ b/tools/sp-pipeline/internal/llm/defaults.go
@@ -1,11 +1,20 @@
 package llm
 
 // DefaultWritingChain returns the provider ordering used for article writing
-// and review/refine steps. Codex GPT-5.5 low is the only default provider:
-// Anthropic and Gemini subscriptions are not assumed to exist on the Clawd VM.
+// and refine steps. On Macs with Claude Code installed, Opus is the writer.
+// On the Clawd VM, where Claude is intentionally not a dependency, the runtime
+// falls back to Codex GPT-5.5.
 func DefaultWritingChain() []Provider {
 	return []Provider{
-		NewCodexGPT55Low(),
+		NewClaudeOpus(),
+	}
+}
+
+// DefaultJudgeChain returns the provider ordering used for eval/review steps.
+// Keep this on the full recommended Codex model, not a mini model.
+func DefaultJudgeChain() []Provider {
+	return []Provider{
+		NewCodexGPT55Medium(),
 	}
 }
 
@@ -18,59 +27,44 @@ func DefaultProbeChain() []Provider {
 	}
 }
 
-// ProbeChain returns the providers `doctor --probe-llm` should canary. It is
-// the symmetric counterpart to WritingChain for the health-check path: codex
-// GPT-5.5 is probed wherever it exists, and only when no codex binary is on
-// PATH — the CCC / Claude Code on the web sandbox case, where only `claude`
-// ships — is a Claude Opus probe appended so doctor reports the provider the
-// pipeline would actually use instead of a misleading codex "missing".
-//
-// Claude is appended ONLY when codex is absent, mirroring WritingChain's
-// invariant: codex present → Claude is never probed, so VPS/mac doctor output
-// is byte-for-byte unchanged. DefaultProbeChain() stays codex-only for callers
-// that want to probe codex explicitly.
+// ProbeChain returns the providers `doctor --probe-llm` should canary.
 func ProbeChain() []Provider {
-	chain := DefaultProbeChain()
-	if anyAvailable(chain) {
-		return chain
-	}
-	return append(chain, NewClaudeOpus())
+	return append(DefaultProbeChain(), NewClaudeOpus())
 }
 
 // WritingChain returns the provider chain the pipeline actually dispatches
-// through (eval / write / review / refine). Codex GPT-5.5 is the primary
-// everywhere it exists. When no codex binary is on PATH — the CCC / Claude
-// Code on the web sandbox case, where only `claude` ships — a Claude Opus
-// fallback is appended so `sp-pipeline run` can complete end to end.
-//
-// Claude is appended ONLY when codex is absent, so the VPS/mac behaviour is
-// byte-for-byte unchanged: codex present → Claude is never in the chain,
-// preserving the "Claude is not a safe default dependency" invariant. This is
-// auto-detection (binary-on-PATH), not a flag — a codex that is present but
-// fails at runtime still surfaces its error rather than silently retrying on
-// Claude.
+// through for write/refine. If Claude is installed, Opus is the writer and a
+// Claude runtime failure should fail loudly rather than silently writing with a
+// different voice. If Claude is absent, Codex GPT-5.5 keeps VM runs alive.
 func WritingChain() []Provider {
-	chain := DefaultWritingChain()
-	if anyAvailable(chain) {
-		return chain
+	claude := NewClaudeOpus()
+	if claude.Available() {
+		return []Provider{claude}
 	}
-	return append(chain, NewClaudeOpus())
+	return []Provider{NewCodexGPT55Medium()}
+}
+
+// JudgeChain returns the provider chain for eval/review. Judges stay on the
+// full recommended Codex model.
+func JudgeChain() []Provider {
+	return DefaultJudgeChain()
 }
 
 // EffectiveStamp returns the (model, harness) display labels for the runtime
-// provider that WritingChain will resolve to. Frontmatter stampers (credits,
-// ralph) use it so a Claude-fallback run is recorded honestly as
-// "Opus 4.6" / "Claude Code CLI" instead of the hardcoded GPT-5.5 / Codex
-// labels. When nothing is on PATH (offline / FakeProvider test runs) it keeps
-// the historical codex labels so those paths do not suddenly flip to Claude.
+// provider that WritingChain will resolve to. When nothing is on PATH (offline
+// / FakeProvider test runs) it keeps Codex labels as the deterministic default.
 func EffectiveStamp() (model, harness string) {
-	chain := DefaultWritingChain()
-	if anyAvailable(chain) {
-		m := chain[0].Model()
-		return DisplayName(m), HarnessName(m)
-	}
-	if c := NewClaudeOpus(); c.Available() {
-		return DisplayName(c.Model()), HarnessName(c.Model())
+	chain := WritingChain()
+	for _, p := range chain {
+		if p.Available() {
+			m := p.Model()
+			if reporter, ok := p.(interface{ ActualModel() ModelID }); ok {
+				if actual := reporter.ActualModel(); actual != "" {
+					m = actual
+				}
+			}
+			return DisplayName(m), HarnessName(p.Model())
+		}
 	}
 	return DisplayName(ModelGPT55), HarnessName(ModelGPT55)
 }

--- a/tools/sp-pipeline/internal/llm/dispatcher.go
+++ b/tools/sp-pipeline/internal/llm/dispatcher.go
@@ -44,6 +44,10 @@ type RunResult struct {
 	ProviderName string
 	// Model is the ModelID of the successful provider.
 	Model ModelID
+	// ActualModel is the concrete model reported by the provider when a moving
+	// alias was used. It falls back to Model when the provider has no richer
+	// runtime metadata.
+	ActualModel ModelID
 	// FellBackFrom is a list of provider names that failed before the
 	// successful one ran (empty when the primary succeeded on the first try).
 	FellBackFrom []string
@@ -95,10 +99,17 @@ func (d *Dispatcher) Run(ctx context.Context, prompt string, opts RunOptions) (*
 			} else {
 				d.log.OK("llm: %s succeeded", p.Name())
 			}
+			actualModel := p.Model()
+			if reporter, ok := p.(interface{ ActualModel() ModelID }); ok {
+				if reported := reporter.ActualModel(); reported != "" {
+					actualModel = reported
+				}
+			}
 			return &RunResult{
 				Output:       out,
 				ProviderName: p.Name(),
 				Model:        p.Model(),
+				ActualModel:  actualModel,
 				FellBackFrom: fellBack,
 			}, nil
 		}

--- a/tools/sp-pipeline/internal/llm/fallback_test.go
+++ b/tools/sp-pipeline/internal/llm/fallback_test.go
@@ -29,37 +29,22 @@ func TestAnyAvailable(t *testing.T) {
 	}
 }
 
-func TestWritingChainKeepsCodexPrimary(t *testing.T) {
-	// WritingChain must always lead with the codex default so that the VPS/mac
-	// dispatch order is unchanged; the only difference is an optional trailing
-	// Claude fallback when codex is absent.
+func TestWritingChainUsesSingleResolvedWriter(t *testing.T) {
 	chain := WritingChain()
 	if len(chain) == 0 {
 		t.Fatal("WritingChain returned an empty chain")
 	}
-	if chain[0].Name() != "codex-gpt-5.5" {
-		t.Fatalf("WritingChain primary = %q, want codex-gpt-5.5", chain[0].Name())
+	if len(chain) != 1 {
+		t.Fatalf("WritingChain length = %d, want exactly 1 resolved writer", len(chain))
 	}
-	// The chain is either codex-only (codex present) or codex+claude (codex
-	// absent). It must never be claude-only or place claude before codex.
-	switch len(chain) {
-	case 1:
-		// codex-only — fine.
-	case 2:
-		if _, ok := chain[1].(*ClaudeProvider); !ok {
-			t.Fatalf("WritingChain fallback = %T, want *ClaudeProvider", chain[1])
-		}
+	switch chain[0].Name() {
+	case "claude-opus", "codex-gpt-5.5":
 	default:
-		t.Fatalf("WritingChain length = %d, want 1 or 2", len(chain))
+		t.Fatalf("WritingChain writer = %q, want claude-opus or codex-gpt-5.5", chain[0].Name())
 	}
 }
 
 func TestProbeChainKeepsCodexPrimary(t *testing.T) {
-	// ProbeChain mirrors WritingChain's invariant for the doctor --probe-llm
-	// path: codex is always primary so VPS/mac probe output is unchanged; the
-	// only difference is an optional trailing Claude probe when codex is absent
-	// (the CCC sandbox case). It must never be claude-only or place claude
-	// before codex.
 	chain := ProbeChain()
 	if len(chain) == 0 {
 		t.Fatal("ProbeChain returned an empty chain")
@@ -67,15 +52,11 @@ func TestProbeChainKeepsCodexPrimary(t *testing.T) {
 	if chain[0].Name() != "codex-gpt-5.5" {
 		t.Fatalf("ProbeChain primary = %q, want codex-gpt-5.5", chain[0].Name())
 	}
-	switch len(chain) {
-	case 1:
-		// codex-only — fine.
-	case 2:
-		if _, ok := chain[1].(*ClaudeProvider); !ok {
-			t.Fatalf("ProbeChain fallback = %T, want *ClaudeProvider", chain[1])
-		}
-	default:
-		t.Fatalf("ProbeChain length = %d, want 1 or 2", len(chain))
+	if len(chain) != 2 {
+		t.Fatalf("ProbeChain length = %d, want codex + claude probes", len(chain))
+	}
+	if _, ok := chain[1].(*ClaudeProvider); !ok {
+		t.Fatalf("ProbeChain fallback = %T, want *ClaudeProvider", chain[1])
 	}
 }
 
@@ -89,11 +70,11 @@ func TestEffectiveStampLabels(t *testing.T) {
 		if harness != "Codex CLI" {
 			t.Fatalf("GPT-5.5 stamped with harness %q, want Codex CLI", harness)
 		}
-	case "Opus 4.6":
+	case "Opus 4.8":
 		if harness != "Claude Code CLI" {
-			t.Fatalf("Opus 4.6 stamped with harness %q, want Claude Code CLI", harness)
+			t.Fatalf("Opus 4.8 stamped with harness %q, want Claude Code CLI", harness)
 		}
 	default:
-		t.Fatalf("EffectiveStamp model = %q, want GPT-5.5 or Opus 4.6", model)
+		t.Fatalf("EffectiveStamp model = %q, want GPT-5.5 or Opus 4.8", model)
 	}
 }

--- a/tools/sp-pipeline/internal/llm/models.go
+++ b/tools/sp-pipeline/internal/llm/models.go
@@ -19,6 +19,11 @@
 //     long writing run spends real credits.
 package llm
 
+import (
+	"regexp"
+	"strings"
+)
+
 // ModelID is an enum-ish string identifying a specific model build.
 // Keep this in sync with scripts/sp-pipeline.sh's model_display_name().
 type ModelID string
@@ -33,6 +38,8 @@ const (
 	ModelClaudeHaiku  ModelID = "claude-haiku"
 )
 
+var claudeFamilyRe = regexp.MustCompile(`claude-(opus|sonnet|haiku)-([0-9]+)-([0-9]+)`)
+
 // DisplayName returns the human-readable model name the validator expects
 // in translatedBy.model. Unknown IDs pass through unchanged so the caller
 // fails loudly at validation time instead of silently truncating.
@@ -41,9 +48,16 @@ const (
 // old fake-provider tests may still mention them. New production credits should
 // normally record GPT-5.5 + Codex CLI.
 func DisplayName(m ModelID) string {
+	raw := string(m)
+	normalized := strings.TrimPrefix(raw, "anthropic/")
+	normalized = strings.TrimSuffix(normalized, "[1m]")
+	if match := claudeFamilyRe.FindStringSubmatch(normalized); match != nil {
+		family := strings.ToUpper(match[1][:1]) + match[1][1:]
+		return family + " " + match[2] + "." + match[3]
+	}
 	switch m {
 	case ModelClaudeOpus:
-		return "Opus 4.6"
+		return "Opus 4.8"
 	case ModelClaudeSonnet:
 		return "Sonnet 4.6"
 	case ModelClaudeHaiku:

--- a/tools/sp-pipeline/internal/pipeline/credits.go
+++ b/tools/sp-pipeline/internal/pipeline/credits.go
@@ -48,19 +48,17 @@ func (s *State) Credits(ctx context.Context) error {
 		return fmt.Errorf("credits: parse final.mdx: %w", err)
 	}
 
-	// Default the per-stage metadata to the runtime provider's labels. A real
-	// run populates these from the dispatcher result in Write/Review/Refine;
-	// the defaults only matter when a stage was skipped via --from-step. They
-	// follow whichever provider WritingChain resolved to (Codex GPT-5.5
-	// normally, Claude Opus in the CCC sandbox fallback) so a Claude run is
-	// stamped honestly rather than mislabelled as GPT-5.5.
-	stampModel, stampHarness := s.StampLabels()
-	writeModel := nonEmpty(s.WriteModel, stampModel)
-	writeHarness := nonEmpty(s.WriteHarness, stampHarness)
-	reviewModel := nonEmpty(s.ReviewModel, stampModel)
-	reviewHarness := nonEmpty(s.ReviewHarness, stampHarness)
-	refineModel := nonEmpty(s.RefineModel, stampModel)
-	refineHarness := nonEmpty(s.RefineHarness, stampHarness)
+	// Default skipped-stage metadata to each role's runtime provider. Writers
+	// use Opus-on-Mac / Codex-on-VM; reviewers and tribunal judges use full
+	// Codex GPT-5.5.
+	writerModel, writerHarness := s.StampLabels()
+	judgeModel, judgeHarness := s.JudgeStampLabels()
+	writeModel := nonEmpty(s.WriteModel, writerModel)
+	writeHarness := nonEmpty(s.WriteHarness, writerHarness)
+	reviewModel := nonEmpty(s.ReviewModel, judgeModel)
+	reviewHarness := nonEmpty(s.ReviewHarness, judgeHarness)
+	refineModel := nonEmpty(s.RefineModel, writerModel)
+	refineHarness := nonEmpty(s.RefineHarness, writerHarness)
 
 	// Patch the top-level model line to match the actual writer.
 	f.SetNestedScalar("translatedBy", "model", quoted(writeModel))
@@ -71,7 +69,7 @@ func (s *State) Credits(ctx context.Context) error {
 		{Role: "Written", Model: writeModel, Harness: writeHarness},
 		{Role: "Reviewed", Model: reviewModel, Harness: reviewHarness},
 		{Role: "Refined", Model: refineModel, Harness: refineHarness},
-		{Role: "Orchestrated", Model: stampModel, Harness: "sp-pipeline"},
+		{Role: "Orchestrated", Model: judgeModel, Harness: "sp-pipeline"},
 	}
 	f.SetNestedBlock("translatedBy", "pipeline", renderPipelineBlock("  pipeline", entries))
 	f.SetNestedScalar("translatedBy", "pipelineUrl", quoted(PipelineURL))
@@ -83,12 +81,10 @@ func (s *State) Credits(ctx context.Context) error {
 	return nil
 }
 
-// StampLabels resolves the (model, harness) display labels for the provider
-// the pipeline actually ran through, so frontmatter credits/ralph stamps are
-// honest about whether a post was written/scored by Codex GPT-5.5 or the
-// Claude Opus CCC fallback. It reads the resolved dispatcher (deterministic
-// for a given run and for FakeProvider tests) and falls back to probing PATH
-// via llm.EffectiveStamp when no dispatcher is wired.
+// StampLabels resolves the (model, harness) display labels for the writer
+// provider. It reads the resolved dispatcher (deterministic for a given run and
+// for FakeProvider tests) and falls back to probing PATH when no dispatcher is
+// wired.
 func (s *State) StampLabels() (model, harness string) {
 	if s.Dispatcher != nil {
 		for _, p := range s.Dispatcher.Providers() {
@@ -98,6 +94,25 @@ func (s *State) StampLabels() (model, harness string) {
 		}
 	}
 	return llm.EffectiveStamp()
+}
+
+// JudgeStampLabels resolves the default judge model/harness used by review and
+// tribunal scoring when a specific per-stage result is unavailable.
+func (s *State) JudgeStampLabels() (model, harness string) {
+	if s.JudgeDispatcher != nil {
+		for _, p := range s.JudgeDispatcher.Providers() {
+			if p.Available() {
+				m := p.Model()
+				if reporter, ok := p.(interface{ ActualModel() llm.ModelID }); ok {
+					if actual := reporter.ActualModel(); actual != "" {
+						m = actual
+					}
+				}
+				return llm.DisplayName(m), llm.HarnessName(p.Model())
+			}
+		}
+	}
+	return llm.DisplayName(llm.ModelGPT55), llm.HarnessName(llm.ModelGPT55)
 }
 
 // renderPipelineBlock builds a YAML snippet for a translatedBy.pipeline

--- a/tools/sp-pipeline/internal/pipeline/eval.go
+++ b/tools/sp-pipeline/internal/pipeline/eval.go
@@ -174,7 +174,11 @@ func (s *State) runEvalProvider(ctx context.Context, template string, lineCount 
 	if err != nil {
 		return nil, err
 	}
-	return s.Dispatcher.Run(ctx, prompt, llm.RunOptions{WorkDir: s.WorkDir})
+	disp := s.judgeDispatcher()
+	if disp == nil {
+		return nil, fmt.Errorf("eval: judge dispatcher is nil")
+	}
+	return disp.Run(ctx, prompt, llm.RunOptions{WorkDir: s.WorkDir})
 }
 
 // parseEvalFile reads an eval-*.json file and validates its shape.

--- a/tools/sp-pipeline/internal/pipeline/ralph.go
+++ b/tools/sp-pipeline/internal/pipeline/ralph.go
@@ -122,13 +122,29 @@ func (s *State) Ralph(ctx context.Context) error {
 	// Frontmatter normaliser — for every file in {zh, en}, strip old
 	// pipeline block + pipelineUrl, then inject the canonical 6-entry
 	// block. Matches the Python heredoc at bash lines 1245-1300.
-	stampModel, stampHarness := s.StampLabels()
+	writerModel, writerHarness := s.StampLabels()
+	judgeModel, judgeHarness := s.JudgeStampLabels()
+	writeModel := nonEmpty(s.WriteModel, writerModel)
+	writeHarness := nonEmpty(s.WriteHarness, writerHarness)
+	reviewModel := nonEmpty(s.ReviewModel, judgeModel)
+	reviewHarness := nonEmpty(s.ReviewHarness, judgeHarness)
+	refineModel := nonEmpty(s.RefineModel, writerModel)
+	refineHarness := nonEmpty(s.RefineHarness, writerHarness)
 	for _, fname := range []string{s.ActiveFilename, s.ActiveENFilename} {
 		path := filepath.Join(postsDir, fname)
 		if _, err := os.Stat(path); err != nil {
 			continue
 		}
-		if err := normalizeRalphFrontmatter(path, stampModel, stampHarness); err != nil {
+		if err := normalizeRalphFrontmatter(path, PipelineStamp{
+			WriteModel:    writeModel,
+			WriteHarness:  writeHarness,
+			ReviewModel:   reviewModel,
+			ReviewHarness: reviewHarness,
+			RefineModel:   refineModel,
+			RefineHarness: refineHarness,
+			JudgeModel:    judgeModel,
+			JudgeHarness:  judgeHarness,
+		}); err != nil {
 			return fmt.Errorf("ralph: normalize %s: %w", fname, err)
 		}
 	}
@@ -144,7 +160,18 @@ func (s *State) Ralph(ctx context.Context) error {
 //  3. Rewrites harness: to the runtime provider's harness (stampHarness).
 //  4. Inserts a canonical 6-entry pipeline: block after harness.
 //  5. Inserts the canonical pipelineUrl.
-func normalizeRalphFrontmatter(path, stampModel, stampHarness string) error {
+type PipelineStamp struct {
+	WriteModel    string
+	WriteHarness  string
+	ReviewModel   string
+	ReviewHarness string
+	RefineModel   string
+	RefineHarness string
+	JudgeModel    string
+	JudgeHarness  string
+}
+
+func normalizeRalphFrontmatter(path string, stamp PipelineStamp) error {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return err
@@ -171,22 +198,18 @@ func normalizeRalphFrontmatter(path, stampModel, stampHarness string) error {
 		return strings.TrimSpace(line) == "pipeline:"
 	})
 
-	// stampModel/stampHarness record who actually wrote/scored the post:
-	// Codex GPT-5.5 on the VPS/mac, Claude Opus in the CCC sandbox fallback.
-	// This keeps tribunal calibration honest — a Claude-scored post is never
-	// mislabelled as a GPT-5.5 one.
-
 	// Canonical harness summary.
-	f.SetNestedScalar("translatedBy", "harness", quoted(stampHarness))
+	f.SetNestedScalar("translatedBy", "model", quoted(stamp.WriteModel))
+	f.SetNestedScalar("translatedBy", "harness", quoted(stamp.WriteHarness))
 
 	// 6-entry canonical pipeline block.
 	entries := []PipelineEntry{
-		{Role: "Written", Model: stampModel, Harness: stampHarness},
-		{Role: "Reviewed", Model: stampModel, Harness: stampHarness},
-		{Role: "Refined", Model: stampModel, Harness: stampHarness},
-		{Role: "Scored", Model: stampModel, Harness: stampHarness + " + Tribunal"},
-		{Role: "Rewritten", Model: stampModel, Harness: stampHarness + " + Tribunal"},
-		{Role: "Orchestrated", Model: stampModel, Harness: "sp-pipeline + Tribunal"},
+		{Role: "Written", Model: stamp.WriteModel, Harness: stamp.WriteHarness},
+		{Role: "Reviewed", Model: stamp.ReviewModel, Harness: stamp.ReviewHarness},
+		{Role: "Refined", Model: stamp.RefineModel, Harness: stamp.RefineHarness},
+		{Role: "Scored", Model: stamp.JudgeModel, Harness: stamp.JudgeHarness + " + Tribunal"},
+		{Role: "Rewritten", Model: stamp.WriteModel, Harness: stamp.WriteHarness + " + Tribunal"},
+		{Role: "Orchestrated", Model: stamp.JudgeModel, Harness: "sp-pipeline + Tribunal"},
 	}
 	f.SetNestedScalar("translatedBy", "pipeline", "")
 	f.SetBlock("  pipeline", renderPipelineBlock("  pipeline", entries))

--- a/tools/sp-pipeline/internal/pipeline/ralph_test.go
+++ b/tools/sp-pipeline/internal/pipeline/ralph_test.go
@@ -58,7 +58,16 @@ func TestNormalizeRalphFrontmatter_StripsAndCanonicalises(t *testing.T) {
 	if err := os.WriteFile(f, []byte(ralphFixtureMDX), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := normalizeRalphFrontmatter(f, "GPT-5.5", "Codex CLI"); err != nil {
+	if err := normalizeRalphFrontmatter(f, PipelineStamp{
+		WriteModel:    "Opus 4.8",
+		WriteHarness:  "Claude Code CLI",
+		ReviewModel:   "GPT-5.5",
+		ReviewHarness: "Codex CLI",
+		RefineModel:   "Opus 4.8",
+		RefineHarness: "Claude Code CLI",
+		JudgeModel:    "GPT-5.5",
+		JudgeHarness:  "Codex CLI",
+	}); err != nil {
 		t.Fatalf("normalize: %v", err)
 	}
 	out, _ := os.ReadFile(f)
@@ -82,40 +91,54 @@ func TestNormalizeRalphFrontmatter_StripsAndCanonicalises(t *testing.T) {
 	if strings.Contains(s, `- role: "Old"`) {
 		t.Error("stale role 'Old' not stripped")
 	}
-	// Canonical summary harness for mac-cdx Codex migration.
-	if !strings.Contains(s, `harness: "Codex CLI"`) {
-		t.Error("canonical summary harness missing")
+	// Canonical summary records the writer, while review/scoring roles record
+	// Codex GPT-5.5.
+	for _, want := range []string{
+		`model: "Opus 4.8"`,
+		`harness: "Claude Code CLI"`,
+		`model: "GPT-5.5"`,
+		`harness: "Codex CLI + Tribunal"`,
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("canonical mixed-role frontmatter missing %q in:\n%s", want, s)
+		}
 	}
 }
 
-func TestNormalizeRalphFrontmatter_HonoursClaudeStamp(t *testing.T) {
-	// When the CCC fallback ran the pipeline through Claude, the canonical
-	// block must record Claude Opus honestly rather than the hardcoded GPT-5.5.
+func TestNormalizeRalphFrontmatter_HonoursMixedRoleStamp(t *testing.T) {
 	f := filepath.Join(t.TempDir(), "post.mdx")
 	if err := os.WriteFile(f, []byte(ralphFixtureMDX), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := normalizeRalphFrontmatter(f, "Opus 4.6", "Claude Code CLI"); err != nil {
+	if err := normalizeRalphFrontmatter(f, PipelineStamp{
+		WriteModel:    "Opus 4.8",
+		WriteHarness:  "Claude Code CLI",
+		ReviewModel:   "GPT-5.5",
+		ReviewHarness: "Codex CLI",
+		RefineModel:   "Opus 4.8",
+		RefineHarness: "Claude Code CLI",
+		JudgeModel:    "GPT-5.5",
+		JudgeHarness:  "Codex CLI",
+	}); err != nil {
 		t.Fatalf("normalize: %v", err)
 	}
 	out, _ := os.ReadFile(f)
 	s := string(out)
 	for _, want := range []string{
 		`harness: "Claude Code CLI"`,
-		`model: "Opus 4.6"`,
+		`model: "Opus 4.8"`,
+		`model: "GPT-5.5"`,
+		`harness: "Codex CLI"`,
 		`harness: "Claude Code CLI + Tribunal"`,
 	} {
 		if !strings.Contains(s, want) {
-			t.Errorf("claude-stamped frontmatter missing %q in:\n%s", want, s)
+			t.Errorf("mixed-role frontmatter missing %q in:\n%s", want, s)
 		}
-	}
-	if strings.Contains(s, "GPT-5.5") || strings.Contains(s, `"Codex CLI"`) {
-		t.Errorf("claude run leaked codex labels:\n%s", s)
 	}
 }
 
 func TestNormalizeRalphFrontmatter_MissingFile(t *testing.T) {
-	if err := normalizeRalphFrontmatter("/tmp/missing-xyz-123.mdx", "GPT-5.5", "Codex CLI"); err == nil {
+	if err := normalizeRalphFrontmatter("/tmp/missing-xyz-123.mdx", PipelineStamp{}); err == nil {
 		t.Fatal("expected error for missing file")
 	}
 }
@@ -126,7 +149,7 @@ func TestNormalizeRalphFrontmatter_NoFrontmatter_Silent(t *testing.T) {
 	if err := os.WriteFile(f, []byte("just body, no frontmatter"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := normalizeRalphFrontmatter(f, "GPT-5.5", "Codex CLI"); err != nil {
+	if err := normalizeRalphFrontmatter(f, PipelineStamp{}); err != nil {
 		t.Fatalf("expected silent success on no-frontmatter, got %v", err)
 	}
 }

--- a/tools/sp-pipeline/internal/pipeline/refine.go
+++ b/tools/sp-pipeline/internal/pipeline/refine.go
@@ -36,7 +36,11 @@ func (s *State) Refine(ctx context.Context) error {
 		return fmt.Errorf("refine: render prompt: %w", err)
 	}
 
-	res, err := s.Dispatcher.Run(ctx, prompt, llm.RunOptions{WorkDir: s.WorkDir})
+	disp := s.writerDispatcher()
+	if disp == nil {
+		return fmt.Errorf("refine: writer dispatcher is nil")
+	}
+	res, err := disp.Run(ctx, prompt, llm.RunOptions{WorkDir: s.WorkDir})
 	if err != nil {
 		return NewStepError(14, fmt.Errorf("refine: dispatcher failed: %w", err))
 	}
@@ -51,7 +55,7 @@ func (s *State) Refine(ctx context.Context) error {
 		}
 	}
 
-	s.RefineModel = llm.DisplayName(res.Model)
+	s.RefineModel = llm.DisplayName(res.ActualModel)
 	s.RefineHarness = llm.HarnessName(res.Model)
 	s.Log.OK("Step 4: final.mdx written by %s", s.RefineModel)
 	return nil

--- a/tools/sp-pipeline/internal/pipeline/review.go
+++ b/tools/sp-pipeline/internal/pipeline/review.go
@@ -33,7 +33,11 @@ func (s *State) Review(ctx context.Context) error {
 		return fmt.Errorf("review: render prompt: %w", err)
 	}
 
-	res, err := s.Dispatcher.Run(ctx, prompt, llm.RunOptions{WorkDir: s.WorkDir})
+	disp := s.judgeDispatcher()
+	if disp == nil {
+		return fmt.Errorf("review: judge dispatcher is nil")
+	}
+	res, err := disp.Run(ctx, prompt, llm.RunOptions{WorkDir: s.WorkDir})
 	if err != nil {
 		return NewStepError(14, fmt.Errorf("review: dispatcher failed: %w", err))
 	}
@@ -50,7 +54,7 @@ func (s *State) Review(ctx context.Context) error {
 		}
 	}
 
-	s.ReviewModel = llm.DisplayName(res.Model)
+	s.ReviewModel = llm.DisplayName(res.ActualModel)
 	s.ReviewHarness = llm.HarnessName(res.Model)
 	s.Log.OK("Step 3: review.md written by %s", s.ReviewModel)
 	return nil

--- a/tools/sp-pipeline/internal/pipeline/state.go
+++ b/tools/sp-pipeline/internal/pipeline/state.go
@@ -82,10 +82,12 @@ type State struct {
 
 	// ── Dependencies injected by the caller ────────────────────────────
 
-	Cfg        *config.Config
-	Log        *logx.Logger
-	Dispatcher *llm.Dispatcher
-	Counter    *counter.Counter
+	Cfg              *config.Config
+	Log              *logx.Logger
+	Dispatcher       *llm.Dispatcher
+	WriterDispatcher *llm.Dispatcher
+	JudgeDispatcher  *llm.Dispatcher
+	Counter          *counter.Counter
 
 	// ── Fields populated during the run ────────────────────────────────
 
@@ -147,6 +149,20 @@ type State struct {
 
 	// Timings per step (seconds), matches bash summary output.
 	Timings map[string]int
+}
+
+func (s *State) writerDispatcher() *llm.Dispatcher {
+	if s.WriterDispatcher != nil {
+		return s.WriterDispatcher
+	}
+	return s.Dispatcher
+}
+
+func (s *State) judgeDispatcher() *llm.Dispatcher {
+	if s.JudgeDispatcher != nil {
+		return s.JudgeDispatcher
+	}
+	return s.Dispatcher
 }
 
 // NewState constructs a State with sensible defaults. Fields left empty

--- a/tools/sp-pipeline/internal/pipeline/write.go
+++ b/tools/sp-pipeline/internal/pipeline/write.go
@@ -48,6 +48,10 @@ func (s *State) Write(ctx context.Context) error {
 		s.PromptTicketID = "PENDING"
 	}
 
+	disp := s.writerDispatcher()
+	if disp == nil {
+		return fmt.Errorf("write: writer dispatcher is nil")
+	}
 	prompt, err := prompts.Render("write", prompts.WriteData{
 		TicketID:       s.PromptTicketID,
 		OriginalDate:   s.OriginalDate,
@@ -56,8 +60,8 @@ func (s *State) Write(ctx context.Context) error {
 		SourceField:    s.ResolveSourceField(),
 		Angle:          s.Angle,
 		TweetURL:       s.TweetURL,
-		Model:          llm.DisplayName(s.Dispatcher.Providers()[0].Model()),
-		Harness:        llm.HarnessName(s.Dispatcher.Providers()[0].Model()),
+		Model:          llm.DisplayName(disp.Providers()[0].Model()),
+		Harness:        llm.HarnessName(disp.Providers()[0].Model()),
 		FirstTag:       s.firstTag(),
 		StyleGuide:     string(styleGuide),
 		Source:         string(source),
@@ -66,7 +70,7 @@ func (s *State) Write(ctx context.Context) error {
 		return fmt.Errorf("write: render prompt: %w", err)
 	}
 
-	res, err := s.Dispatcher.Run(ctx, prompt, llm.RunOptions{WorkDir: s.WorkDir})
+	res, err := disp.Run(ctx, prompt, llm.RunOptions{WorkDir: s.WorkDir})
 	if err != nil {
 		return NewStepError(14, fmt.Errorf("write: dispatcher failed: %w", err))
 	}
@@ -85,7 +89,7 @@ func (s *State) Write(ctx context.Context) error {
 		}
 	}
 
-	s.WriteModel = llm.DisplayName(res.Model)
+	s.WriteModel = llm.DisplayName(res.ActualModel)
 	s.WriteHarness = llm.HarnessName(res.Model)
 	s.Log.OK("Step 2: draft-v1.mdx written by %s", s.WriteModel)
 	return nil


### PR DESCRIPTION
## Summary
- route Mac writer/refine stages through Claude CLI `opus` alias while keeping judge/review/tribunal work on full Codex `gpt-5.5`
- record provider-resolved actual model IDs in pipeline/frontmatter credits instead of stamping only aliases
- update SP pipeline defaults, role dispatchers, tests, and CCC playbook notes

## Verification
- `go test ./...` from `tools/sp-pipeline`
- `bash scripts/tests/test-tribunal-safety-contract.sh`
- `tools/sp-pipeline/gp-pipeline run --help`
- `PLAYWRIGHT_BASE_URL=https://gu-log.vercel.app ./node_modules/.bin/playwright test tests/content-integrity.spec.ts --project='Desktop Chrome' --reporter=line`
- pre-commit hook passed with remote Playwright base URL
- pre-push bundle budget check passed