### PR TITLE
feat(tribunal): broker writer rewrites via subagent

### DIFF
--- a/.claude/agents/tribunal-writer.md
+++ b/.claude/agents/tribunal-writer.md
@@ -1,11 +1,13 @@
 ---
 name: tribunal-writer
 description: "Tribunal Writer — rewrite agent for the tribunal quality pipeline. Receives judge feedback and the scoring standard, then rewrites the article to address specific failures. Used across all 4 tribunal stages (Librarian, Fact Checker, Fresh Eyes, Vibe Scorer)."
-# PINNED: claude-opus-4-6[1m]. This is the SP / rewrite voice — maintainer
-# has explicitly rejected Opus 4.7's writing style (too press-release, loses
-# LHY persona). Do NOT bump to "opus" alias or 4.7 without owner sign-off.
+# PINNED: claude-opus-4-6. This is the SP / rewrite voice — maintainer has
+# explicitly rejected Opus 4.7's writing style (too press-release, loses LHY
+# persona). Do NOT bump to "opus" alias or 4.7 without owner sign-off. The
+# previous [1m] context variant requires usage credits this account does not
+# have; standard 200K context is enough to rewrite one post.
 # Matched by tools/sp-pipeline/internal/llm/claude.go ClaudeOpusPinned.
-model: claude-opus-4-6[1m]
+model: claude-opus-4-6
 tools:
   - Read
   - Write

--- a/playbooks/mac-CC-playbook.md
+++ b/playbooks/mac-CC-playbook.md
@@ -64,6 +64,84 @@ mac-cdx / mac-CC 有的 CCC 沒有的：
 
 mac-cdx 會有 `CODEX_SHELL=1`、`CODEX_INTERNAL_ORIGINATOR_OVERRIDE` 或 `__CFBundleIdentifier=com.openai.codex` 這類環境線索。需要判斷 runtime 時，先用這些訊號，不要只靠舊的 `CC` 命名。舊命名還在，是為了讓 automation 活著，不是為了讓人類困惑。
 
+## Tribunal writer mode 與子代理 broker
+
+Tribunal 評審仍由 Codex/GPT-5.5 跑；文章正文的改寫永遠只能交給 Claude 寫手。為了避免 `claude -p` 產生額外付費用量，寫手路徑由 `GP_WRITER_MODE` 明確控制：
+
+- `GP_WRITER_MODE=subagent`：Mac 互動式協調使用。pipeline 寫出請求檔，外層 CC session 讀請求後啟動 `tribunal-writer` Claude 子代理，子代理改文，最後寫完成標記。
+- `GP_WRITER_MODE=none`：不改寫，只跑評分。這也是未設定或空字串時的預設，避免靜默花 API 錢。
+- `GP_WRITER_MODE=cli`：舊的 `claude -p` 路徑，只有 operator 明確選用時可用；這會走 Claude CLI，可能產生額外付費用量。
+
+VM cron 沒有互動式 CC、沒有 `claude -p`，也沒有 API 預算，所以 VM 使用 `GP_WRITER_MODE=none` 或直接不設定；結果是只跑評分，不會嘗試改寫。
+
+### 子代理 broker protocol
+
+外層負責協調的 CC 啟動 pipeline 時設定：
+
+```bash
+export GP_WRITER_MODE=subagent
+export GP_WRITER_BROKER_DIR=/tmp/gu-log-writer-broker
+export GP_WRITER_BROKER_TIMEOUT=1800
+```
+
+`GP_WRITER_BROKER_DIR` 若未設定，pipeline 會退回寫手暫存工作目錄裡的 `.writer-broker`，並在輸出中印出實際 broker 目錄；正常 Mac 協調流程應該總是明確設定。`GP_WRITER_BROKER_TIMEOUT` 預設 1800 秒。
+
+寫手步驟會用 temp file 加 `mv` 的方式原子寫出：
+
+```json
+{
+  "id": "<post-stage-attempt-epoch>",
+  "agent_name": "tribunal-writer",
+  "post_file": "sp-xxx.mdx",
+  "post_path": "<abs path to src/content/posts/sp-xxx.mdx>",
+  "en_post_path": "<abs path to en-sp-xxx.mdx, or empty>",
+  "prompt": "<full tribunal-writer prompt>",
+  "stage": "<stage_key>",
+  "attempt": 1,
+  "created_at": "2026-06-15T00:00:00Z"
+}
+```
+
+完成標記檔與請求檔放在同一個目錄：
+
+- `<id>.done`：Claude 子代理已成功在原檔改寫；pipeline 把寫手步驟視為成功。
+- `<id>.failed`：Claude 子代理失敗；pipeline 把它視為一般寫手失敗，交給既有 cheap validation / revert 流程處理。
+- `<id>.claimed`：由等待 helper 建立，避免兩個 CC loop 拿到同一個請求。
+
+外層 CC loop 範例：
+
+```bash
+GP_WRITER_MODE=subagent GP_WRITER_BROKER_DIR="$broker_dir" \
+  tools/sp-pipeline/gp-pipeline ralph ... &
+pipeline_pid=$!
+
+while true; do
+  event="$(scripts/writer-broker-wait.sh --dir "$broker_dir" --pid "$pipeline_pid")"
+  case "$event" in
+    REQUEST\ *)
+      request_path="${event#REQUEST }"
+      # 啟動 Claude 子代理：
+      # 1. 讀取 "$request_path"。
+      # 2. 讀 request.prompt、request.post_path、需要時讀 request.en_post_path，
+      #    再讀 GU-LOG_WRITER_PROMPT.md、CONTRIBUTING.md、tribunal-writer agent spec。
+      # 3. 在原檔改寫文章。
+      # 4. 成功寫 "$broker_dir/<id>.done"，失敗寫 "<id>.failed"。
+      ;;
+    PIPELINE_DONE)
+      break
+      ;;
+  esac
+done
+```
+
+等待 helper 介面：
+
+```bash
+scripts/writer-broker-wait.sh --dir <broker_dir> --pid <pipeline_pid> [--timeout <s>]
+```
+
+它 claim 到新的未處理請求時印 `REQUEST <abs path to request.json>`；pipeline pid 已結束且沒有請求時印 `PIPELINE_DONE`；可選 timeout 到期時印 `TIMEOUT` 並用非零 exit code 結束。
+
 ## 這份 playbook 是 living doc
 
 mac-cdx / mac-CC 如果遇到 Mac 專屬的狀況需要 codify（例如發現某個本地工具的坑、某個 skill 的新用法、某個 iCloud sync 的陷阱），直接編輯這份 playbook 加進去。

--- a/scripts/tests/test-writer-broker.sh
+++ b/scripts/tests/test-writer-broker.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# shellcheck source=scripts/tribunal-helpers.sh
+# shellcheck disable=SC1091
+source "$ROOT_DIR/scripts/tribunal-helpers.sh"
+
+fail() { echo "x $*" >&2; exit 1; }
+pass() { echo "ok $*"; }
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+make_repo() {
+  local repo="$1"
+  mkdir -p "$repo/src/content/posts"
+  cat > "$repo/src/content/posts/sp-test.mdx" <<'POST'
+---
+ticketId: "SP-TEST"
+title: "Test"
+originalDate: "2026-06-15"
+translatedDate: "2026-06-15"
+translatedBy:
+  model: "Test"
+  harness: "Test"
+source: "Test"
+sourceUrl: "https://example.com"
+lang: "zh-tw"
+summary: "Test"
+---
+
+Original body.
+POST
+}
+
+wait_for_request() {
+  local broker="$1"
+  local deadline=$((SECONDS + 5))
+  local request=""
+  while [ "$SECONDS" -lt "$deadline" ]; do
+    request="$(find "$broker" -name '*.request.json' -print -quit)"
+    if [ -n "$request" ]; then
+      printf '%s\n' "$request"
+      return 0
+    fi
+    sleep 0.1
+  done
+  return 1
+}
+
+run_writer() {
+  local mode="$1"
+  local broker="$2"
+  local work_dir="$3"
+  GP_WRITER_MODE="$mode" \
+    GP_WRITER_BROKER_DIR="$broker" \
+    GP_WRITER_BROKER_TIMEOUT="${GP_WRITER_BROKER_TIMEOUT:-5}" \
+    GP_WRITER_BROKER_POLL_INTERVAL=0.1 \
+    TRIBUNAL_WRITER_POST_FILE="sp-test.mdx" \
+    TRIBUNAL_WRITER_STAGE="vibe" \
+    TRIBUNAL_WRITER_ATTEMPT=2 \
+    tribunal_writer_exec "$work_dir" "tribunal-writer" "rewrite prompt"
+}
+
+repo="$TMP/repo-success"
+broker="$TMP/broker-success"
+work="$TMP/work-success"
+make_repo "$repo"
+mkdir -p "$broker" "$work"
+export REPO_ROOT="$repo"
+
+(
+  request="$(wait_for_request "$broker")" || exit 1
+  id="$(jq -r '.id' "$request")"
+  post_path="$(jq -r '.post_path' "$request")"
+  [ "$(jq -r '.agent_name' "$request")" = "tribunal-writer" ] || exit 2
+  [ "$(jq -r '.post_file' "$request")" = "sp-test.mdx" ] || exit 3
+  [ "$(jq -r '.stage' "$request")" = "vibe" ] || exit 4
+  [ "$(jq -r '.attempt' "$request")" = "2" ] || exit 5
+  printf '\nFake rewrite complete.\n' >> "$post_path"
+  : > "$broker/$id.done"
+) &
+fulfiller_pid=$!
+
+run_writer subagent "$broker" "$work" >/dev/null
+wait "$fulfiller_pid"
+grep -q 'Fake rewrite complete' "$repo/src/content/posts/sp-test.mdx" || fail "subagent success did not alter target file"
+if find "$broker" -name '*.request.json' -o -name '*.done' -o -name '*.failed' -o -name '*.claimed' | grep -q .; then
+  fail "subagent success did not clean request/marker files"
+fi
+pass "subagent mode emits request, fake fulfiller satisfies it, and writer returns success"
+
+repo="$TMP/repo-failed"
+broker="$TMP/broker-failed"
+work="$TMP/work-failed"
+make_repo "$repo"
+mkdir -p "$broker" "$work"
+export REPO_ROOT="$repo"
+(
+  request="$(wait_for_request "$broker")" || exit 1
+  id="$(jq -r '.id' "$request")"
+  : > "$broker/$id.failed"
+) &
+fulfiller_pid=$!
+set +e
+run_writer subagent "$broker" "$work" >/dev/null 2>&1
+rc=$?
+set -e
+wait "$fulfiller_pid"
+[ "$rc" -ne 0 ] || fail "subagent failed marker should return non-zero"
+pass "subagent mode returns non-zero when fake fulfiller writes failed marker"
+
+repo="$TMP/repo-timeout"
+broker="$TMP/broker-timeout"
+work="$TMP/work-timeout"
+make_repo "$repo"
+mkdir -p "$broker" "$work"
+export REPO_ROOT="$repo"
+set +e
+GP_WRITER_BROKER_TIMEOUT=1 run_writer subagent "$broker" "$work" >/dev/null 2>&1
+rc=$?
+set -e
+[ "$rc" -ne 0 ] || fail "subagent timeout should return non-zero"
+if find "$broker" -name '*.request.json' -o -name '*.done' -o -name '*.failed' -o -name '*.claimed' | grep -q .; then
+  fail "subagent timeout did not clean request/marker files"
+fi
+pass "subagent mode times out non-zero and cleans request files"
+
+repo="$TMP/repo-none"
+broker="$TMP/broker-none"
+work="$TMP/work-none"
+make_repo "$repo"
+mkdir -p "$broker" "$work"
+export REPO_ROOT="$repo"
+set +e
+run_writer none "$broker" "$work" >/dev/null 2>&1
+rc=$?
+set -e
+[ "$rc" -ne 0 ] || fail "none mode should not report writer success"
+if find "$broker" -name '*.request.json' | grep -q .; then
+  fail "none mode emitted a broker request"
+fi
+pass "none mode skips rewrite without emitting a broker request"
+
+grep -q 'Rewrite skipped (GP_WRITER_MODE=none); failing score-only' "$ROOT_DIR/scripts/tribunal.sh" \
+  || fail "tribunal.sh should log none-mode score-only skip"
+# shellcheck disable=SC2016 # Intentionally matching literal shell variables in tribunal.sh.
+grep -q 'write_stage_progress "$post_file" "$stage_key" "fail"' "$ROOT_DIR/scripts/tribunal.sh" \
+  || fail "tribunal.sh should write fail progress when none mode skips rewrite"
+pass "none mode stage branch records fail progress"
+
+broker="$TMP/wait-helper"
+mkdir -p "$broker"
+broker_real="$(cd "$broker" && pwd -P)"
+sleep 5 &
+pipeline_pid=$!
+request="$broker/manual.request.json"
+request_real="$broker_real/manual.request.json"
+cat > "$request" <<'JSON'
+{"id":"manual"}
+JSON
+event="$("$ROOT_DIR/scripts/writer-broker-wait.sh" --dir "$broker" --pid "$pipeline_pid" --timeout 2)"
+case "$event" in
+  REQUEST\ "$request_real") ;;
+  *) fail "wait helper should print REQUEST path, got: $event" ;;
+esac
+[ -f "$broker/manual.claimed" ] || fail "wait helper did not claim request"
+rm -f "$request" "$broker/manual.claimed"
+kill "$pipeline_pid" >/dev/null 2>&1 || true
+wait "$pipeline_pid" 2>/dev/null || true
+event="$("$ROOT_DIR/scripts/writer-broker-wait.sh" --dir "$broker" --pid "$pipeline_pid" --timeout 2)"
+[ "$event" = "PIPELINE_DONE" ] || fail "wait helper should print PIPELINE_DONE, got: $event"
+pass "wait helper claims requests and reports pipeline completion"

--- a/scripts/tribunal-helpers.sh
+++ b/scripts/tribunal-helpers.sh
@@ -18,6 +18,7 @@ get_ticket_id() {
 validate_score_json() {
   local json_file="$1"
   local expected_file="$2"
+  : "$expected_file"
 
   # File exists?
   [ -f "$json_file" ] || return 1
@@ -52,8 +53,11 @@ validate_score_json() {
 # Sets: SCORE_P, SCORE_C, SCORE_V
 read_scores() {
   local json_file="$1"
+  # shellcheck disable=SC2034 # Exported-by-convention globals used by callers.
   SCORE_P=$(jq -r '.dimensions.persona' "$json_file")
+  # shellcheck disable=SC2034 # Exported-by-convention globals used by callers.
   SCORE_C=$(jq -r '.dimensions.clawdNote' "$json_file")
+  # shellcheck disable=SC2034 # Exported-by-convention globals used by callers.
   SCORE_V=$(jq -r '.dimensions.vibe' "$json_file")
 }
 
@@ -342,10 +346,11 @@ PROMPT
   local codex_cmd
   codex_cmd="$(tribunal_codex_cmd)" || return 127
   (
-    cd "$work_dir"
+    cd "$work_dir" || exit
     # Close stdin so non-interactive Codex runs don't inherit the caller's
     # open stdin and hang waiting for extra prompt text.
     exec </dev/null
+    # shellcheck disable=SC2086 # codex_cmd may be "node <bundled codex.js>".
     timeout "$timeout_sec" $codex_cmd exec --model gpt-5.5 -c "model_reasoning_effort=\"$reasoning_effort\"" --sandbox danger-full-access --skip-git-repo-check -- "$prompt"
   )
 }
@@ -390,19 +395,22 @@ tribunal_llm_provider() {
   return 1
 }
 
-# Resolve the writer provider. Unlike judge scoring, tribunal-internal prose
-# rewrites must prefer Claude when it is installed; Codex is only the VM-style
-# fallback when Claude is absent.
+# Resolve the legacy CLI writer provider. Tribunal-internal prose rewrites must
+# never fall back to Codex/GPT; the only CLI writer is explicit opt-in Claude.
 tribunal_writer_provider() {
   if tribunal_claude_cmd >/dev/null 2>&1; then
     printf 'claude\n'
     return 0
   fi
-  if tribunal_codex_cmd >/dev/null 2>&1; then
-    printf 'codex\n'
-    return 0
-  fi
   return 1
+}
+
+tribunal_writer_mode() {
+  if [ -n "${GP_WRITER_MODE:-}" ]; then
+    printf '%s\n' "$GP_WRITER_MODE"
+  else
+    printf 'none\n'
+  fi
 }
 
 # Parse the `model:` field from a .claude/agents/<name>.md spec so each judge
@@ -421,7 +429,7 @@ tribunal_claude_agent_model() {
   if [ -n "$m" ]; then
     printf '%s\n' "$m"
   else
-    printf 'claude-opus-4-6[1m]\n'
+    printf 'claude-opus-4-6\n'
   fi
 }
 
@@ -546,7 +554,7 @@ PROMPT
     perm_args=(--permission-mode bypassPermissions)
   fi
   (
-    cd "$work_dir"
+    cd "$work_dir" || exit
     printf '%s' "$prompt" | timeout "$timeout_sec" "$claude_cmd" -p --model "$model" "${perm_args[@]}"
   )
 }
@@ -596,7 +604,124 @@ tribunal_llm_exec() {
   tribunal_llm_exec_raw "$@"
 }
 
+tribunal_writer_exec_broker() {
+  local work_dir="$1"
+  local agent_name="$2"
+  local user_prompt="$3"
+  if [ -z "${REPO_ROOT:-}" ]; then
+    REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+  fi
+
+  local broker_dir="${GP_WRITER_BROKER_DIR:-$work_dir/.writer-broker}"
+  local timeout_sec="${GP_WRITER_BROKER_TIMEOUT:-1800}"
+  local poll_interval="${GP_WRITER_BROKER_POLL_INTERVAL:-2}"
+  local post_file="${TRIBUNAL_WRITER_POST_FILE:-unknown-post.mdx}"
+  local stage="${TRIBUNAL_WRITER_STAGE:-unknown}"
+  local attempt="${TRIBUNAL_WRITER_ATTEMPT:-0}"
+  local attempt_json="$attempt"
+  case "$attempt_json" in
+    ''|*[!0-9]*) attempt_json=0 ;;
+  esac
+
+  mkdir -p "$broker_dir"
+  local safe_post safe_stage epoch id request tmp done_marker failed_marker claimed_marker
+  safe_post="$(printf '%s' "$post_file" | tr -c 'A-Za-z0-9._-' '-')"
+  safe_stage="$(printf '%s' "$stage" | tr -c 'A-Za-z0-9._-' '-')"
+  epoch="$(date +%s)"
+  id="${safe_post}-${safe_stage}-${attempt_json}-${epoch}-$$-$RANDOM"
+  request="$broker_dir/$id.request.json"
+  tmp="$broker_dir/$id.request.json.tmp.$$"
+  done_marker="$broker_dir/$id.done"
+  failed_marker="$broker_dir/$id.failed"
+  claimed_marker="$broker_dir/$id.claimed"
+
+  local post_path en_post_path created_at
+  post_path="$REPO_ROOT/src/content/posts/$post_file"
+  en_post_path=""
+  if [ -f "$REPO_ROOT/src/content/posts/en-$post_file" ]; then
+    en_post_path="$REPO_ROOT/src/content/posts/en-$post_file"
+  fi
+  created_at="$(TZ=UTC date '+%Y-%m-%dT%H:%M:%SZ')"
+
+  jq -n \
+    --arg id "$id" \
+    --arg agent_name "$agent_name" \
+    --arg post_file "$post_file" \
+    --arg post_path "$post_path" \
+    --arg en_post_path "$en_post_path" \
+    --arg prompt "$user_prompt" \
+    --arg stage "$stage" \
+    --argjson attempt "$attempt_json" \
+    --arg created_at "$created_at" \
+    '{
+      id: $id,
+      agent_name: $agent_name,
+      post_file: $post_file,
+      post_path: $post_path,
+      en_post_path: $en_post_path,
+      prompt: $prompt,
+      stage: $stage,
+      attempt: $attempt,
+      created_at: $created_at
+    }' > "$tmp"
+  mv "$tmp" "$request"
+
+  printf 'writer broker request: %s\n' "$request"
+  printf 'writer broker dir: %s\n' "$broker_dir"
+
+  local start now
+  start="$(date +%s)"
+  while true; do
+    if [ -f "$done_marker" ]; then
+      rm -f "$request" "$done_marker" "$failed_marker" "$claimed_marker"
+      return 0
+    fi
+    if [ -f "$failed_marker" ]; then
+      echo "ERROR: tribunal-writer broker request failed: $request" >&2
+      rm -f "$request" "$done_marker" "$failed_marker" "$claimed_marker"
+      return 1
+    fi
+    now="$(date +%s)"
+    if [ $((now - start)) -ge "$timeout_sec" ]; then
+      echo "WARN: tribunal-writer broker timed out after ${timeout_sec}s waiting for $request" >&2
+      rm -f "$request" "$done_marker" "$failed_marker" "$claimed_marker"
+      return 1
+    fi
+    sleep "$poll_interval"
+  done
+}
+
 tribunal_writer_exec_raw() {
+  local work_dir="$1"
+  local agent_name="$2"
+  local user_prompt="$3"
+  case "$(tribunal_writer_mode)" in
+    subagent)
+      tribunal_writer_exec_broker "$work_dir" "$agent_name" "$user_prompt"
+      ;;
+    none)
+      echo "rewrite skipped (GP_WRITER_MODE=none)" >&2
+      return 76
+      ;;
+    cli)
+      case "$(tribunal_writer_provider 2>/dev/null)" in
+        claude)
+          tribunal_claude_exec "$work_dir" "$agent_name" "$user_prompt"
+          ;;
+        *)
+          echo "ERROR: GP_WRITER_MODE=cli requires claude on PATH; refusing Codex/GPT writer fallback" >&2
+          return 127
+          ;;
+      esac
+      ;;
+    *)
+      echo "ERROR: unsupported GP_WRITER_MODE='$(tribunal_writer_mode)' (expected none, subagent, or cli)" >&2
+      return 2
+      ;;
+  esac
+}
+
+tribunal_writer_exec_raw_legacy_cli() {
   local work_dir="$1"
   local agent_name="$2"
   local user_prompt="$3"
@@ -604,11 +729,8 @@ tribunal_writer_exec_raw() {
     claude)
       tribunal_claude_exec "$work_dir" "$agent_name" "$user_prompt"
       ;;
-    codex)
-      tribunal_codex_exec "$work_dir" "$agent_name" "$user_prompt"
-      ;;
     *)
-      echo "ERROR: no tribunal writer provider available (need claude or codex on PATH)" >&2
+      echo "ERROR: GP_WRITER_MODE=cli requires claude on PATH; refusing Codex/GPT writer fallback" >&2
       return 127
       ;;
   esac
@@ -787,12 +909,19 @@ tribunal_writer_exec() {
   local work_dir="$1"
   local agent_name="$2"
   local user_prompt="$3"
+  local mode
+  mode="$(tribunal_writer_mode)"
+  if [ "$mode" != "cli" ]; then
+    tribunal_writer_exec_raw "$work_dir" "$agent_name" "$user_prompt"
+    return $?
+  fi
+
   local waits=0 provider out rc qrc
   provider="$(tribunal_writer_provider 2>/dev/null || true)"
   while true; do
     out="$(mktemp)"
     rc=0
-    tribunal_writer_exec_raw "$work_dir" "$agent_name" "$user_prompt" >"$out" 2>&1 || rc=$?
+    tribunal_writer_exec_raw_legacy_cli "$work_dir" "$agent_name" "$user_prompt" >"$out" 2>&1 || rc=$?
     cat "$out"
     if [ "$rc" -eq 0 ]; then
       rm -f "$out"

--- a/scripts/tribunal.sh
+++ b/scripts/tribunal.sh
@@ -31,10 +31,11 @@ source "$SCRIPT_DIR/score-helpers.sh"
 # shellcheck source=scripts/tribunal-helpers.sh
 source "$SCRIPT_DIR/tribunal-helpers.sh"
 
-# shellcheck source=scripts/tribunal-run-control.sh
 # Graceful stop helpers — file-flag only channel (no traps here; parent
 # loop owns signals and writes the flag file on stop).
 export RC_ROOT_DIR="$ROOT_DIR"
+# shellcheck source=scripts/tribunal-run-control.sh
+# shellcheck disable=SC1091
 source "$SCRIPT_DIR/tribunal-run-control.sh"
 
 # ─── Args ─────────────────────────────────────────────────────────────────────
@@ -131,7 +132,8 @@ mkdir -p "$LOG_DIR"
 LOG_FILE="$LOG_DIR/tribunal-$(TZ=Asia/Taipei date +%Y%m%d-%H%M%S)-${POST_FILE%.mdx}.log"
 
 tlog() {
-  local msg="[$(TZ=Asia/Taipei date '+%Y-%m-%d %H:%M:%S %z')] [tribunal] $*"
+  local msg
+  msg="[$(TZ=Asia/Taipei date '+%Y-%m-%d %H:%M:%S %z')] [tribunal] $*"
   echo "$msg" | tee -a "$LOG_FILE"
 }
 
@@ -204,7 +206,6 @@ init_article_progress() {
   local article="$1"
   # Entire init + attempts increment + cap check runs under a single
   # flock so two workers can't both see attempts=N and both bump to N+1.
-  local exhausted=0
   (
     flock -x 9
     local tmp
@@ -529,6 +530,12 @@ $evidence
 5. Do not rewrite unrelated content and do not change stable frontmatter fields unless the build error specifically requires it.
 PROMPT
 )"
+  local writer_mode
+  writer_mode="$(tribunal_writer_mode)"
+  if [ "$writer_mode" = "none" ]; then
+    tlog "  Rewrite skipped (GP_WRITER_MODE=none) during final build repair; failing without invoking tribunal-writer."
+    return 1
+  fi
   writer_out="$(mktemp)"
   writer_quota_status_file="$(mktemp)"
   writer_rc=0
@@ -537,6 +544,9 @@ PROMPT
   local writer_work_dir
   writer_work_dir="$(tribunal_llm_work_dir)"
   TRIBUNAL_QUOTA_STATUS_FILE="$writer_quota_status_file" \
+    TRIBUNAL_WRITER_POST_FILE="$post_file" \
+    TRIBUNAL_WRITER_STAGE="finalBuild" \
+    TRIBUNAL_WRITER_ATTEMPT="$repair_attempt" \
     tribunal_writer_exec "$writer_work_dir" "tribunal-writer" "$writer_prompt" > "$writer_out" 2>&1 || writer_rc=$?
   rm -rf "$writer_work_dir"
   if [ "$writer_rc" -eq 75 ]; then
@@ -721,7 +731,7 @@ run_stage() {
   ssot_content="$(cat "$ROOT_DIR/scripts/vibe-scoring-standard.md")"
 
   local score_tmp
-  score_tmp="$(mktemp /tmp/tribunal-${stage_key}-XXXXXX.json)"
+  score_tmp="$(mktemp /tmp/tribunal-"${stage_key}"-XXXXXX.json)"
 
   local attempt=0
   while [ "$attempt" -lt "$max_loops" ]; do
@@ -968,6 +978,14 @@ Follow $ROOT_DIR/GU-LOG_WRITER_PROMPT.md and $ROOT_DIR/CONTRIBUTING.md frontmatt
 Do NOT change frontmatter fields (title, ticketId, dates, sourceUrl). Preserve MDX components, URLs, source attribution, and already-passing dimensions unless the judge feedback explicitly targets them.
 PROMPT
 )"
+    local writer_mode
+    writer_mode="$(tribunal_writer_mode)"
+    if [ "$writer_mode" = "none" ]; then
+      tlog "  Rewrite skipped (GP_WRITER_MODE=none); failing score-only without invoking tribunal-writer."
+      write_stage_progress "$post_file" "$stage_key" "fail" "$score_json" "$runner_label" "$attempt"
+      rm -f "$score_tmp"
+      return 1
+    fi
     writer_out="$(mktemp)"
     writer_quota_status_file="$(mktemp)"
     writer_rc=0
@@ -977,6 +995,9 @@ PROMPT
     local rewrite_work_dir
     rewrite_work_dir="$(tribunal_llm_work_dir)"
     TRIBUNAL_QUOTA_STATUS_FILE="$writer_quota_status_file" \
+      TRIBUNAL_WRITER_POST_FILE="$post_file" \
+      TRIBUNAL_WRITER_STAGE="$stage_key" \
+      TRIBUNAL_WRITER_ATTEMPT="$attempt" \
       tribunal_writer_exec "$rewrite_work_dir" "tribunal-writer" "$writer_prompt" > "$writer_out" 2>&1 || writer_rc=$?
     rm -rf "$rewrite_work_dir"
 

--- a/scripts/writer-broker-wait.sh
+++ b/scripts/writer-broker-wait.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0 --dir <broker_dir> --pid <pipeline_pid> [--timeout <s>]" >&2
+}
+
+broker_dir=""
+pipeline_pid=""
+timeout_sec=""
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --dir)
+      broker_dir="${2:-}"
+      shift 2
+      ;;
+    --pid)
+      pipeline_pid="${2:-}"
+      shift 2
+      ;;
+    --timeout)
+      timeout_sec="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "ERROR: unknown argument: $1" >&2
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+if [ -z "$broker_dir" ] || [ -z "$pipeline_pid" ]; then
+  usage
+  exit 2
+fi
+
+if [ ! -d "$broker_dir" ]; then
+  echo "ERROR: broker dir not found: $broker_dir" >&2
+  exit 2
+fi
+
+broker_dir="$(cd "$broker_dir" && pwd -P)"
+
+pid_alive() {
+  kill -0 "$pipeline_pid" >/dev/null 2>&1
+}
+
+try_claim_request() {
+  local request base id done_marker failed_marker claimed_marker
+  for request in "$broker_dir"/*.request.json; do
+    [ -e "$request" ] || return 1
+    base="$(basename "$request")"
+    id="${base%.request.json}"
+    done_marker="$broker_dir/$id.done"
+    failed_marker="$broker_dir/$id.failed"
+    claimed_marker="$broker_dir/$id.claimed"
+    if [ -e "$done_marker" ] || [ -e "$failed_marker" ] || [ -e "$claimed_marker" ]; then
+      continue
+    fi
+    if ( set -C; : > "$claimed_marker" ) 2>/dev/null; then
+      printf 'REQUEST %s\n' "$request"
+      return 0
+    fi
+  done
+  return 1
+}
+
+start="$(date +%s)"
+while true; do
+  if try_claim_request; then
+    exit 0
+  fi
+
+  if ! pid_alive; then
+    if ! compgen -G "$broker_dir/*.request.json" >/dev/null; then
+      echo "PIPELINE_DONE"
+      exit 0
+    fi
+  fi
+
+  if [ -n "$timeout_sec" ]; then
+    now="$(date +%s)"
+    if [ $((now - start)) -ge "$timeout_sec" ]; then
+      echo "TIMEOUT"
+      exit 1
+    fi
+  fi
+
+  sleep 1
+done


### PR DESCRIPTION
## Summary

- Adds `GP_WRITER_MODE` dispatch for tribunal writer rewrites: `none` by default, `subagent` for the broker flow, and explicit `cli` for legacy `claude -p` usage.
- Adds the writer broker request/marker protocol and `scripts/writer-broker-wait.sh` for the outer CC orchestration loop.
- Removes Codex/GPT as a writer fallback, updates tribunal-writer from `claude-opus-4-6[1m]` to standard `claude-opus-4-6`, and documents the Mac/VM operating modes.
- Adds a shell test with fake broker fulfillers for success, failed marker, timeout, none-mode skip, and wait-helper claim behavior.

## Validation

- `bash scripts/tests/test-writer-broker.sh`
- `bash scripts/tests/test-tribunal-shell-quota-parser.sh`
- `bash -n scripts/tribunal.sh scripts/tribunal-helpers.sh scripts/writer-broker-wait.sh scripts/tests/test-writer-broker.sh`
- `shellcheck -x -P . scripts/tribunal.sh scripts/tribunal-helpers.sh scripts/writer-broker-wait.sh scripts/tests/test-writer-broker.sh`
- `cd tools/sp-pipeline && go build ./...`
- `cd tools/sp-pipeline && go test ./...`

## Notes

- This PR intentionally does not merge to `main`; a separate reviewer should gate the merge.
- `.claude/agents/vibe-opus-scorer.md` still pins `[1m]`; that is left as a known follow-up because this change is scoped to the writer path.