### PR TITLE
docs(openspec): plan post version manifest autofix

### DIFF
--- a/openspec/changes/automate-post-version-manifest-freshness/design.md
+++ b/openspec/changes/automate-post-version-manifest-freshness/design.md
@@ -1,0 +1,144 @@
+# Design: Post version manifest freshness automation
+
+## Current behavior
+
+`scripts/build-version-manifest.mjs` counts commits touching
+`src/content/posts/*.mdx` and writes `src/data/post-versions.json`.
+
+Because the count is history-sensitive, running the generator before the final
+content commit exists can still leave the committed manifest stale. CI catches
+this through `tests/post-version-manifest.test.ts`, which validates the committed
+manifest against a full-history checkout.
+
+`scripts/hooks/pre-push` already helps: it checks freshness, regenerates the
+manifest if stale, and aborts the push. The missing step is a repo-owned repair
+that creates the required manifest commit without relying on the operator to
+remember it.
+
+## Proposed flow
+
+Install a new `post-commit` hook:
+
+```bash
+scripts/hooks/post-commit
+```
+
+The hook calls a Node helper, for example:
+
+```bash
+node scripts/refresh-post-version-manifest-after-commit.mjs
+```
+
+The helper only runs when the latest commit touched posts:
+
+```bash
+git diff-tree --no-commit-id --name-only -r HEAD -- src/content/posts
+```
+
+If no post changed, it exits 0.
+
+If a post changed, it:
+
+1. Ensures the clone can see full history.
+2. Runs `node scripts/build-version-manifest.mjs`.
+3. Checks whether `src/data/post-versions.json` changed.
+4. If unchanged, exits 0.
+5. If changed, stages only `src/data/post-versions.json`.
+6. Creates a generated follow-up commit:
+
+   ```bash
+   git commit -m "chore: refresh post version manifest"
+   ```
+
+## Recursion guard
+
+The generated manifest commit must not trigger itself forever. Use an env guard:
+
+```bash
+GU_LOG_POST_VERSION_AUTOCOMMIT=1
+```
+
+The `post-commit` hook exits immediately when that variable is set. The helper
+sets it only around the generated commit.
+
+The helper should also no-op when the latest commit does not touch
+`src/content/posts/*.mdx`, so a manifest-only commit is naturally ignored even
+without the env guard.
+
+## Shallow clone policy
+
+The helper may try to deepen history locally:
+
+```bash
+git fetch --unshallow --quiet origin
+# fallback:
+git fetch --depth=2147483647 --quiet origin
+```
+
+If it still cannot get meaningful full history, it must not write an incomplete
+manifest. It should print a clear warning and exit 0 so the content commit is
+not blocked locally. `pre-push` and CI remain the blocking layers.
+
+## Dirty worktree policy
+
+The helper should be conservative. It may auto-commit only when:
+
+- `HEAD` exists;
+- the repo is not in merge, rebase, cherry-pick, or revert state;
+- the latest commit is not itself the generated manifest commit;
+- there are no staged changes before the helper stages the manifest;
+- there are no unstaged changes to `src/data/post-versions.json` before
+  regeneration;
+- after regeneration, only `src/data/post-versions.json` changed.
+
+If unrelated dirty files exist, the first implementation should refuse to
+auto-commit and print the exact repair command. This avoids attributing a
+generated commit to an unclear worktree state.
+
+## Why follow-up commit instead of amend
+
+Follow-up commit is noisier, but safer:
+
+- it does not rewrite the commit the user or agent just created;
+- it avoids surprises with signed commits and commit metadata;
+- it works even when the authored commit already passed hooks;
+- it keeps the generated repair visible and easy to inspect.
+
+`pre-push` can still keep its existing "regenerate and abort" behavior as a
+fallback. A future change may add an explicit `--amend` repair command for
+agents, but the default long-term guardrail should not rewrite history.
+
+## Pre-push and CI remain final gates
+
+Do not remove the existing checks:
+
+- `pre-push` still catches missing or failed `post-commit` hooks.
+- CI still validates the committed manifest with full history.
+- `scripts/build-version-manifest.mjs --check` should update its stale message
+  to mention the new hook/helper and the manual fallback.
+
+## Tests
+
+Add synthetic repo tests for the helper:
+
+- latest commit touches a post and stale manifest becomes a generated follow-up
+  commit;
+- generated manifest commit does not recurse;
+- non-post commit exits without changes;
+- shallow clone that cannot deepen does not write an incomplete manifest;
+- dirty unrelated worktree refuses auto-commit and leaves actionable output;
+- existing CI freshness test still fails stale manifests.
+
+Extend hook integration tests to verify:
+
+- `setup-hooks.sh` installs `post-commit`;
+- `post-commit` invokes the helper;
+- `pre-push` remains a fallback when the hook is missing.
+
+## Rollout
+
+1. Implement helper and hook.
+2. Add tests.
+3. Update setup-hooks.
+4. Update docs and agent playbooks.
+5. Observe a few content PRs before considering CI auto-commit or amend mode.

--- a/openspec/changes/automate-post-version-manifest-freshness/proposal.md
+++ b/openspec/changes/automate-post-version-manifest-freshness/proposal.md
@@ -1,0 +1,63 @@
+# Proposal: Automate post version manifest freshness
+
+## Why
+
+`src/data/post-versions.json` is derived from full git history. For a
+reader-visible post edit, the final value is only knowable after the commit
+exists. That is why the current agent workflow can pass local build, push a PR,
+and still fail CI later with a stale manifest.
+
+The repo already has guardrails:
+
+- `tests/post-version-manifest.test.ts` catches stale manifests in CI.
+- `scripts/hooks/pre-push` can detect staleness, regenerate the file, and abort.
+
+But the repair still depends on a human or agent remembering the last step:
+commit the regenerated manifest, or amend the previous commit, then push again.
+This should be machine work.
+
+## What Changes
+
+- Add a `post-commit` hook that runs after a local commit touches
+  `src/content/posts/*.mdx`.
+- The hook refreshes `src/data/post-versions.json` against the new `HEAD`.
+- If the manifest changed, automation creates a generated follow-up commit such
+  as `chore: refresh post version manifest`.
+- Keep `pre-push` and CI as layered safety nets for missing hooks, shallow
+  history, failed regeneration, or skipped local automation.
+- Document that agents should no longer rely on memory for this sequence; the
+  repo owns the repair loop.
+
+## Non-goals
+
+- Do not predict the next manifest from `pre-commit`; the commit does not exist
+  yet and history simulation is fragile.
+- Do not rewrite the user's just-created commit by default.
+- Do not auto-commit from CI in the first implementation.
+- Do not remove the committed manifest or change its semantics from full-history
+  post touch counts.
+- Do not let Vercel shallow builds regenerate this manifest; production still
+  serves the committed file.
+
+## Capabilities
+
+### New Capabilities
+
+- `post-version-manifest-freshness`: defines the post-commit automation and
+  layered freshness checks for `post-versions.json`.
+
+### Modified Capabilities
+
+- None.
+
+## Impact
+
+This changes local authoring, agent shipping workflows, git hook installation,
+and CI diagnostics. It should remove the recurring "commit → push → CI stale
+manifest → amend → push again" failure mode for content PRs while preserving CI
+as the final authority.
+
+## Approval Meaning
+
+Approving this change means gu-log should treat `post-versions.json` freshness
+as an automated post-commit repair, not as an agent checklist item.

--- a/openspec/changes/automate-post-version-manifest-freshness/specs/post-version-manifest-freshness/spec.md
+++ b/openspec/changes/automate-post-version-manifest-freshness/specs/post-version-manifest-freshness/spec.md
@@ -1,0 +1,44 @@
+## ADDED Requirements
+
+### Requirement: Post-changing commits SHALL leave the post version manifest fresh
+
+When a local commit changes `src/content/posts/*.mdx`, gu-log SHALL attempt to
+refresh `src/data/post-versions.json` after the commit exists in git history.
+
+#### Scenario: Commit changes a post
+
+- GIVEN a local commit touches `src/content/posts/*.mdx`
+- WHEN the commit completes locally
+- THEN automation SHALL run the post version manifest generator against the new `HEAD`
+- AND `src/data/post-versions.json` SHALL be made fresh before push readiness when full history is available
+
+#### Scenario: Manifest changes after regeneration
+
+- GIVEN post-commit regeneration changes `src/data/post-versions.json`
+- WHEN local git hooks are installed and the worktree is safe for generated commits
+- THEN automation SHALL create a separate generated follow-up commit
+- AND the generated commit SHALL NOT touch post MDX files
+
+#### Scenario: Hook cannot safely regenerate
+
+- GIVEN full git history is unavailable or the worktree is unsafe for generated commits
+- WHEN the post-commit automation runs
+- THEN it SHALL NOT write or commit an incomplete manifest
+- AND it SHALL print an actionable fallback
+
+### Requirement: Freshness checks SHALL remain layered
+
+Pre-push and CI SHALL remain blocking guards even when post-commit automation
+exists.
+
+#### Scenario: Hook missing or skipped
+
+- GIVEN a contributor does not have local hooks installed or skips local hooks
+- WHEN they push stale `src/data/post-versions.json`
+- THEN pre-push or CI SHALL fail with an actionable message
+
+#### Scenario: CI validates the committed manifest
+
+- GIVEN a pull request changes reader-visible post history
+- WHEN CI runs unit tests
+- THEN `tests/post-version-manifest.test.ts` SHALL validate that the committed manifest matches full git history

--- a/openspec/changes/automate-post-version-manifest-freshness/tasks.md
+++ b/openspec/changes/automate-post-version-manifest-freshness/tasks.md
@@ -1,0 +1,37 @@
+# Tasks
+
+## 1. OpenSpec
+
+- [ ] 1.1 Add `post-version-manifest-freshness` capability spec delta.
+- [ ] 1.2 Validate the change with OpenSpec when the CLI is available.
+
+## 2. Post-commit automation
+
+- [ ] 2.1 Add `scripts/hooks/post-commit`.
+- [ ] 2.2 Add `scripts/refresh-post-version-manifest-after-commit.mjs`.
+- [ ] 2.3 Detect whether latest `HEAD` touches `src/content/posts/*.mdx`.
+- [ ] 2.4 Regenerate `src/data/post-versions.json` only when full history is available.
+- [ ] 2.5 Create generated follow-up commit when the manifest changes.
+- [ ] 2.6 Add recursion guard so generated manifest commits do not trigger another generated commit.
+- [ ] 2.7 Refuse auto-commit on dirty unrelated worktree, in-progress git operations, or incomplete history.
+
+## 3. Existing guardrails
+
+- [ ] 3.1 Keep `pre-push` freshness check as a fallback.
+- [ ] 3.2 Improve `scripts/build-version-manifest.mjs --check` stale message to mention the new helper/hook.
+- [ ] 3.3 Ensure `scripts/setup-hooks.sh` installs `post-commit` and syncs `.githooks/post-commit`.
+- [ ] 3.4 Keep CI `tests/post-version-manifest.test.ts` as final authority.
+
+## 4. Tests
+
+- [ ] 4.1 Add helper tests with synthetic repos for stale/fresh/non-post commits.
+- [ ] 4.2 Add recursion guard test for generated manifest commit.
+- [ ] 4.3 Add dirty worktree refusal test.
+- [ ] 4.4 Add hook installation/integration test for `post-commit`.
+- [ ] 4.5 Run targeted vitest and full build.
+
+## 5. Docs
+
+- [ ] 5.1 Update `CONTRIBUTING.md` to explain automatic manifest repair.
+- [ ] 5.2 Update `CLAUDE.md` / agent playbook so agents no longer manually remember the post-commit manifest sequence.
+- [ ] 5.3 Document the fallback when hooks are not installed: run the helper or rely on pre-push/CI error output.


### PR DESCRIPTION
## Summary
- Adds an OpenSpec change for long-term automation of post-versions.json freshness.
- Chooses a post-commit generated follow-up commit as the primary repair path.
- Keeps pre-push and CI as layered safety nets when hooks are missing or repair is unsafe.

## Scope
Planning only. No runtime hook or script implementation in this PR.

## Validation
- git diff --check
- OpenSpec CLI was unavailable in this environment, so strict OpenSpec validation is listed as an implementation task.