### PR TITLE
fix(tribunal): cli writer uses auto permission mode; surface writer errors

### DIFF
--- a/scripts/tribunal-helpers.sh
+++ b/scripts/tribunal-helpers.sh
@@ -533,7 +533,12 @@ PROMPT
   timeout_sec="${TRIBUNAL_CODEX_TIMEOUT_SEC:-3600}"
   claude_cmd="$(tribunal_claude_cmd)" || return 127
   # Permission handling differs by uid:
-  #  - non-root (mac/VPS): bypassPermissions never prompts — judge runs free.
+  #  - non-root (mac/VPS): auto mode runs free without prompting. NOTE: we used
+  #    to use bypassPermissions here, but on current CC `claude -p
+  #    --permission-mode bypassPermissions` exits 1 the moment the agent invokes
+  #    a tool (Edit/Write), so the writer never rewrote. auto mode auto-approves
+  #    the read/edit/write the writer+judge need (verified editing an
+  #    out-of-cwd post) and is the maintainer's chosen mode (no bypassPermissions).
   #  - root (CCC sandbox): claude *rejects* bypassPermissions, so we fall back to
   #    acceptEdits. But acceptEdits only auto-approves *edits*; the judge task
   #    passes the post as a PATH (not inlined), so the judge must Read it — which
@@ -551,7 +556,7 @@ PROMPT
   if [ "$(id -u)" = "0" ]; then
     perm_args=(--permission-mode acceptEdits --allowed-tools "Read,Grep,Glob,Bash,Write,Edit,MultiEdit")
   else
-    perm_args=(--permission-mode bypassPermissions)
+    perm_args=(--permission-mode auto)
   fi
   (
     cd "$work_dir" || exit

--- a/scripts/tribunal.sh
+++ b/scripts/tribunal.sh
@@ -1012,6 +1012,10 @@ PROMPT
 
     if [ "$writer_rc" -ne 0 ]; then
       tlog "  WARN: tribunal-writer exited with code $writer_rc"
+      # Surface the writer's own output so a non-quota failure (e.g. a permission
+      # rejection, a CLI error) is diagnosable instead of silently discarded.
+      # Mirrors the final-build repair path's dump.
+      tail -15 "$writer_out" | while IFS= read -r line; do tlog "    $line"; done
     fi
     rm -f "$writer_out" "$writer_quota_status_file"
 


### PR DESCRIPTION
## What

The mac/non-root `cli` writer ran `claude -p --permission-mode bypassPermissions`. On current Claude Code that **exits 1 the instant the agent invokes a tool** (Edit/Write), so `tribunal-writer` never actually rewrote the post — it died in ~8s and the *unchanged* post got re-scored (looked like a flaky low score, was really a no-op writer).

## Fix

- `scripts/tribunal-helpers.sh`: non-root writer/judge path switches `--permission-mode bypassPermissions` → `--permission-mode auto`. `auto` auto-approves the read/edit/write the writer needs without prompting. Verified end-to-end: the writer edits an out-of-cwd post and runs a full ~4-min rewrite (vs the old instant 8s exit-1). Maintainer also prefers `auto` over `bypassPermissions`.
- `scripts/tribunal.sh`: dump the writer's output (`tail -15`) on a non-quota failure in the per-stage rewrite path. It was silently discarded before, which made this bug hard to diagnose; the final-build repair path already dumps.

Root (CCC) branch is untouched (still `acceptEdits` + allowlist).

## Test

- `bash scripts/tests/test-writer-broker.sh` — 6/6 pass
- `bash scripts/tests/test-tribunal-shell-quota-parser.sh` — 4/4 pass
- `bash -n` + `shellcheck -x` clean on both files
- pre-commit content-integrity — 10/10 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)