### PR TITLE
spec: tribunal 24/7 部署硬化（OpenSpec，尚未實作）

### DIFF
--- a/.claude/skills/level-up/learning/INDEX.md
+++ b/.claude/skills/level-up/learning/INDEX.md
@@ -6,5 +6,6 @@
 | Topic | Status | Evidence | Updated | File |
 | --- | --- | --- | --- | --- |
 | CCC SOP (gu-log) | mastered (Lv.1–7)，boss 未打 | 七關 MCQ 全部一次答對 | 2026-06-18 | topics/ccc-sop.md |
+| Tribunal 24/7 readiness | mastered (Lv.1–9 full clear) | 9/9 MCQ 一次過；自己推出 claim 必須共享、用單機/clawd-vm 決策繞 boss | 2026-06-19 | topics/tribunal-24-7.md |
 
 Learner profile（taste / framing / 語氣）：`learner-profile.md`

--- a/.claude/skills/level-up/learning/topics/tribunal-24-7.md
+++ b/.claude/skills/level-up/learning/topics/tribunal-24-7.md
@@ -1,0 +1,40 @@
+# Tribunal 24/7 Readiness (gu-log)
+
+## Current Level
+- Status: mastered (Lv.1–9, full clear, zero misses)
+- Last updated: 2026-06-19
+- Confidence: high — strong systems intuition, made correct scope-cutting decisions unprompted
+
+## Evidence
+- 2026-06-19: 9/9 MCQ correct first try, no misses. Topics proven:
+  - Lv.1 continuous quota-aware loop vs one-shot batch (not `while true`).
+  - Lv.2 worktree isolation; understood "dirty worktree" = drift from main, cured by reset-to-ref.
+  - Lv.3 the `GP_WRITER_MODE=none` bomb — scores-but-never-rewrites → EXHAUSTED, zero improvement.
+  - Lv.4 atomic `mkdir` claims prevent double-scoring. **Deduced unprompted** that the claim dir must be shared/outside each worktree — correctly reasoned to the `RC_ROOT_DIR=main repo` design before being told.
+  - Lv.5 two dispatch paths; per-role model split only on Go-writer + CCC-claude fallback, production VM hardcodes gpt-5.5 (`helpers.sh:358`).
+  - Lv.6 multi-host double-claim via PID-based staleness misread; chose single-machine to skip it.
+  - Lv.7 mac fallback trap (missing usage-monitor.sh → 1-worker/600s); chose clawd-vm to skip it.
+  - Lv.8 burst default under-spends a 48h deadline (paces to 7d window, 10% floor, WORKERS=1).
+  - Lv.9 observability gap (osascript no-op on Linux, stale monitor skill, reboot needs enable+linger).
+- Asked sharp clarifying questions mid-journey: "dispatch vs 啟動" (frequency distinction), "which dir, outside git repo?" (claim location). Both showed real understanding, not guessing.
+
+## Known Gaps
+- None on concepts. Open WORK items (not learner gaps) = the deploy punch-list below.
+
+## Teaching Notes
+- Vainglory framing lands hard and the learner explicitly wants MORE of it — carry the knowledge ON the analogy (grinder-bots, ranked vs scrim client, arcade seats/PID, stadium move, farm with alarm in empty building). Keep technical prose to short anchor lines + file:line.
+- Learner makes strong architecture decisions to AVOID work (single-host, clawd-vm) rather than build features — reward that as high-skill play.
+- One MCQ per level, vary correct-answer position, kaomoji throughout.
+
+## Deploy punch-list (decided target: clawd-vm, deploy via codex goal-mode + 6h monitor)
+- P0: set `GP_WRITER_MODE=subagent` in systemd unit (else score-only).
+- P0: per-role model routing — drop hardcoded `--model gpt-5.5` (helpers.sh:358), route writer/vibe→Opus 4.5, judges+orchestrator→gpt-5.5.
+- P0: reboot persistence — `systemctl --user enable` + `loginctl enable-linger`.
+- P1: real alert channel (Telegram/clawd notifier) replacing osascript.
+- P1: fix tribunal-monitor skill to parse `CONTROLLER:` + quota-controller.json + 10% floor.
+- Burst: `--workers N`, `QUOTA_FLOOR=0`, `QUOTA_BURST_ALLOWANCE`↑, `MIN_COOLDOWN`↓; cgroup autoscaler caps at 2 under RAM pressure; Claude quota invisible to controller.
+- P2: doc/spec drift (runbook quota section; archive tribunal-closed-loop-quota-controller 0/29).
+
+## Next Suggested Levels
+- Hands-on: actually implement the P0 fixes as a PR / OpenSpec change.
+- New topic: the quota burn-rate controller math (ideal-burn-line, debt sleep) in depth.

--- a/openspec/changes/tribunal-24-7-deploy-readiness/.openspec.yaml
+++ b/openspec/changes/tribunal-24-7-deploy-readiness/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-19

--- a/openspec/changes/tribunal-24-7-deploy-readiness/design.md
+++ b/openspec/changes/tribunal-24-7-deploy-readiness/design.md
@@ -1,12 +1,12 @@
 ## Context
 
-The clawd-vm tribunal daemon is `tribunal-quota-loop.sh` (a quota-aware supervisor) dispatching `tribunal.sh` per article. Provider/model selection happens in `tribunal-helpers.sh`: `tribunal_llm_provider()` picks ONE provider for all roles (codex if present), and `tribunal_codex_exec` hardcodes `--model gpt-5.5` (helpers.sh:358) while the prompt explicitly tells the model to "Ignore model". The per-role `model` fields in `.codex/agents/*.toml` are therefore dead on the production path; only the CCC-claude fallback path honors `.claude/agents/*.md` models. `GP_WRITER_MODE` defaults to `none` (helpers.sh:412) and no deploy unit sets it. Alerting is `osascript` (Linux no-op). The quota controller writes `quota-controller.json` with modes `pacing/floor_stop/fallback`; the `tribunal-monitor` skill greps for the retired `Tier GO / 3%` format. Reboot survival needs `systemctl --user enable` + `loginctl enable-linger`.
+The clawd-vm tribunal daemon is `tribunal-quota-loop.sh` (a quota-aware supervisor) dispatching `tribunal.sh` per article. Provider/model selection happens in `tribunal-helpers.sh`: `tribunal_llm_provider()` picks ONE provider for all roles (codex if present), and `tribunal_codex_exec` hardcodes `--model gpt-5.5` (helpers.sh:358) while the prompt explicitly tells the model to "Ignore model". The per-role `model` fields in `.codex/agents/*.toml` are therefore dead on the production path; only the CCC-claude fallback path honors `.claude/agents/*.md` models. `GP_WRITER_MODE` defaults to `none` (helpers.sh:416) and no deploy unit sets it. Alerting is `osascript` (Linux no-op). The quota controller writes `quota-controller.json` with modes `pacing/floor_stop/fallback`; the `tribunal-monitor` skill greps for the retired `Tier …% remaining` format and a stale 3% floor (the real default floor is 10%, `QUOTA_FLOOR:-10`). Reboot survival needs `systemctl --user enable` + `loginctl enable-linger`.
 
 ## Goals / Non-Goals
 
 **Goals:**
 - A 24/7 clawd-vm run that actually rewrites sub-bar posts (not score-only).
-- The intended model split: Opus 4.5 writes/judges-vibe; GPT-5.5 does the other judges + orchestration.
+- The intended model split: Claude (Opus) writes/judges-vibe; Codex (GPT-5.5) does the other judges + orchestration. The exact builds are owned by `tribunal-model-pinning-strategy`; this change only routes to whatever each role's config declares.
 - Unattended operability: reboot-persistent, operator gets alerted, monitor reflects reality, burst is tunable.
 
 **Non-Goals:**
@@ -16,9 +16,9 @@ The clawd-vm tribunal daemon is `tribunal-quota-loop.sh` (a quota-aware supervis
 
 ## Decisions
 
-**D1. Per-role resolution, not a global provider.** Introduce a role→(provider, model) map: `{writer, rewriter, vibe} → claude/claude-opus-4-5`; `{fact-checker, librarian, fresh-eyes, orchestrator} → codex/gpt-5.5`. Each judge/writer invocation consults the map instead of `tribunal_llm_provider()` choosing once for all. *Alternative considered:* keep one provider and just swap it to claude globally — rejected: the user wants GPT doing the cheaper judges to spread quota across both balances.
+**D1. Per-role resolution, not a global provider.** Introduce a role→provider map: `{writer, rewriter, vibe} → claude`; `{fact-checker, librarian, fresh-eyes, orchestrator} → codex`. The **model** for each role is read from that role's existing config field (`.claude/agents/*.md` for claude roles — today `claude-opus-4-5`; `.codex/agents/*.toml` for codex roles — today `gpt-5.5`), **not hardcoded in the resolver**. The exact build values are owned by `tribunal-model-pinning-strategy`; this resolver just stops ignoring them. Each judge/writer invocation consults the map instead of `tribunal_llm_provider()` choosing once for all. *Alternative considered:* keep one provider and just swap it to claude globally — rejected: the user wants GPT doing the cheaper judges to spread quota across both balances.
 
-**D2. Remove the hardcoded codex model flag.** Replace `--model gpt-5.5` (helpers.sh:358) with a lookup of the `.codex/agents/<role>.toml` `model` field (already present, currently ignored), and drop the "Ignore model" prompt line so codex roles honor their declared model. Defaults to gpt-5.5 when unset.
+**D2. Remove the hardcoded codex model flag.** Replace `--model gpt-5.5` (helpers.sh:358) with a lookup of the `.codex/agents/<role>.toml` `model` field (already present, currently ignored), and drop the "Ignore model" prompt line so codex roles honor their declared model. Defaults to gpt-5.5 when unset. **`scripts/tests/test-tribunal-safety-contract.sh` must move in the same change** — it currently asserts the hardcode, the "Ignore YAML" prompt, the static `codex-gpt-5.5-medium` runner label, and pinned `.codex` models; those assertions flip from "must exist" to "must read from config" (see tasks 1.6).
 
 **D3. Deployment opts into rewrites; library default stays safe.** Keep `GP_WRITER_MODE` defaulting to `none` in `tribunal-helpers.sh` (safe for ad-hoc/library use) but require the deployed unit/wrapper to export `GP_WRITER_MODE=subagent`. This makes the dangerous-by-omission state impossible in production without changing safe local behavior.
 

--- a/openspec/changes/tribunal-24-7-deploy-readiness/design.md
+++ b/openspec/changes/tribunal-24-7-deploy-readiness/design.md
@@ -1,0 +1,45 @@
+## Context
+
+The clawd-vm tribunal daemon is `tribunal-quota-loop.sh` (a quota-aware supervisor) dispatching `tribunal.sh` per article. Provider/model selection happens in `tribunal-helpers.sh`: `tribunal_llm_provider()` picks ONE provider for all roles (codex if present), and `tribunal_codex_exec` hardcodes `--model gpt-5.5` (helpers.sh:358) while the prompt explicitly tells the model to "Ignore model". The per-role `model` fields in `.codex/agents/*.toml` are therefore dead on the production path; only the CCC-claude fallback path honors `.claude/agents/*.md` models. `GP_WRITER_MODE` defaults to `none` (helpers.sh:412) and no deploy unit sets it. Alerting is `osascript` (Linux no-op). The quota controller writes `quota-controller.json` with modes `pacing/floor_stop/fallback`; the `tribunal-monitor` skill greps for the retired `Tier GO / 3%` format. Reboot survival needs `systemctl --user enable` + `loginctl enable-linger`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- A 24/7 clawd-vm run that actually rewrites sub-bar posts (not score-only).
+- The intended model split: Opus 4.5 writes/judges-vibe; GPT-5.5 does the other judges + orchestration.
+- Unattended operability: reboot-persistent, operator gets alerted, monitor reflects reality, burst is tunable.
+
+**Non-Goals:**
+- Multi-host concurrency (single-host by decision — claims are local/PID-based; two hosts double-score).
+- macOS daemon runtime (target is clawd-vm; mac path is a separate effort blocked by an off-repo `usage-monitor.sh`).
+- Vendoring `usage-monitor.sh` or changing the burn-rate controller math.
+
+## Decisions
+
+**D1. Per-role resolution, not a global provider.** Introduce a role→(provider, model) map: `{writer, rewriter, vibe} → claude/claude-opus-4-5`; `{fact-checker, librarian, fresh-eyes, orchestrator} → codex/gpt-5.5`. Each judge/writer invocation consults the map instead of `tribunal_llm_provider()` choosing once for all. *Alternative considered:* keep one provider and just swap it to claude globally — rejected: the user wants GPT doing the cheaper judges to spread quota across both balances.
+
+**D2. Remove the hardcoded codex model flag.** Replace `--model gpt-5.5` (helpers.sh:358) with a lookup of the `.codex/agents/<role>.toml` `model` field (already present, currently ignored), and drop the "Ignore model" prompt line so codex roles honor their declared model. Defaults to gpt-5.5 when unset.
+
+**D3. Deployment opts into rewrites; library default stays safe.** Keep `GP_WRITER_MODE` defaulting to `none` in `tribunal-helpers.sh` (safe for ad-hoc/library use) but require the deployed unit/wrapper to export `GP_WRITER_MODE=subagent`. This makes the dangerous-by-omission state impossible in production without changing safe local behavior.
+
+**D4. Alerting via an injectable notifier.** Replace the hardcoded `osascript` call with a notifier hook (env-configured command / existing clawd Telegram notifier) invoked on stall / EXHAUSTED / `fallback` / `floor_stop`. On hosts without a notifier configured it degrades to a log line (never silently no-ops the way osascript does on Linux).
+
+**D5. Monitor parses live state.** Point the `tribunal-monitor` skill at `quota-controller.json` + the `CONTROLLER:` log lines + the configured floor, not the retired strings.
+
+**D6. Burst is configuration, not new code.** The controller already fills the worker pool when behind the ideal line; document the operator knobs (`--workers`, `QUOTA_FLOOR=0`, `QUOTA_BURST_ALLOWANCE↑`, `MIN_COOLDOWN↓`) and the caveats (cgroup autoscaler caps at `AUTOSCALE_OOM_CAP=2` under memory pressure; the controller paces GPT/Codex quota only, not Claude).
+
+## Risks / Trade-offs
+
+- **Per-role routing runs two CLIs (codex + claude) in one tribunal run.** → Both must be installed + authed on clawd-vm; document as a prerequisite and fail loudly if a role's required CLI is absent rather than silently rerouting all roles.
+- **Enabling rewrites increases spend per failing article.** → That is the intended value conversion; the burn controller + `QUOTA_FLOOR` still bound it.
+- **Alert spam.** → Alert only on terminal/abnormal states (stall, EXHAUSTED spike, fallback, floor_stop), not every article.
+- **`usage-monitor.sh` is off-repo.** → If absent the controller sits in `fallback` (1 worker/600s); make its presence a documented pre-flight check, not a silent degrade.
+
+## Migration Plan
+
+Config + targeted code edits; no data migration. Roll out on clawd-vm: set the unit env, deploy the routing change, wire the notifier, fix the monitor skill, enable + linger. Rollback = revert; the `none` default and single-provider path still work.
+
+## Open Questions
+
+- Which notifier exactly (existing clawd Telegram bot vs a generic webhook env)? Pick during implementation; the spec only requires "operator-reachable on the deploy host".
+- Whether to also add a deadline-aware burst mode (shorten the controller's window perception) or leave it as the documented `WEEKLY_WINDOW_SEC` hack — deferred; not required for the core ask.

--- a/openspec/changes/tribunal-24-7-deploy-readiness/proposal.md
+++ b/openspec/changes/tribunal-24-7-deploy-readiness/proposal.md
@@ -1,13 +1,13 @@
 ## Why
 
-The tribunal engine is architecturally ready for a 24/7 run (atomic claims, graceful stop, bounded retries, a burn-rate quota controller), but the **deployed configuration** is not. As shipped, the clawd-vm daemon (a) scores every article but never rewrites it (`GP_WRITER_MODE` defaults to `none` and the systemd unit never sets it) → every failing post burns 5 attempts to EXHAUSTED for zero quality gain; (b) runs all five judge/writer roles on a hardcoded `gpt-5.5` instead of the intended Opus-4.5-for-writer/vibe split; (c) has no operator alerting that works on Linux (the only alarm is a macOS `osascript` no-op); (d) ships a monitor tool that parses a dead quota format; and (e) has no documented reboot-persistence. This change hardens the deployment so a real 24/7 run improves articles instead of expensively confirming they are bad.
+The tribunal engine is architecturally ready for a 24/7 run (atomic claims, graceful stop, bounded retries, a burn-rate quota controller), but the **deployed configuration** is not. As shipped, the clawd-vm daemon (a) scores every article but never rewrites it (`GP_WRITER_MODE` defaults to `none` and the systemd unit never sets it) → every failing post burns 5 attempts to EXHAUSTED for zero quality gain; (b) runs all five judge/writer roles on a hardcoded `gpt-5.5` instead of the intended Claude-for-writer/vibe split (the exact Opus build each role pins is owned by the `tribunal-model-pinning-strategy` change, not this one); (c) has no operator alerting that works on Linux (the only alarm is a macOS `osascript` no-op); (d) ships a monitor tool that parses a dead quota format; and (e) has no documented reboot-persistence. This change hardens the deployment so a real 24/7 run improves articles instead of expensively confirming they are bad.
 
 ## What Changes
 
-- **Per-role model routing.** Replace the single global provider choice + hardcoded `--model gpt-5.5` (`tribunal-helpers.sh:358`) with per-role resolution: writer/rewriter + vibe scorer → Claude Opus 4.5; fact-checker / librarian / fresh-eyes + the orchestrator → Codex GPT-5.5. Honor the existing-but-ignored `model` field in `.codex/agents/*.toml`.
+- **Per-role model routing.** Replace the single global provider choice + hardcoded `--model gpt-5.5` (`tribunal-helpers.sh:358`) with per-role resolution: writer/rewriter + vibe scorer → Claude (Opus); fact-checker / librarian / fresh-eyes + the orchestrator → Codex (GPT-5.5). This change owns the **mechanism** — read each role's already-present `model` field (`.codex/agents/*.toml`, `.claude/agents/*.md`) instead of ignoring it; the **values** (which Opus / Codex build each role pins) are owned by the `tribunal-model-pinning-strategy` change and are not re-decided here.
 - **Enable rewrites in the deployed runtime.** The long-running unit/wrapper SHALL set `GP_WRITER_MODE=subagent` (the `none` default stays as a safe library default; the deployment opts in).
 - **Real operator alerting.** Replace the macOS-only `osascript` alarm with a channel the operator receives on the Linux deploy host (Telegram / existing clawd notifier) for stall / EXHAUSTED / `fallback` / `floor_stop`.
-- **Accurate monitoring.** Update the `tribunal-monitor` skill to parse the live `CONTROLLER:` log lines + `quota-controller.json` + the real 10% floor instead of the retired `Tier GO / 3%` strings.
+- **Accurate monitoring.** Update the `tribunal-monitor` skill to parse the live `CONTROLLER:` log lines + `quota-controller.json` + the real 10% floor instead of the retired `Tier …% remaining` format + stale 3% floor.
 - **Reboot persistence.** Document + require `systemctl --user enable` + `loginctl enable-linger` so the daemon returns after a reboot.
 - **Operator-configurable burst.** Document the knobs (`--workers`, `QUOTA_FLOOR`, `QUOTA_BURST_ALLOWANCE`, `MIN_COOLDOWN`) to drain a large quota balance before a refresh deadline, including the cgroup autoscaler cap and that the controller does not see Claude quota.
 
@@ -18,13 +18,17 @@ The tribunal engine is architecturally ready for a 24/7 run (atomic claims, grac
 - `tribunal-24-7-operations`: What the deployed long-running runtime must guarantee to run unattended — rewrites enabled, reboot persistence, operator-reachable alerting, accurate health readout, and operator-configurable burst spend.
 
 ### Modified Capabilities
-- (none — these are new operational requirements; existing `tribunal-run-control` / `tribunal-ops-policy` cover pause/parallelism, not model routing or deploy-time enablement.)
+- (no in-place capability edits — these are new operational requirements. Existing `tribunal-run-control` / `tribunal-ops-policy` cover pause/parallelism, not model routing or deploy-time enablement.)
+
+### Coupled Changes
+- **`tribunal-model-pinning-strategy`** (active): owns the model **values** each role pins (e.g. the Opus build, codex build). This change owns only the **routing mechanism** that reads those values. The two must land coherently — if pinning-strategy changes the agent-config `model` fields, this change's resolver picks them up automatically. Do not duplicate the value decision here; reconcile any conflict in `tribunal-model-pinning-strategy`.
 
 ## Impact
 
 - **Model routing:** `scripts/tribunal-helpers.sh` (provider/model dispatch ~358-401, the "Ignore model" prompt note ~336-338), `.codex/agents/*.toml` + `.claude/agents/*.md` (`model` fields already set), `tools/sp-pipeline/internal/llm/defaults.go` (Go writer chain — already Opus).
+- **Safety contract test:** `scripts/tests/test-tribunal-safety-contract.sh` — **currently green and asserts the exact things this change removes** (the `--model gpt-5.5` hardcode at line 77, the "Ignore YAML / frontmatter runtime fields" prompt at line 72, the static `codex-gpt-5.5-medium` runner label at 109/115, and `^model = "gpt-5.5"` pinned across all `.codex/agents/*.toml` at line 95). It MUST be updated in lockstep or routing edits turn it red.
 - **Runtime enablement:** `scripts/tribunal-loop.service`, `scripts/cc-tribunal-loop-wrapper.sh`, `scripts/cc-cron-tribunal.sh` (set `GP_WRITER_MODE`).
-- **Alerting:** `scripts/tribunal-helpers.sh` (`tribunal_quota_alarm` ~748-755), `scripts/tribunal-quota-loop.sh` (alarm hooks).
+- **Alerting:** `scripts/tribunal-helpers.sh` (`tribunal_quota_alarm` ~778-785; the macOS `osascript` no-op is at line 784; existing alarm call sites at ~938/940/943/1046), `scripts/tribunal-quota-loop.sh` (**add** alarm hooks — it has none today; all current alarm calls live in `tribunal-helpers.sh`).
 - **Monitoring:** `.claude/skills/tribunal-monitor/SKILL.md`.
 - **Reboot + burst docs:** `docs/tribunal-runbook.md`.
 - **External dependency:** `usage-monitor.sh` (off-repo, `$HOME/clawd/scripts/`) — note as a deploy prerequisite; not in scope to vendor.

--- a/openspec/changes/tribunal-24-7-deploy-readiness/proposal.md
+++ b/openspec/changes/tribunal-24-7-deploy-readiness/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+The tribunal engine is architecturally ready for a 24/7 run (atomic claims, graceful stop, bounded retries, a burn-rate quota controller), but the **deployed configuration** is not. As shipped, the clawd-vm daemon (a) scores every article but never rewrites it (`GP_WRITER_MODE` defaults to `none` and the systemd unit never sets it) → every failing post burns 5 attempts to EXHAUSTED for zero quality gain; (b) runs all five judge/writer roles on a hardcoded `gpt-5.5` instead of the intended Opus-4.5-for-writer/vibe split; (c) has no operator alerting that works on Linux (the only alarm is a macOS `osascript` no-op); (d) ships a monitor tool that parses a dead quota format; and (e) has no documented reboot-persistence. This change hardens the deployment so a real 24/7 run improves articles instead of expensively confirming they are bad.
+
+## What Changes
+
+- **Per-role model routing.** Replace the single global provider choice + hardcoded `--model gpt-5.5` (`tribunal-helpers.sh:358`) with per-role resolution: writer/rewriter + vibe scorer → Claude Opus 4.5; fact-checker / librarian / fresh-eyes + the orchestrator → Codex GPT-5.5. Honor the existing-but-ignored `model` field in `.codex/agents/*.toml`.
+- **Enable rewrites in the deployed runtime.** The long-running unit/wrapper SHALL set `GP_WRITER_MODE=subagent` (the `none` default stays as a safe library default; the deployment opts in).
+- **Real operator alerting.** Replace the macOS-only `osascript` alarm with a channel the operator receives on the Linux deploy host (Telegram / existing clawd notifier) for stall / EXHAUSTED / `fallback` / `floor_stop`.
+- **Accurate monitoring.** Update the `tribunal-monitor` skill to parse the live `CONTROLLER:` log lines + `quota-controller.json` + the real 10% floor instead of the retired `Tier GO / 3%` strings.
+- **Reboot persistence.** Document + require `systemctl --user enable` + `loginctl enable-linger` so the daemon returns after a reboot.
+- **Operator-configurable burst.** Document the knobs (`--workers`, `QUOTA_FLOOR`, `QUOTA_BURST_ALLOWANCE`, `MIN_COOLDOWN`) to drain a large quota balance before a refresh deadline, including the cgroup autoscaler cap and that the controller does not see Claude quota.
+
+## Capabilities
+
+### New Capabilities
+- `tribunal-model-routing`: How each tribunal role (writer, rewriter, vibe, fact-checker, librarian, fresh-eyes, orchestrator) resolves its provider and model, per-role rather than one global provider, with documented fallback when a preferred CLI is absent.
+- `tribunal-24-7-operations`: What the deployed long-running runtime must guarantee to run unattended — rewrites enabled, reboot persistence, operator-reachable alerting, accurate health readout, and operator-configurable burst spend.
+
+### Modified Capabilities
+- (none — these are new operational requirements; existing `tribunal-run-control` / `tribunal-ops-policy` cover pause/parallelism, not model routing or deploy-time enablement.)
+
+## Impact
+
+- **Model routing:** `scripts/tribunal-helpers.sh` (provider/model dispatch ~358-401, the "Ignore model" prompt note ~336-338), `.codex/agents/*.toml` + `.claude/agents/*.md` (`model` fields already set), `tools/sp-pipeline/internal/llm/defaults.go` (Go writer chain — already Opus).
+- **Runtime enablement:** `scripts/tribunal-loop.service`, `scripts/cc-tribunal-loop-wrapper.sh`, `scripts/cc-cron-tribunal.sh` (set `GP_WRITER_MODE`).
+- **Alerting:** `scripts/tribunal-helpers.sh` (`tribunal_quota_alarm` ~748-755), `scripts/tribunal-quota-loop.sh` (alarm hooks).
+- **Monitoring:** `.claude/skills/tribunal-monitor/SKILL.md`.
+- **Reboot + burst docs:** `docs/tribunal-runbook.md`.
+- **External dependency:** `usage-monitor.sh` (off-repo, `$HOME/clawd/scripts/`) — note as a deploy prerequisite; not in scope to vendor.
+- **Non-goals:** multi-host coordination (explicitly single-host); macOS daemon runtime (target is clawd-vm); vendoring `usage-monitor.sh`; changing the controller's burn-rate math.

--- a/openspec/changes/tribunal-24-7-deploy-readiness/specs/tribunal-24-7-operations/spec.md
+++ b/openspec/changes/tribunal-24-7-deploy-readiness/specs/tribunal-24-7-operations/spec.md
@@ -1,0 +1,51 @@
+## ADDED Requirements
+
+### Requirement: The deployed long-running runtime SHALL enable rewrites
+
+The deployed 24/7 runtime (systemd unit / wrapper) SHALL set a writer mode that performs rewrites (`GP_WRITER_MODE=subagent` or `cli`). The library default MAY remain `none`, but the production daemon SHALL NOT run in score-only mode.
+
+#### Scenario: Failing article is rewritten, not skipped
+
+- **WHEN** an article fails a judge under the deployed daemon
+- **THEN** the tribunal writer SHALL be invoked to rewrite it
+- **AND** the run SHALL NOT log "rewrite skipped (GP_WRITER_MODE=none)" and burn attempts to EXHAUSTED without rewriting
+
+### Requirement: The runtime SHALL survive a host reboot
+
+The deployed runtime SHALL be configured to restart automatically after a host reboot.
+
+#### Scenario: Daemon returns after reboot
+
+- **WHEN** the clawd-vm host reboots
+- **THEN** the tribunal daemon SHALL start again without manual intervention
+- **AND** the deploy documentation SHALL state the required `systemctl --user enable` + `loginctl enable-linger` steps
+
+### Requirement: Operational failures SHALL reach the operator on the deploy host
+
+Abnormal runtime states SHALL be delivered to a channel the operator actually receives on the Linux deploy host. A macOS-only notification SHALL NOT be the sole alert path.
+
+#### Scenario: Stall or EXHAUSTED or fallback alerts the operator
+
+- **WHEN** the daemon stalls, hits an EXHAUSTED spike, or enters `fallback`/`floor_stop`
+- **THEN** an alert SHALL be sent via a host-appropriate channel (e.g. Telegram / clawd notifier)
+- **AND** where no channel is configured it SHALL at least record an observable log line, never silently no-op
+
+### Requirement: The monitoring tool SHALL report the live controller state
+
+The monitoring tool SHALL parse the current controller output (`quota-controller.json`, `CONTROLLER:` log lines, the configured floor) rather than a retired format.
+
+#### Scenario: Monitor shows real quota/mode
+
+- **WHEN** an operator runs the tribunal monitor against the live daemon
+- **THEN** it SHALL show the current controller `mode` and quota reading
+- **AND** SHALL NOT report blanks because it is matching a removed `Tier GO / 3%` format
+
+### Requirement: Burst spend SHALL be operator-configurable
+
+The runtime SHALL let an operator increase burn rate to drain a large quota balance before a refresh deadline, with the limits documented.
+
+#### Scenario: Operator raises burn rate
+
+- **WHEN** an operator wants to spend a large balance before refresh
+- **THEN** raising `--workers`, lowering `QUOTA_FLOOR`, raising `QUOTA_BURST_ALLOWANCE`, and lowering `MIN_COOLDOWN` SHALL increase throughput
+- **AND** the docs SHALL state that the cgroup autoscaler can cap workers at `AUTOSCALE_OOM_CAP` under memory pressure and that the controller paces Codex/GPT quota only, not Claude

--- a/openspec/changes/tribunal-24-7-deploy-readiness/specs/tribunal-24-7-operations/spec.md
+++ b/openspec/changes/tribunal-24-7-deploy-readiness/specs/tribunal-24-7-operations/spec.md
@@ -38,7 +38,7 @@ The monitoring tool SHALL parse the current controller output (`quota-controller
 
 - **WHEN** an operator runs the tribunal monitor against the live daemon
 - **THEN** it SHALL show the current controller `mode` and quota reading
-- **AND** SHALL NOT report blanks because it is matching a removed `Tier GO / 3%` format
+- **AND** SHALL NOT report blanks because it is matching a removed `Tier …% remaining` format or a stale 3% floor (the real default floor is 10%)
 
 ### Requirement: Burst spend SHALL be operator-configurable
 

--- a/openspec/changes/tribunal-24-7-deploy-readiness/specs/tribunal-model-routing/spec.md
+++ b/openspec/changes/tribunal-24-7-deploy-readiness/specs/tribunal-model-routing/spec.md
@@ -1,0 +1,40 @@
+## ADDED Requirements
+
+### Requirement: Each tribunal role SHALL resolve its provider and model independently
+
+The tribunal SHALL select the LLM provider and model per role, not once globally for all roles. The writer, rewriter, and vibe scorer SHALL run on Claude Opus 4.5; the fact-checker, librarian, fresh-eyes judge, and the orchestrator/supervisor SHALL run on Codex GPT-5.5.
+
+#### Scenario: Writer and vibe run on Opus 4.5
+
+- **WHEN** the tribunal invokes the writer/rewriter or the vibe scorer
+- **THEN** it SHALL execute on Claude `claude-opus-4-5`
+
+#### Scenario: Other judges and orchestrator run on GPT-5.5
+
+- **WHEN** the tribunal invokes fact-checker, librarian, fresh-eyes, or the supervisor loop
+- **THEN** it SHALL execute on Codex `gpt-5.5`
+
+#### Scenario: Roles do not share one global provider
+
+- **WHEN** both `codex` and `claude` CLIs are present
+- **THEN** the presence of one SHALL NOT force every role onto a single provider
+
+### Requirement: Codex execution SHALL honor the per-role declared model
+
+The codex execution path SHALL read the model from the role's `.codex/agents/<role>.toml` `model` field rather than a hardcoded CLI flag, and SHALL NOT instruct the model to ignore its declared model. It SHALL default to `gpt-5.5` only when no model is declared.
+
+#### Scenario: Declared codex model is used
+
+- **WHEN** a codex role has a `model` field in its agent spec
+- **THEN** that model SHALL be passed to the codex CLI
+- **AND** no prompt line SHALL instruct the model to ignore it
+
+### Requirement: Missing provider CLI SHALL fail loudly, not silently reroute
+
+When a role's required provider CLI is absent, the tribunal SHALL fail that role with a clear error rather than silently rerouting all roles onto the other provider.
+
+#### Scenario: Required CLI absent
+
+- **WHEN** a role requires `claude` but `claude` is not on PATH
+- **THEN** the tribunal SHALL emit an explicit error for that role
+- **AND** SHALL NOT silently move every role to codex

--- a/openspec/changes/tribunal-24-7-deploy-readiness/specs/tribunal-model-routing/spec.md
+++ b/openspec/changes/tribunal-24-7-deploy-readiness/specs/tribunal-model-routing/spec.md
@@ -2,17 +2,17 @@
 
 ### Requirement: Each tribunal role SHALL resolve its provider and model independently
 
-The tribunal SHALL select the LLM provider and model per role, not once globally for all roles. The writer, rewriter, and vibe scorer SHALL run on Claude Opus 4.5; the fact-checker, librarian, fresh-eyes judge, and the orchestrator/supervisor SHALL run on Codex GPT-5.5.
+The tribunal SHALL select the LLM provider per role, not once globally for all roles: the writer, rewriter, and vibe scorer SHALL run on the Claude provider; the fact-checker, librarian, fresh-eyes judge, and the orchestrator/supervisor SHALL run on the Codex provider. The **model** for each role SHALL be resolved from that role's declared config (`.claude/agents/<role>.md` for Claude roles, `.codex/agents/<role>.toml` for Codex roles); the specific build values are owned by the `tribunal-model-pinning-strategy` change and SHALL NOT be hardcoded in the router.
 
-#### Scenario: Writer and vibe run on Opus 4.5
+#### Scenario: Writer and vibe run on Claude with their configured model
 
 - **WHEN** the tribunal invokes the writer/rewriter or the vibe scorer
-- **THEN** it SHALL execute on Claude `claude-opus-4-5`
+- **THEN** it SHALL execute on the Claude provider using the model declared in that role's `.claude/agents/<role>.md` (currently `claude-opus-4-5`)
 
-#### Scenario: Other judges and orchestrator run on GPT-5.5
+#### Scenario: Other judges and orchestrator run on Codex with their configured model
 
 - **WHEN** the tribunal invokes fact-checker, librarian, fresh-eyes, or the supervisor loop
-- **THEN** it SHALL execute on Codex `gpt-5.5`
+- **THEN** it SHALL execute on the Codex provider using the model declared in that role's `.codex/agents/<role>.toml` (currently `gpt-5.5`)
 
 #### Scenario: Roles do not share one global provider
 

--- a/openspec/changes/tribunal-24-7-deploy-readiness/tasks.md
+++ b/openspec/changes/tribunal-24-7-deploy-readiness/tasks.md
@@ -24,7 +24,7 @@
 
 ## 5. Accurate monitoring (P1)
 
-- [ ] 5.1 Update `.claude/skills/tribunal-monitor/SKILL.md` to parse `quota-controller.json` + `CONTROLLER:` log lines + the real floor (default 10%), not the retired `Tier GO / 3%` strings.
+- [ ] 5.1 Update `.claude/skills/tribunal-monitor/SKILL.md` to parse `quota-controller.json` + `CONTROLLER:` log lines + the real floor (default 10%), not the retired `Tier …% remaining` format / stale 3% floor.
 
 ## 6. Burst configurability + docs (P2)
 

--- a/openspec/changes/tribunal-24-7-deploy-readiness/tasks.md
+++ b/openspec/changes/tribunal-24-7-deploy-readiness/tasks.md
@@ -1,10 +1,11 @@
 ## 1. Per-role model routing (P0 — unblocks the intended split)
 
-- [ ] 1.1 In `scripts/tribunal-helpers.sh`, add a role→(provider, model) resolver: `{writer, rewriter, vibe}`→claude/`claude-opus-4-5`; `{fact-checker, librarian, fresh-eyes, orchestrator}`→codex/`gpt-5.5`.
+- [ ] 1.1 In `scripts/tribunal-helpers.sh`, add a role→provider resolver: `{writer, rewriter, vibe}`→claude; `{fact-checker, librarian, fresh-eyes, orchestrator}`→codex. Resolve each role's **model** by reading its config field (`.claude/agents/<role>.md` / `.codex/agents/<role>.toml`), not a literal in the resolver — the build values are owned by `tribunal-model-pinning-strategy`.
 - [ ] 1.2 Route each judge/writer invocation through the resolver instead of the global `tribunal_llm_provider()` choosing one provider for all (helpers.sh ~380-401).
 - [ ] 1.3 Replace the hardcoded `--model gpt-5.5` (helpers.sh:358) with a lookup of `.codex/agents/<role>.toml` `model`; default `gpt-5.5` when unset; remove the "Ignore model" prompt line (helpers.sh ~336-338).
 - [ ] 1.4 Make a missing required CLI fail that role loudly (explicit error), not silently reroute all roles.
-- [ ] 1.5 Add/extend a shell test asserting writer/vibe resolve to claude-opus-4-5 and the other judges to codex gpt-5.5 (mirror `scripts/tests/` patterns).
+- [ ] 1.5 Add/extend a shell test asserting writer/vibe resolve to the claude provider + their configured Opus model, and the other judges to the codex provider + their configured model (assert against the config field, not a hardcoded version string; mirror `scripts/tests/` patterns).
+- [ ] 1.6 Update `scripts/tests/test-tribunal-safety-contract.sh` in the same change: its current assertions (`--model gpt-5.5` hardcode at line 77, the "Ignore YAML / frontmatter runtime fields" prompt at line 72, the static `codex-gpt-5.5-medium` runner label at 109/115, and `^model = "gpt-5.5"` pinned across `.codex/agents/*.toml` at line 95) flip from "must be hardcoded/pinned" to "must be read from per-role config". Removing the hardcode without this turns a currently-green test red.
 
 ## 2. Enable rewrites in the deployed runtime (P0 — the headline bomb)
 
@@ -18,8 +19,8 @@
 
 ## 4. Operator alerting (P1)
 
-- [ ] 4.1 Replace the macOS `osascript` `tribunal_quota_alarm` (helpers.sh ~748-755) with an injectable notifier (env-configured command / clawd Telegram notifier).
-- [ ] 4.2 Fire the notifier on stall / EXHAUSTED spike / `fallback` / `floor_stop` from `tribunal-quota-loop.sh`; fall back to an observable log line when no channel is configured.
+- [ ] 4.1 Replace the macOS `osascript` `tribunal_quota_alarm` (helpers.sh ~778-785; `osascript` at line 784) with an injectable notifier (env-configured command / clawd Telegram notifier).
+- [ ] 4.2 Add alarm hooks to `tribunal-quota-loop.sh` (it has none today — current alarm calls live in `tribunal-helpers.sh`) firing the notifier on stall / EXHAUSTED spike / `fallback` / `floor_stop`; fall back to an observable log line when no channel is configured.
 
 ## 5. Accurate monitoring (P1)
 
@@ -33,4 +34,4 @@
 ## 7. Verify
 
 - [ ] 7.1 Shell tests green; `node scripts/validate-posts.mjs` unaffected; `openspec validate tribunal-24-7-deploy-readiness --strict` passes.
-- [ ] 7.2 Dry-run on clawd-vm: confirm a failing article is rewritten (not skipped), writer/vibe run on Opus 4.5, other judges on GPT-5.5, and the monitor shows live controller state.
+- [ ] 7.2 Dry-run on clawd-vm: confirm a failing article is rewritten (not skipped), writer/vibe run on the configured Claude/Opus model, other judges on the configured Codex/GPT-5.5 model, and the monitor shows live controller state.

--- a/openspec/changes/tribunal-24-7-deploy-readiness/tasks.md
+++ b/openspec/changes/tribunal-24-7-deploy-readiness/tasks.md
@@ -1,0 +1,36 @@
+## 1. Per-role model routing (P0 — unblocks the intended split)
+
+- [ ] 1.1 In `scripts/tribunal-helpers.sh`, add a role→(provider, model) resolver: `{writer, rewriter, vibe}`→claude/`claude-opus-4-5`; `{fact-checker, librarian, fresh-eyes, orchestrator}`→codex/`gpt-5.5`.
+- [ ] 1.2 Route each judge/writer invocation through the resolver instead of the global `tribunal_llm_provider()` choosing one provider for all (helpers.sh ~380-401).
+- [ ] 1.3 Replace the hardcoded `--model gpt-5.5` (helpers.sh:358) with a lookup of `.codex/agents/<role>.toml` `model`; default `gpt-5.5` when unset; remove the "Ignore model" prompt line (helpers.sh ~336-338).
+- [ ] 1.4 Make a missing required CLI fail that role loudly (explicit error), not silently reroute all roles.
+- [ ] 1.5 Add/extend a shell test asserting writer/vibe resolve to claude-opus-4-5 and the other judges to codex gpt-5.5 (mirror `scripts/tests/` patterns).
+
+## 2. Enable rewrites in the deployed runtime (P0 — the headline bomb)
+
+- [ ] 2.1 Set `GP_WRITER_MODE=subagent` in `scripts/tribunal-loop.service` (and `cc-tribunal-loop-wrapper.sh` / `cc-cron-tribunal.sh` if they spawn the loop), keeping the library default `none` in helpers.sh.
+- [ ] 2.2 Add a startup pre-flight assertion that warns loudly if the deployed daemon resolves `GP_WRITER_MODE=none`.
+
+## 3. Reboot persistence (P0)
+
+- [ ] 3.1 Document in `docs/tribunal-runbook.md` the required `systemctl --user enable tribunal-loop` + `loginctl enable-linger <user>` and add it to the deploy checklist.
+- [ ] 3.2 Add a doctor/health check that reports whether the unit is enabled + linger is on.
+
+## 4. Operator alerting (P1)
+
+- [ ] 4.1 Replace the macOS `osascript` `tribunal_quota_alarm` (helpers.sh ~748-755) with an injectable notifier (env-configured command / clawd Telegram notifier).
+- [ ] 4.2 Fire the notifier on stall / EXHAUSTED spike / `fallback` / `floor_stop` from `tribunal-quota-loop.sh`; fall back to an observable log line when no channel is configured.
+
+## 5. Accurate monitoring (P1)
+
+- [ ] 5.1 Update `.claude/skills/tribunal-monitor/SKILL.md` to parse `quota-controller.json` + `CONTROLLER:` log lines + the real floor (default 10%), not the retired `Tier GO / 3%` strings.
+
+## 6. Burst configurability + docs (P2)
+
+- [ ] 6.1 Document the burst knobs in `docs/tribunal-runbook.md`: `--workers N`, `QUOTA_FLOOR=0`, `QUOTA_BURST_ALLOWANCE↑`, `MIN_COOLDOWN↓`, plus the `AUTOSCALE_OOM_CAP` cap and the "controller does not see Claude quota" caveat.
+- [ ] 6.2 Document the off-repo `usage-monitor.sh` prerequisite and that its absence drops the controller into `fallback` (1 worker / 600s).
+
+## 7. Verify
+
+- [ ] 7.1 Shell tests green; `node scripts/validate-posts.mjs` unaffected; `openspec validate tribunal-24-7-deploy-readiness --strict` passes.
+- [ ] 7.2 Dry-run on clawd-vm: confirm a failing article is rewritten (not skipped), writer/vibe run on Opus 4.5, other judges on GPT-5.5, and the monitor shows live controller state.


### PR DESCRIPTION
## 這是什麼

把「tribunal 能不能 7×24 跑」偵察出的**部署缺口**用 OpenSpec spec 起來（**只有 SDD、尚未實作**），給 review。`openspec validate --strict` 通過。

偵察結論：**引擎架構 READY，但現行部署 NOT READY**——卡的全是部署設定，不是程式爛。Scope 鎖定**單機 / clawd-vm**。

## 兩個新 capability

### `tribunal-model-routing`
逐角色選 provider+model，不再「全隊一個 provider」：
- 寫手 / 重寫 / vibe → **Claude Opus 4.5**
- fact-checker / librarian / fresh-eyes / orchestrator → **Codex GPT-5.5**
- 砍掉 `tribunal-helpers.sh:358` 寫死的 `--model gpt-5.5` + 那句叫模型「Ignore model」的 prompt；改讀 `.codex/agents/*.toml` 已存在卻被無視的 `model` 欄
- 缺 CLI 要**大聲報錯**，不准默默把全隊改道

### `tribunal-24-7-operations`
讓 daemon 能無人值守跑：
- **啟用重寫**：部署 unit 設 `GP_WRITER_MODE=subagent`（library 預設 `none` 保留為安全值）——否則評分但不改寫、白燒到 EXHAUSTED
- **reboot 持久化**：`systemctl --user enable` + `loginctl enable-linger`
- **Linux 可達告警**：把 macOS `osascript`（在 VPS 等於對空氣喊）換成 Telegram / clawd notifier
- **monitor 校準**：`tribunal-monitor` skill 改 parse `CONTROLLER:` + `quota-controller.json` + 真實 floor
- **burst 可調**：`--workers` / `QUOTA_FLOOR=0` / `QUOTA_BURST_ALLOWANCE` / `MIN_COOLDOWN`，並標註 autoscaler RAM cap、controller 看不到 Claude 額度

## Non-goals
多主機協調（claims 是 local/PID-based，明確單機）、mac daemon runtime、vendoring `usage-monitor.sh`、改 burn-rate 數學。

## artifacts
`openspec/changes/tribunal-24-7-deploy-readiness/`：proposal / design / specs ×2 / tasks（P0→P2 排序）。

⚠️ **下一步是 `apply`（實作）**，你說過要用 codex goal-mode 自己推上 prod——這份 spec 可以直接餵給它當施工藍圖。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rc8JH624waKTGngDgz9opm

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rc8JH624waKTGngDgz9opm)_