### PR TITLE
fix(sp-232): 引言就點明「六個字」是哪六個字（ShroomDog 回饋）

### DIFF
--- a/docs/shroomdog-editorial-feedback.md
+++ b/docs/shroomdog-editorial-feedback.md
@@ -380,3 +380,13 @@ Sprin asked whether Tribunal v7 FreshEyes covers “length should be just right,
 - 情境：SD-26 用「三百多篇 AI 翻譯文章」描述 gu-log 規模。這低估了目前內容量，也把 MP 精選、SD 原創、教學混成「AI 翻譯文章」，分類不準。
 - 修法：改成「五百多篇文章——大約兩百篇 GP 翻譯、三百篇 MP 精選，外加 SD 跟教學」。後續句子只用「五百多篇 / 500 posts」，避免每次重複解釋 taxonomy。
 - Reusable lesson：談 gu-log 全站規模時，不要憑印象寫「三百多」。要先算 active unique posts，並區分 GP / MP / SD / LevelUp。若文意不是只談翻譯，不要寫成「AI 翻譯文章」。
+
+## 2026-06-17 — SP-232 loop engineering /「六個字」沒講是哪六個字
+
+### Feedback: 標題/引言一直說「六個字的咒語」，卻從頭到尾沒講那六個字是什麼
+
+- ShroomDog feedback：`什麼東西六個字？三小xD 太沒資訊量了吧`（看 SP-232 標題與引言時）
+- 情境：SP-232 開場 hook 是「一句六個字的咒語衝到 220 萬瀏覽」，正文又反覆出現「那六個字」「一句六個字的話」，但**從來沒有把那六個英文字寫出來**。原文 mvanhorn 說 the most repeated sentence is "six words long"，指的是 Steinberger 那句的英文核心「design loops that prompt your agents」（剛好六個 word）。漏掉它＝把整個 hook 變成空殼，讀者被吊著卻拿不到 payoff。
+- 翻譯陷阱（中文版更糟）：英文 six words 很自然，但中文「六個字」會被讀成「六個漢字」。引言裡那句翻成中文的咒語明明十幾個漢字，讀者一對照就覺得「哪來六個字？」——word 與「字」的計數單位不一樣，直接搬會製造矛盾感。
+- 修法：引言第一段就把那六個字攤開——zh 改成「那句話濃縮成英文就六個字——『design loops that prompt your agents』（去設計那些會 prompt agent 的 loop）」；en 改成「Compressed, it's six words — "design loops that prompt your agents"」。英文原句包在引號裡（直接引用原文，jingjing 放行），後面附中文翻譯。標題與後面的「那六個字」callback 就站得住了，因為 payoff 已在第一段交付。
+- Reusable lesson：(1) 任何「數字＋名詞」的 hook（六個字、三句話、兩張圖、一行指令）都必須在開場附近**把那個東西本體交出來**，不能只丟數字吊胃口；hook 的 promise 要在同段或下一段兌現。(2) 跨語言搬「count words」類說法要小心單位錯位——英文 word ≠ 中文「字」。要保留「精簡到很短」的張力時，中文要嘛點明「英文六個字」並秀出英文，要嘛改用不綁計數單位的講法（例如「短到不行的一句」）。

--- a/src/content/posts/en-sp-232-20260617-mvanhorn-wtf-is-a-loop.mdx
+++ b/src/content/posts/en-sp-232-20260617-mvanhorn-wtf-is-a-loop.mdx
@@ -19,7 +19,7 @@ tags: ["shroom-picks", "loop", "agent", "ralph-loop", "claude-code"]
 
 import ClawdNote from '../../components/ClawdNote.astro';
 
-In early June 2026, the entire AI-coding timeline got grabbed by the throat by one sentence. The sentence is six words long — and the funniest part is that almost everyone repeating it could not tell you what it meant.
+In early June 2026, the entire AI-coding timeline got grabbed by the throat by one sentence. Compressed, it's six words — "design loops that prompt your agents" — and the funniest part is that almost everyone repeating it could not tell you what it meant.
 
 [Peter Steinberger](/en/glossary#peter-steinberger) — creator of [OpenClaw](/en/glossary#openclaw), now at OpenAI — fired first. On June 7, this post cleared 2.2 million views:
 

--- a/src/content/posts/sp-232-20260617-mvanhorn-wtf-is-a-loop.mdx
+++ b/src/content/posts/sp-232-20260617-mvanhorn-wtf-is-a-loop.mdx
@@ -30,7 +30,7 @@ scores:
 
 import ClawdNote from '../../components/ClawdNote.astro';
 
-2026 六月初，整條 AI coding 的時間軸被一句話掐住喉嚨。那句話只有六個字——英文六個字——而且最妙的是：幾乎每個在轉發它的人，都說不清楚它到底什麼意思。
+2026 六月初，整條 AI coding 的時間軸被一句話掐住喉嚨。那句話濃縮成英文就六個字——「design loops that prompt your agents」（去設計那些會 prompt agent 的 loop）——而最妙的是：幾乎每個在轉發它的人，都說不清楚它到底什麼意思。
 
 開砲的是 [OpenClaw](/glossary#openclaw) 的作者 [Peter Steinberger](/glossary#peter-steinberger)（現在人在 OpenAI）。六月七號，這則貼文衝到 220 萬瀏覽：
 

--- a/src/data/post-versions.json
+++ b/src/data/post-versions.json
@@ -1,10 +1,10 @@
 {
+  "en-sp-232-20260617-mvanhorn-wtf-is-a-loop": 3,
+  "sp-232-20260617-mvanhorn-wtf-is-a-loop": 2,
   "en-sp-233-20260617-polished-ui-rules": 2,
   "sp-233-20260617-polished-ui-rules": 1,
-  "en-sp-232-20260617-mvanhorn-wtf-is-a-loop": 2,
   "en-sp-pending-20260617-polished-ui-rules": 1,
   "sp-pending-20260617-polished-ui-rules": 1,
-  "sp-232-20260617-mvanhorn-wtf-is-a-loop": 1,
   "en-sp-231-20260614-arxiv-coding-agents-fail-users": 1,
   "sp-231-20260614-arxiv-coding-agents-fail-users": 1,
   "en-sp-210-20260523-jxnlco-codex-computer-work-system": 3,


### PR DESCRIPTION
## 問題（ShroomDog 回饋）

> `什麼東西六個字？三小xD 太沒資訊量了吧`

SP-232 的 hook 一直講「六個字的咒語」「那六個字」，卻**從頭到尾沒寫出那六個字是什麼**——讀者被吊著拿不到 payoff。中文版更糟：「六個字」會被讀成六個漢字，但引言裡翻成中文的咒語明明十幾個漢字，對不上（word ≠ 字）。

## 修法

引言第一段直接攤開那六個英文字（Steinberger 那句的核心，原文 mvanhorn 說的 "six words"）：

- **zh**：「那句話濃縮成英文就六個字——『design loops that prompt your agents』（去設計那些會 prompt agent 的 loop）」
- **en**：「Compressed, it's six words — "design loops that prompt your agents"」

英文原句包在引號裡（直接引用原文，jingjing 放行）＋中文翻譯。標題與後面「那六個字」的 callback 就站得住了，因為 payoff 在第一段就交付。

回饋已進 `docs/shroomdog-editorial-feedback.md`：數字型 hook 要在開場兌現本體；跨語言搬 count-words 說法要注意 word/字 單位錯位。

## 驗證

jingjing ✅、pronoun-clarity ✅、validate ✅、content-integrity 10/10 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TDQ1uhoeCc9UFKDDMhaGr9)_