### PR TITLE
chore(claude): 開啟 fork subagent type

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,7 @@
 {
+  "env": {
+    "CLAUDE_CODE_FORK_SUBAGENT": "1"
+  },
   "hooks": {
     "SessionStart": [
       {


### PR DESCRIPTION
CCC sandbox 預設沒設 CLAUDE_CODE_FORK_SUBAGENT，導致 Agent tool 的
fork subagent type 不會被註冊，呼叫直接被擋。把 flag 寫進 project
settings.json 的 env，讓 CC 啟動時就帶上，fork 才能用來生繼承完整
對話 context 的 subagent（一般 subagent 仍是 fresh context）。

User 在對話中明確授權此次 self-modification。

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01JFxzMx5pcr8hnMbdFDziRL