### PR TITLE
docs: SSOT 紀律強制行為規則（權威端=code/openspec + 自主收斂）+ 結構去重路由表

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,6 +192,30 @@ gu-log 寫的就是 AI / agent / tooling 圈，這個圈子有兩個特性：
 - **Subagent 的事實結論要自己驗證一次**：subagent 也會用聽起來合理但錯的詞（例如把 closed source 說成 source-available）。看到關鍵 claim 就 fetch 一次原始碼或 license 確認
 - 完整時間線參考 `src/data/glossary.json` 的 Claude Code 條目
 
+### 🧭 SSOT 紀律：別複製事實，發現 drift 當場收斂
+
+**每個事實只有一個家（SSOT）。任何 CC/CCC/agent 動到有 SSOT 的東西時，預設責任就是「維持單一真相來源」——不複製事實、發現對不上就當場修。** 這是強制行為，不是「有空再做」。
+
+**為什麼這條要硬**：drift 幾乎都源自同一個錯——**把本來住在某個 SSOT 的值，複製一份到散文/表格裡**。複製出來的副本遲早跟本尊分岔，而且分岔時兩邊都長得「看起來對」，沒人會發現，直到某次踩到才知道文件在說謊。實例（2026-06-18 連踩兩次）：model 版本的 SSOT 是 `.claude/agents/*.md` 的 `model:` frontmatter，但 `playbooks/CCC-playbook.md` 路由表把版本號複製了一份 → agent 檔改了、playbook 沒跟 → fresh-eyes 跟 librarian 都 drift 成假資訊。
+
+**四條操作規則（每個 agent 都要內化）**：
+
+1. **寫一個值之前先問「這是不是別處已有事實的副本？」**——版本號、計數、路徑、清單、schema、設定值都算。是副本 → **連到 / 指向 SSOT，不要複製值**。文件的工作是描述 **policy / 為什麼**，不是當第二份資料庫。
+2. **真的非列出來不可時（為了可讀性），明確標註「SSOT = X，此處為 derived view，以 X 為準」**，讓下個讀者知道哪邊是真的、該往哪改。
+3. **一旦發現某份文件跟它的 SSOT 對不上（值/路徑/數字/清單兜不攏），當場收斂**——在同一個 PR 把 drift 修掉，不要留給下一個 session（這是〈順手修 friction〉的一種）。**SSOT 永遠贏，文件副本服從 SSOT**，除非你查出來是 SSOT 本身錯了（那就修 SSOT + 同步副本，並說明）。
+4. **動到任何系統時，順手掃一眼「我改的這個事實，有沒有別的地方也抄了一份？」**——改 agent frontmatter 就回頭看 playbook 有沒有複述、改 schema 就看 docs 有沒有舊欄位、bump counter 就看有沒有別處寫死數字。改 SSOT 不順手掃副本 = 主動製造下一個 drift。
+
+**哪一邊才是 SSOT？可以 drift 的內容，權威端是「程式碼（code）或 openspec spec」，不是散文文件。** 值 / 行為 / schema / 設定 / 流程的真相住在 **code（含 frontmatter、常數、config、Zod schema）或 openspec 的 spec**；playbook / README / CLAUDE.md / 註解 / task prompt 這些散文都是 **derived view**。兩邊對不上時，**散文服從 code/openspec**，把散文那份改成跟權威端一致——除非你查出來是 code/openspec 本身錯了（那才反過來修權威端，並說明）。兩個權威端互相矛盾（code 跟 openspec 講的不一樣）= 這不是 drift 是真衝突，往下看〈收斂的自主姿態〉第 2 點。
+
+**收斂的自主姿態（跟 CCC self-merge 同一條精神：能自己判斷就別問）**：
+
+1. **能判斷哪邊對 → 自己判斷、把錯的那邊（通常是散文副本）修掉、最後跟 user 提一聲就好**。不要為了確認而停下來問——「playbook 寫 4.7 但 frontmatter 是 opus 浮動」這種 code-vs-doc drift，code 端就是 SSOT，直接把 doc 修好、回報時帶一句「順手收了 X 的 drift」即可。（本 session 的 librarian drift 其實就該這樣自己收，不必開 AskUserQuestion。）
+2. **只有「難以判斷、又是重要決定」才叫 user 拍板**（用 `AskUserQuestion`）：例如兩個權威端真的互相矛盾、或要決定的是產品方向 / 架構 / 對外承諾 / 品牌調性 / config 取向（像「fresh-eyes 該 pin 哪代還是浮動」那種是 taste/config 偏好，不是單純 reconcile drift，才值得問）。判斷不出來時，預設往「自己收 + 提一聲」靠，不要往「停下來問」靠。
+
+**為什麼用 prompt 而不是只靠 lint**：drift 的形態太多（版本號、計數、路徑、清單、描述措辭），deterministic guard 抓不完、還容易誤殺正當用法。真正可靠的是**每個 agent 帶著 SSOT 意識在動**——看到對不上就順手收，而不是等某支 checker 剛好覆蓋到。lint 只是補網，不是主防線。
+
+這條把既有的「改規則時只改 SSOT 來源檔，不要在 task prompt 裡重複定義」（見〈文件架構〉）從「規則文件」推廣到**所有事實**（值、設定、計數、路徑），並加上「權威端 = code/openspec」「主動偵測 + 自主收斂 + 提一聲」的義務。
+
 ## 文件架構（誰讀什麼）
 
 ```

--- a/docs/shroomdog-editorial-feedback.md
+++ b/docs/shroomdog-editorial-feedback.md
@@ -494,3 +494,15 @@ Sprin asked whether Tribunal v7 FreshEyes covers “length should be just right,
 - 發現的 drift：`.claude/agents/fresh-eyes.md` frontmatter 本來就是 `model: opus`（浮動），但 `playbooks/CCC-playbook.md` 路由表寫死成 `claude-opus-4-7`——playbook 漂掉了。已把路由表改回浮動 opus alias，跟 agent 檔對齊。
 - CCC 機制備忘（寫進 CCC-playbook〈CCC 怎麼 pin 到指定 Opus 版本〉）：`Agent` tool 的 `model` 只吃 alias（`opus`→最新 4.8），**選不到指定版本**；要 pin（writer/rewriter/vibe = `claude-opus-4-5`）唯一可靠路徑是 `claude -p --model claude-opus-4-5`（完整 id；`opus-4-5`/`opus-4.5` 半截寫法會被拒）。版本不敏感的角色（fact-check / fresh-eyes）用 `Agent` tool 省事即可，不要無腦全改 `claude -p`。
 - Reusable lesson：(1) **judge 的 model 路由不是「越新越好」也不是「全部對齊 writer」**——voice/taste-sensitive（writer/rewriter/vibe）要 pin 同代；要 diversity 的陌生讀者視角（fresh-eyes）反而要放它浮動、跟 writer 拉開。(2) 改 model 路由時，playbook 路由表 + `.claude/agents/*.md` frontmatter 兩邊要同步，不然又 drift。(3) CCC 要 pin 版本只能走 `claude -p --model <完整-id>`，Agent tool 做不到。
+
+## 2026-06-18 — SSOT 紀律升級成強制行為規則（drift 連踩兩次後的根因處理）
+
+### Feedback: 「我們應該有個 strong prompt 讓 agent 自主隨時意識並維持 SSOT」
+
+- ShroomDog insight：連續抓到 fresh-eyes、librarian 兩個 model-routing drift 後，ShroomDog 點出根因不是「忘了同步」，而是該有一條 standing prompt 讓每個 agent 自主維持 SSOT——`I think it is just we should have a strong prompt that will autonomously always try to aware and keep ssot`。
+- 根因：drift 幾乎都來自同一個錯——**把住在某 SSOT 的值複製一份到散文/表格**。`.claude/agents/*.md` 的 `model:` frontmatter 是 model 選擇的 SSOT，但 `CCC-playbook` 路由表（還有 fallback 清單、品質 section）把版本號各抄了一份 → agent 檔改了、副本沒跟 → 兩處 drift 成假資訊。
+- 修法（兩層）：
+  1. **行為層**：CLAUDE.md ⚠️ 必讀 新增〈🧭 SSOT 紀律：別複製事實，發現 drift 當場收斂〉——四條操作規則（寫值前先問是不是副本→指向 SSOT；非列不可就標 derived view；發現對不上當場在同一 PR 收斂、SSOT 永遠贏；改 SSOT 順手掃別處有沒有抄一份）。並說明為什麼用 prompt 而不只靠 lint（drift 形態太多、lint 抓不完又誤殺，主防線是每個 agent 帶 SSOT 意識）。
+  2. **結構層（practice what we preach）**：CCC-playbook 模型路由表從「複述版本號」改成「只講 policy（voice-sensitive pin / judge 浮動）+ 版本值指向 frontmatter SSOT」，結構上讓它無從 drift。順手把同檔另外兩處抄了版本號的清單（fallback 四審清單、寫作 SOP Step 2）也一併拔掉版本號。
+- 權威端 + 自主姿態（ShroomDog 補充）：**可以 drift 的內容，SSOT 權威端是「code 或 openspec」，不是散文**；散文服從 code/openspec。**能判斷哪邊對就自己判斷、把錯的那邊修掉、跟 user 提一聲就好，不要停下來問**；只有「難判斷又是重要決定」（兩權威端真衝突、或產品/架構/品牌/config 取向）才用 `AskUserQuestion`。對照本 session：librarian 那種 code(frontmatter)-vs-doc drift 該直接自己收（不必問）；fresh-eyes「pin 哪代 vs 浮動」是 config 取向，問 user 才對。
+- Reusable lesson：(1) **看到「doc 跟實際對不上」不要只修這一處，要問『這個事實在幾個地方被抄了』，全部收斂**——這次一條 routing fact 在 playbook 抄了三份。(2) **預防勝於修補：能不複製就不複製**，doc 講 policy / why，值留在它的 SSOT（code：frontmatter / 常數 / config / schema，或 openspec spec），要列就標明 derived view + 指向真身。(3) deterministic guard 是補網不是主防線；真正可靠的是把 SSOT 紀律寫成每個 agent 都讀得到的強規則（CLAUDE.md），讓它自主偵測 + 當場收斂 + 提一聲。

--- a/playbooks/CCC-playbook.md
+++ b/playbooks/CCC-playbook.md
@@ -125,14 +125,16 @@ Vercel build / tribunal / validate-posts / CI 沒過：
 
 **沙箱 fallback**（只有上面 shell/pipeline 路真的壞掉時才用——例如 quota 用盡、CLI 版本回歸）：**CCC 自己用 `Agent` tool 一次 spawn 四個 subagent 平行跑**，對應 `.claude/agents/`：
 
-- `vibe-opus-scorer.md`（Opus）→ persona / clawdNote / vibe / narrative（v9；clarity 已移到 Fresh Eyes，v8 以下才含 clarity）
-- `fact-checker.md`（Opus）→ accuracy / fidelity / consistency（要 WebFetch 驗 sourceUrl）
-- `librarian.md`（Opus 4.7）→ glossary / crossRef / sourceAlign / attribution
-- `fresh-eyes.md`（Opus 4.7）→ readability / firstImpression / payoffDensity / lengthFit / clarity（v9；clarity 是非補償硬門檻，v8 以下無）
+（每個 agent 用哪個 model = 它的 `model:` frontmatter，**這裡不複述版本號**，見〈模型路由〉的 SSOT 提醒）：
+
+- `vibe-opus-scorer.md` → persona / clawdNote / vibe / narrative（v9；clarity 已移到 Fresh Eyes，v8 以下才含 clarity）
+- `fact-checker.md` → accuracy / fidelity / consistency（要 WebFetch 驗 sourceUrl）
+- `librarian.md` → glossary / crossRef / sourceAlign / attribution
+- `fresh-eyes.md` → readability / firstImpression / payoffDensity / lengthFit / clarity（v9；clarity 是非補償硬門檻，v8 以下無）
 
 每個 agent 寫 JSON 到 `/tmp/tribunal-<ticketId>-<judge>.json`，schema 照各 agent spec。
 
-**⚠️ 實測 caveat（2026-06-13）**：不是每個 CCC 網頁 harness 都把 `.claude/agents/` 註冊成 `Agent` tool 的 `subagent_type`。有的 session `Agent` tool 只開 built-in 的 `general-purpose` / `Explore` / `Plan`，named agent（`vibe-opus-scorer` 等）會回 `Agent type '...' not found`。遇到這種：**spawn `general-purpose`，在 prompt 裡叫它「讀 `.claude/agents/<judge>.md` 並完全照著做（zero parent context）」**，效果等同——judge 一樣 zero-context、一樣寫同一份 JSON。差別只在 model pin 顧不到（named agent 走 frontmatter 的 `claude-opus-4-6[1m]`，general-purpose 繼承 parent model），所以 `scores.*.model` 要記**實際**用到的 model，不要照抄 pin。agent 檔已補 `name:` frontmatter，環境若支援 project agent 就會吃到 named 路徑。`scripts/tribunal-helpers.sh` 在 CCC 偵測到沒有 CLI provider 時，也會把這條 fallback 指令印到 stderr。
+**⚠️ 實測 caveat（2026-06-13）**：不是每個 CCC 網頁 harness 都把 `.claude/agents/` 註冊成 `Agent` tool 的 `subagent_type`。有的 session `Agent` tool 只開 built-in 的 `general-purpose` / `Explore` / `Plan`，named agent（`vibe-opus-scorer` 等）會回 `Agent type '...' not found`。遇到這種：**spawn `general-purpose`，在 prompt 裡叫它「讀 `.claude/agents/<judge>.md` 並完全照著做（zero parent context）」**，效果等同——judge 一樣 zero-context、一樣寫同一份 JSON。差別只在 model pin 顧不到（named agent 走 frontmatter 的 pin，general-purpose 繼承 parent model），所以 `scores.*.model` 要記**實際**用到的 model，不要照抄 pin。agent 檔已補 `name:` frontmatter，環境若支援 project agent 就會吃到 named 路徑。`scripts/tribunal-helpers.sh` 在 CCC 偵測到沒有 CLI provider 時，也會把這條 fallback 指令印到 stderr。
 
 **Pass bar（四條全部要過才能 merge）**：
 - Vibe composite ≥ 8 **AND** 至少一維 ≥ 9 **AND** 無任何維 < 8
@@ -219,17 +221,18 @@ tools/sp-pipeline/gp-pipeline run <url> --force
 
 ### 模型路由（Mac writer + Codex judges）
 
-2026-06-13 更新：Claude 在 VM/CCC 上不作為主要 runtime；VM 是 Codex GPT-5.5 的地盤。Mac pipeline 的分工如下：
+2026-06-13 更新：Claude 在 VM/CCC 上不作為主要 runtime；VM 是 Codex GPT-5.5 的地盤。
 
-- **SP writer / refine**（`tools/sp-pipeline/internal/llm/claude.go` 的 `ClaudeOpusPinned`）→ 鎖 `claude-opus-4-5`（不走浮動 alias，避免寫作 voice 漂移），runtime metadata 記錄實際版本
-- **Eval / review / tribunal judges** → `codex exec --model gpt-5.5`，完整版 GPT，不走 mini
-- **Vibe Scorer**（`.claude/agents/vibe-opus-scorer.md`）→ 鎖 `claude-opus-4-5`
-- **Tribunal Writer legacy agent**（`.claude/agents/tribunal-writer.md`）→ 鎖 `claude-opus-4-5`，只當 legacy / fallback calibration，不是 Codex runtime selector
-- **Fact Checker**（`.claude/agents/fact-checker.md`）→ 用 `opus` alias（追最新，fact-check 要 reasoning 強的，沒有 voice 問題；**不動**）
-- **Librarian**（`.claude/agents/librarian.md`）→ 浮動 `opus` alias（追最新，現在 **Opus 4.8**）。跟 Fact Checker / Fresh Eyes 同路——glossary / cross-ref 檢查不是 voice-sensitive，要最新 reasoning 就好，不 pin。（agent 檔 frontmatter 一直是 `model: opus`；2026-06-18 把這張表從寫死的 4.7 改回浮動，對齊實際 runtime。）
-- **Fresh Eyes**（`.claude/agents/fresh-eyes.md`）→ 浮動 `opus` alias（追最新，現在是 **Opus 4.8**）。**刻意不 pin**（2026-06-18 ShroomDog 決定）——fresh-eyes 是「陌生讀者」視角，用跟 writer **不同代 / 最新**的 model 反而能抓 writer 同代看不到的盲點（diversity > taste 對齊）。所以 CCC 用 `Agent(subagent_type:"fresh-eyes")` 直接跑即可，不需要 `claude -p` pin。
+> **🧭 SSOT 提醒（見 `CLAUDE.md`〈SSOT 紀律〉）**：每個 agent 用哪個 model，**值的 SSOT 是各 agent 的 `model:` frontmatter**（`.claude/agents/*.md`）；Mac SP writer 是 `tools/sp-pipeline/internal/llm/claude.go` 的 `ClaudeOpusPinned`。**下面這張表只描述 policy（哪一類 pin、哪一類浮動、為什麼），刻意不複述版本號**——版本號一旦抄進這裡就會 drift（2026-06-18 fresh-eyes / librarian 連踩兩次就是因為表裡寫死了 4-7）。要知道某 agent 現在實際跑哪版 → 去讀它的 frontmatter，不要相信任何散文裡的版本數字。
 
-修 `.claude/agents` 這些 legacy calibration 檔之前先讀 frontmatter 上方的 PIN 註解；它們不是 active Codex runtime model selection。
+分工 policy（**按類別，不按版本號**）：
+
+- **Voice / taste-sensitive（SP writer / refine / rewriter、Vibe Scorer）→ pin 到固定 Opus 世代**。理由：寫作 voice 跟評分 taste 對 Opus 版本敏感，Anthropic 一升浮動 alias 就可能改掉 LHY persona / 評分基準，所以釘死世代、讓 writer 跟 vibe scorer 共用同一代以對齊 taste。實際版本 = 各自 frontmatter / `ClaudeOpusPinned`（**SSOT**）。
+- **非-voice judge（Fact Checker / Librarian / Fresh Eyes）→ 浮動 `opus` alias（追最新），刻意不 pin**。理由：fact-check / glossary / 陌生讀者視角要的是**最新 reasoning + diversity**，不是跟 writer taste 對齊；fresh-eyes 用跟 writer 不同代的 model 反而能抓同代看不到的盲點。CCC 用 `Agent(subagent_type:"…")` 直接跑即可（`opus` alias 本來就解析成最新，不需要 `claude -p` pin）。
+- **Codex judges（eval / review / tribunal on VM）→ `codex exec --model gpt-5.5`**，完整版不走 mini。
+- **Tribunal Writer legacy agent**（`.claude/agents/tribunal-writer.md`）→ 跟 writer 同類（pin），只當 legacy / fallback calibration，不是 active runtime selector。
+
+改某 agent 的 model = 改它的 frontmatter（SSOT）；改完**順手確認沒有別的 doc 又把版本號抄了一份**（這張表已經不抄了，但別處若有就一併收斂）。修 `.claude/agents` 這些 calibration 檔之前先讀 frontmatter 上方的 PIN 註解；它們不是 active Codex runtime model selection。
 
 ### CCC 怎麼 pin 到指定 Opus 版本（`claude -p` vs `Agent` tool）
 
@@ -249,15 +252,17 @@ claude -p --model claude-opus-4-5 --allowed-tools "Read,Grep,Glob,Bash,Write,Edi
 
 **什麼時候必須走 `claude -p`（版本敏感的角色）vs `Agent` tool 就夠（版本不敏感）**：
 
-| 角色 | 路由表的 pin | CCC 怎麼跑 |
-|---|---|---|
-| **SP writer / rewriter** | `claude-opus-4-5`（voice 對版本敏感） | **必須 `claude -p --model claude-opus-4-5`**。寫作/改寫 voice 一漂就毀 LHY persona，pin 不能漏 |
-| **Vibe Scorer** | `claude-opus-4-5`（與 writer 同代，taste 對齊） | **必須 `claude -p --model claude-opus-4-5`** 才對得上 writer 的 taste 校準 |
-| **Fact Checker** | 浮動 `opus` alias（追最新） | `Agent(subagent_type:"fact-checker")` 直接用就好，本來就要最新 |
-| **Fresh Eyes** | 浮動 `opus` alias（追最新，現在 4.8；**刻意不 pin**，要 diversity 不要 taste 對齊） | `Agent(subagent_type:"fresh-eyes")` 直接用就好，跟 Fact Checker 同路 |
-| **Librarian** | 浮動 `opus` alias（追最新，現在 4.8；**不 pin**） | `Agent(subagent_type:"librarian")` 直接用就好，跟 Fact Checker / Fresh Eyes 同路 |
+> 下表的 `<id>` = 該 agent `model:` frontmatter 裡寫的那個 id（**SSOT**，見上面 SSOT 提醒）。要打 `--model` 之前**先去 frontmatter 讀當下的 id**，不要憑記憶打——pin 的世代日後可能變，但「讀 frontmatter」這條不變。snapshot：寫這段時 pinned 世代是 `claude-opus-4-5`。
 
-**規則一句話**：**版本要 pin（writer / rewriter / vibe，或 user 當次明講某 judge 用某版）→ `claude -p --model <完整-id>`；版本不在乎 → `Agent` tool 省事**。不要無腦把所有東西都改成 `claude -p`（fact-check / 一般 tribunal 用 `Agent` tool 更省 token、也不會踩 stream idle timeout）。
+| 角色 | model 來源（SSOT） | CCC 怎麼跑 |
+|---|---|---|
+| **SP writer / rewriter** | pin（`ClaudeOpusPinned` / writer agent frontmatter） | **必須 `claude -p --model <id>`**。寫作/改寫 voice 一漂就毀 LHY persona，pin 不能漏 |
+| **Vibe Scorer** | pin（`vibe-opus-scorer.md` frontmatter，與 writer 同代） | **必須 `claude -p --model <id>`** 才對得上 writer 的 taste 校準 |
+| **Fact Checker** | 浮動 `opus` alias（追最新） | `Agent(subagent_type:"fact-checker")` 直接用就好，本來就要最新 |
+| **Fresh Eyes** | 浮動 `opus` alias（**刻意不 pin**，要 diversity 不要 taste 對齊） | `Agent(subagent_type:"fresh-eyes")` 直接用就好，跟 Fact Checker 同路 |
+| **Librarian** | 浮動 `opus` alias（**不 pin**） | `Agent(subagent_type:"librarian")` 直接用就好，跟 Fact Checker / Fresh Eyes 同路 |
+
+**規則一句話**：**版本要 pin（writer / rewriter / vibe，或 user 當次明講某 judge 用某版）→ `claude -p --model <frontmatter 的 id>`；版本不在乎 → `Agent` tool 省事**。不要無腦把所有東西都改成 `claude -p`（fact-check / 一般 tribunal 用 `Agent` tool 更省 token、也不會踩 stream idle timeout）。
 
 **`claude -p` 跑長生成的雷**：write / rewrite 這種 long creative generation 會踩 stream idle timeout（見〈Stream idle timeout 應對〉）。對策：prompt 走 stdin、輸出用 `<<<MDX_START>>>…<<<MDX_END>>>` sentinel 包住再 `awk` 抽出、judge 一律 `--allowed-tools` 顯式 allowlist（root 下 `bypassPermissions` 會被拒）。
 
@@ -281,11 +286,11 @@ Step 1: 寫 zh-tw 版
   - ClawdNote / ShroomDogNote 都在這步完成
   - validate-posts.mjs 確認格式
 
-Step 2: Tribunal review（spawn subagent）
-  - Vibe Scorer（Opus 4.6[1m]）：四維評分（v9；clarity 移到 Fresh Eyes）
-  - Fact Checker（Opus 4.7）：技術準確度
-  - Librarian（Opus 4.7）：glossary / cross-ref
-  - Fresh Eyes（Opus 4.7）：陌生讀者第一印象
+Step 2: Tribunal review（spawn subagent；model 見各 agent frontmatter，不在這列版本號）
+  - Vibe Scorer：四維評分（v9；clarity 移到 Fresh Eyes）
+  - Fact Checker：技術準確度
+  - Librarian：glossary / cross-ref
+  - Fresh Eyes：陌生讀者第一印象
   - Pass bar：Vibe composite ≥ 8 且沒有任何維 < 8
 
 Step 3: Iterate（如未通過）


### PR DESCRIPTION
## 為什麼

連踩兩次 model-routing drift（fresh-eyes、librarian）後，ShroomDog 點出根因 + 解法方向：「應該有個 strong prompt 讓 agent 自主隨時意識並維持 SSOT」，並補充「可 drift 的內容以 **code 或 openspec** 為準，能判斷就自己修掉、提一聲就好，難判斷的重要決定才問 user」。

drift 的根因不是「忘了同步」，是**把住在 SSOT 的值複製進散文/表格**——複製＝必然 drift。

## 改了什麼（純 docs）

**1. 行為層 — `CLAUDE.md` ⚠️ 必讀 新增〈🧭 SSOT 紀律〉**
- 每個 agent 自主維持單一真相來源：寫值前先問是不是副本→指向 SSOT；非列不可就標 derived view；發現 drift 當場在同一 PR 收斂；改 SSOT 順手掃別處副本。
- **權威端定死**：可 drift 的內容 SSOT = **code**（frontmatter / 常數 / config / Zod schema）**或 openspec spec**，散文（playbook/README/註解）服從 code/openspec。
- **自主姿態**（跟 CCC self-merge 同精神）：能判斷哪邊對 → 自己修錯的那邊 + 跟 user 提一聲；只有「難判斷又是重要決定」（兩權威端真衝突 / 產品 / 架構 / 品牌 / config 取向）才 `AskUserQuestion`。
- 說明為何用 prompt 而非只靠 lint（drift 形態太多、lint 抓不完又誤殺，主防線是 agent 帶 SSOT 意識）。

**2. 結構層（practice what we preach）— `playbooks/CCC-playbook.md`**
- 模型路由表從「複述版本號」改成「**只講 policy（voice-sensitive pin / judge 浮動）+ 版本值指向 agent frontmatter SSOT**」，結構上無從 drift。
- 順手收斂同檔另外**兩處也抄了版本號、且已 stale** 的清單（fallback 四審清單、寫作 SOP Step 2）——正好示範規則第 4 條「一條 fact 在 doc 抄了三份，全部收斂」。

**3. `docs/shroomdog-editorial-feedback.md`** 記 meta-lesson + 權威端/自主姿態。

## 自我檢討

本 session 的 librarian drift 我其實該直接自己收（code/frontmatter 就是 SSOT），不必開 AskUserQuestion——這條新規則正是要避免下次再為這種 code-vs-doc drift 多問一輪。fresh-eyes「pin 哪代 vs 浮動」是 config 取向，問 user 才對。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0122KmX4xifbf7nCSFmXcbza

---
_Generated by [Claude Code](https://claude.ai/code/session_0122KmX4xifbf7nCSFmXcbza)_