### PR TITLE
sp-pipeline: 3 token-saving optimizations (fetch / dedup / fixers)

### DIFF
--- a/scripts/inject-related-posts.mjs
+++ b/scripts/inject-related-posts.mjs
@@ -9,9 +9,11 @@
  *   node scripts/inject-related-posts.mjs --input /tmp/crosslink-suggestions.json --dry-run
  *   node scripts/inject-related-posts.mjs --input /tmp/crosslink-suggestions.json
  *   node scripts/inject-related-posts.mjs --dry-run          # generates suggestions inline
+ *   node scripts/inject-related-posts.mjs --file src/content/posts/sp-123-foo.mdx --dry-run
  *
  * Options:
  *   --input <file>    Path to suggestions JSON (default: generate inline)
+ *   --file <path>     Only process one post file
  *   --dry-run         Print diffs without writing files
  *   --limit <n>       Only process first N eligible posts (default: all)
  */
@@ -29,6 +31,8 @@ const args = process.argv.slice(2);
 const DRY_RUN = args.includes('--dry-run');
 const inputIdx = args.indexOf('--input');
 const INPUT_FILE = inputIdx !== -1 ? args[inputIdx + 1] : null;
+const fileIdx = args.indexOf('--file');
+const ONLY_FILE = fileIdx !== -1 ? path.basename(args[fileIdx + 1]) : null;
 const limitIdx = args.indexOf('--limit');
 const LIMIT = limitIdx !== -1 ? parseInt(args[limitIdx + 1], 10) : Infinity;
 
@@ -114,7 +118,8 @@ for (const entry of suggestions) {
 }
 
 // ─── Process posts ───────────────────────────────────────────────────
-const files = fs.readdirSync(POSTS_DIR).filter((f) => f.endsWith('.mdx'));
+let files = fs.readdirSync(POSTS_DIR).filter((f) => f.endsWith('.mdx'));
+if (ONLY_FILE) files = files.filter((f) => f === ONLY_FILE);
 let processed = 0;
 let injected = 0;
 let skippedHasLinks = 0;

--- a/tools/sp-pipeline/internal/config/config.go
+++ b/tools/sp-pipeline/internal/config/config.go
@@ -28,6 +28,8 @@ type Config struct {
 	WritingGuide string
 	// FetchXArticle is $RepoRoot/scripts/fetch-x-article.sh.
 	FetchXArticle string
+	// FetchArticle is $RepoRoot/scripts/fetch-article.py.
+	FetchArticle string
 	// ValidatePosts is $RepoRoot/scripts/validate-posts.mjs.
 	ValidatePosts string
 }
@@ -69,6 +71,7 @@ func fromRoot(root string) (*Config, error) {
 		CounterFile:   filepath.Join(abs, "scripts", "article-counter.json"),
 		WritingGuide:  filepath.Join(abs, "GU-LOG_WRITER_PROMPT.md"),
 		FetchXArticle: filepath.Join(abs, "scripts", "fetch-x-article.sh"),
+		FetchArticle:  filepath.Join(abs, "scripts", "fetch-article.py"),
 		ValidatePosts: filepath.Join(abs, "scripts", "validate-posts.mjs"),
 	}
 	return cfg, nil

--- a/tools/sp-pipeline/internal/config/config_test.go
+++ b/tools/sp-pipeline/internal/config/config_test.go
@@ -57,6 +57,9 @@ func TestResolve_FromEnv(t *testing.T) {
 	if cfg.FetchXArticle != filepath.Join(resolvedRoot, "scripts", "fetch-x-article.sh") {
 		t.Fatalf("FetchXArticle wrong: %q", cfg.FetchXArticle)
 	}
+	if cfg.FetchArticle != filepath.Join(resolvedRoot, "scripts", "fetch-article.py") {
+		t.Fatalf("FetchArticle wrong: %q", cfg.FetchArticle)
+	}
 	if cfg.ValidatePosts != filepath.Join(resolvedRoot, "scripts", "validate-posts.mjs") {
 		t.Fatalf("ValidatePosts wrong: %q", cfg.ValidatePosts)
 	}

--- a/tools/sp-pipeline/internal/pipeline/dedup.go
+++ b/tools/sp-pipeline/internal/pipeline/dedup.go
@@ -8,6 +8,48 @@ import (
 	"github.com/chitienhsiehwork-ai/gu-log/tools/sp-pipeline/internal/dedup"
 )
 
+// DedupURL is the URL-only dedup gate that runs before Eval. It catches
+// exact URL / tweet-ID duplicates before spending the two eval LLM calls.
+func (s *State) DedupURL(ctx context.Context) error {
+	if s.shouldSkipBelow(StepDedupURL) {
+		s.Log.Info("Step 1.2: URL dedup gate — SKIPPED (--from-step)")
+		return nil
+	}
+	if s.TweetURL == "" {
+		s.Log.Info("Step 1.2: URL dedup — skipping (no URL)")
+		return nil
+	}
+
+	s.Log.Info("Step 1.2: URL dedup gate")
+
+	scriptPath := filepath.Join(s.Cfg.ScriptsDir, "dedup-gate.mjs")
+	result, err := dedup.Check(ctx, dedup.Options{
+		ScriptPath: scriptPath,
+		URL:        s.TweetURL,
+		Title:      "",
+		Series:     s.Prefix,
+	})
+	if err != nil {
+		return fmt.Errorf("dedup-url: %w", err)
+	}
+	s.DedupVerdict = string(result.Verdict)
+	switch result.Verdict {
+	case dedup.VerdictPass:
+		s.Log.OK("Step 1.2 URL dedup: PASS")
+		return nil
+	case dedup.VerdictWarn:
+		s.Log.Warn("Step 1.2 URL dedup: WARN — %d potential match(es) (advisory)", len(result.Matches))
+		return nil
+	case dedup.VerdictBlock:
+		for _, m := range result.Matches {
+			s.Log.Warn("  match: %s", m)
+		}
+		return NewStepError(13, fmt.Errorf("dedup-url: BLOCK (%d match(es))", len(result.Matches)))
+	default:
+		return fmt.Errorf("dedup-url: unknown verdict %q", result.Verdict)
+	}
+}
+
 // Dedup is the Go port of scripts/sp-pipeline.sh Step 1.7. It wraps
 // scripts/dedup-gate.mjs via internal/dedup and sets s.DedupVerdict for
 // downstream logging. A BLOCK verdict returns StepError{Code:13}, which

--- a/tools/sp-pipeline/internal/pipeline/fetch.go
+++ b/tools/sp-pipeline/internal/pipeline/fetch.go
@@ -48,6 +48,7 @@ func (s *State) Fetch(ctx context.Context) error {
 	res, err := source.Fetch(ctx, s.TweetURL, source.FetchOptions{
 		WorkDir:             s.WorkDir,
 		FetchXArticleScript: s.Cfg.FetchXArticle,
+		FetchArticleScript:  s.Cfg.FetchArticle,
 	})
 	if err != nil {
 		code := 10

--- a/tools/sp-pipeline/internal/pipeline/phase3_test.go
+++ b/tools/sp-pipeline/internal/pipeline/phase3_test.go
@@ -263,6 +263,49 @@ body
 	}
 }
 
+func TestRunPostFixers_BestEffortOnFailure(t *testing.T) {
+	tmp := t.TempDir()
+	binDir := filepath.Join(tmp, "bin")
+	scriptsDir := filepath.Join(tmp, "scripts")
+	for _, d := range []string{binDir, scriptsDir} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	logPath := filepath.Join(tmp, "node-calls.log")
+	nodeStub := `#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$FIXER_CALL_LOG"
+exit 1
+`
+	if err := os.WriteFile(filepath.Join(binDir, "node"), []byte(nodeStub), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("FIXER_CALL_LOG", logPath)
+
+	postPath := filepath.Join(tmp, "post.mdx")
+	if err := os.WriteFile(postPath, []byte("---\ntitle: Test\n---\nbody\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	s := NewState()
+	s.Log = logx.New()
+	s.Cfg = &config.Config{RepoRoot: tmp, ScriptsDir: scriptsDir}
+
+	s.runPostFixers(context.Background(), postPath)
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("fake node was not called: %v", err)
+	}
+	got := string(data)
+	for _, want := range []string{"add-kaomoji.mjs --write", "apply-glossary-links.mjs", "inject-related-posts.mjs --file"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("node calls missing %q:\n%s", want, got)
+		}
+	}
+}
+
 // TestDeploy_DryRunWithFakeGitRepo exercises the deploy flow end-to-end
 // against a real temp git repo, with validate/build skipped and push
 // disabled (no remote). Uses a real counter file.

--- a/tools/sp-pipeline/internal/pipeline/ralph.go
+++ b/tools/sp-pipeline/internal/pipeline/ralph.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/chitienhsiehwork-ai/gu-log/tools/sp-pipeline/internal/frontmatter"
 	"github.com/chitienhsiehwork-ai/gu-log/tools/sp-pipeline/internal/ralph"
+	"github.com/chitienhsiehwork-ai/gu-log/tools/sp-pipeline/internal/runner"
 )
 
 // finalPipelineURL matches scripts/sp-pipeline.sh line 1290.
@@ -100,6 +101,8 @@ func (s *State) Ralph(ctx context.Context) error {
 		}
 	}
 
+	s.runPostFixers(ctx, activePath)
+
 	// Run the tribunal. tribunal.sh auto-selects its own runtime provider
 	// (Codex GPT-5.5 normally; Claude Opus when codex is absent in CCC).
 	s.Log.Info("  Running 4-stage tribunal (via tribunal.sh)...")
@@ -150,6 +153,41 @@ func (s *State) Ralph(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+func (s *State) runPostFixers(ctx context.Context, postPath string) {
+	if s.Cfg == nil || s.Cfg.ScriptsDir == "" {
+		return
+	}
+	s.Log.Info("  Running deterministic fixers (kaomoji/glossary/related)...")
+
+	type fixer struct {
+		name string
+		args []string
+	}
+	fixers := []fixer{
+		{
+			name: "kaomoji",
+			args: []string{filepath.Join(s.Cfg.ScriptsDir, "add-kaomoji.mjs"), "--write", postPath},
+		},
+		{
+			name: "glossary",
+			args: []string{filepath.Join(s.Cfg.ScriptsDir, "apply-glossary-links.mjs"), postPath},
+		},
+		{
+			name: "related",
+			args: []string{filepath.Join(s.Cfg.ScriptsDir, "inject-related-posts.mjs"), "--file", postPath},
+		},
+	}
+	for _, f := range fixers {
+		if _, err := runner.RunWithOptions(ctx, runner.Options{
+			Name:    "node",
+			Args:    f.args,
+			WorkDir: s.Cfg.RepoRoot,
+		}); err != nil {
+			s.Log.Warn("  fixer %s failed (advisory): %v", f.name, err)
+		}
+	}
 }
 
 // normalizeRalphFrontmatter is the Go port of the Python heredoc at

--- a/tools/sp-pipeline/internal/pipeline/run.go
+++ b/tools/sp-pipeline/internal/pipeline/run.go
@@ -66,6 +66,7 @@ func Run(ctx context.Context, s *State) error {
 	}
 	steps := []step{
 		{"fetch", s.Fetch},
+		{"dedup-url", s.DedupURL},
 		{"eval", s.Eval},
 		{"dedup", s.Dedup},
 		{"write", s.Write},
@@ -126,7 +127,7 @@ func PrintSummary(w io.Writer, s *State) {
 	fmt.Fprintf(w, "Title       : %s\n", nonEmpty(s.Title, "N/A"))
 	fmt.Fprintf(w, "Filename    : %s\n", nonEmpty(s.Filename, nonEmpty(s.ActiveFilename, "N/A (dry-run)")))
 	fmt.Fprintf(w, "Work dir    : %s\n", s.WorkDir)
-	for _, name := range []string{"fetch", "eval", "dedup", "write", "review", "refine", "credits", "ralph", "deploy"} {
+	for _, name := range []string{"fetch", "dedup-url", "eval", "dedup", "write", "review", "refine", "credits", "ralph", "deploy"} {
 		fmt.Fprintf(w, "%-7s time: %ds\n", name, s.Timings[name])
 	}
 }

--- a/tools/sp-pipeline/internal/pipeline/run_test.go
+++ b/tools/sp-pipeline/internal/pipeline/run_test.go
@@ -208,11 +208,46 @@ func TestRun_HappyPath(t *testing.T) {
 	var buf bytes.Buffer
 	PrintSummary(&buf, s)
 	sum := buf.String()
-	for _, want := range []string{"SP number", "SP-171" /* "171" appears in number row */, "Work dir", "fetch", "eval", "write", "deploy"} {
+	for _, want := range []string{"SP number", "SP-171" /* "171" appears in number row */, "Work dir", "fetch", "dedup-url", "eval", "write", "deploy"} {
 		_ = want
 	}
 	if !strings.Contains(sum, "171") {
 		t.Errorf("summary missing SP-171: %s", sum)
+	}
+	if !strings.Contains(sum, "dedup-url") {
+		t.Errorf("summary missing dedup-url timing: %s", sum)
+	}
+}
+
+func TestRun_DedupURLBlockExit13BeforeEval(t *testing.T) {
+	s, tmp := makeRunHarness(t)
+	if err := os.WriteFile(filepath.Join(tmp, "scripts", "dedup-gate.mjs"), []byte(`#!/usr/bin/env node
+if (!process.argv.includes('--title')) {
+  console.log('BLOCK: Duplicate of SP-1 (URL match): Existing post');
+  process.exit(1);
+}
+console.log('PASS');
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	fake := llm.NewFakeClaude()
+	disp, err := llm.NewDispatcher(logx.New(), fake)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.Dispatcher = disp
+	_, _ = SetupWorkDir(s)
+
+	err = Run(context.Background(), s)
+	if err == nil {
+		t.Fatalf("expected StepError")
+	}
+	var se *StepError
+	if !errors.As(err, &se) || se.Code != 13 {
+		t.Fatalf("expected exit 13 for URL dedup BLOCK, got %v", err)
+	}
+	if len(fake.Called) != 0 {
+		t.Fatalf("eval should not be reached after URL dedup BLOCK, got %d LLM call(s)", len(fake.Called))
 	}
 }
 

--- a/tools/sp-pipeline/internal/pipeline/state.go
+++ b/tools/sp-pipeline/internal/pipeline/state.go
@@ -16,15 +16,16 @@ import (
 
 // Step integer encoding — matches scripts/sp-pipeline.sh step_to_int.
 const (
-	StepSetup  = 0
-	StepFetch  = 10
-	StepEval   = 15
-	StepDedup  = 17
-	StepWrite  = 20
-	StepReview = 30
-	StepRefine = 40
-	StepRalph  = 47
-	StepDeploy = 50
+	StepSetup    = 0
+	StepFetch    = 10
+	StepDedupURL = 12
+	StepEval     = 15
+	StepDedup    = 17
+	StepWrite    = 20
+	StepReview   = 30
+	StepRefine   = 40
+	StepRalph    = 47
+	StepDeploy   = 50
 )
 
 // State is the mutable snapshot of an in-flight pipeline run. Each step

--- a/tools/sp-pipeline/internal/pipeline/state_test.go
+++ b/tools/sp-pipeline/internal/pipeline/state_test.go
@@ -257,11 +257,11 @@ func TestRefine_AnglePropagates(t *testing.T) {
 
 func TestResolveSourceField(t *testing.T) {
 	cases := []struct {
-		name        string
-		label       string
-		isX         bool
-		handle      string
-		want        string
+		name   string
+		label  string
+		isX    bool
+		handle string
+		want   string
 	}{
 		{"explicit override wins", "OpenClaw Docs", true, "nick", "OpenClaw Docs"},
 		{"x with handle", "", true, "nickbaumann_", "@nickbaumann_ on X"},

--- a/tools/sp-pipeline/internal/source/fetch.go
+++ b/tools/sp-pipeline/internal/source/fetch.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	nethttp "net/url"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -42,6 +43,8 @@ type FetchOptions struct {
 	WorkDir string
 	// FetchXArticleScript is the absolute path to scripts/fetch-x-article.sh.
 	FetchXArticleScript string
+	// FetchArticleScript is the absolute path to scripts/fetch-article.py.
+	FetchArticleScript string
 }
 
 // xURLRe matches https://x.com/... and twitter.com/... URLs.
@@ -129,14 +132,41 @@ func FetchGeneric(ctx context.Context, urlStr string, opts FetchOptions) (*Fetch
 		return nil, fmt.Errorf("fetchgeneric: WorkDir is required")
 	}
 
+	host := hostname(urlStr)
+	date := time.Now().Format("2006-01-02")
+	outPath := filepath.Join(opts.WorkDir, "source-tweet.md")
+
+	if opts.FetchArticleScript != "" {
+		if _, err := exec.LookPath("python3"); err == nil {
+			if res, runErr := runner.Run(ctx, "python3", opts.FetchArticleScript, urlStr); runErr == nil {
+				body := strings.TrimSpace(string(res.Stdout))
+				if body != "" {
+					header := fmt.Sprintf("@%s — %s\nSource URL: %s\nFetched via: fetch-article.py\n\n", host, date, urlStr)
+					payload := []byte(header + body + "\n")
+					if verr := ValidateArticleCapture(payload); verr == nil {
+						if err := os.WriteFile(outPath, payload, 0o644); err != nil {
+							return nil, fmt.Errorf("fetchgeneric: writing capture to %s: %w", outPath, err)
+						}
+						return &FetchResult{
+							Path:       outPath,
+							Handle:     "@" + host,
+							Date:       date,
+							FetchedVia: "fetch-article.py",
+							Bytes:      len(payload),
+							IsX:        false,
+						}, nil
+					}
+				}
+			}
+		}
+	}
+
 	ua := "Mozilla/5.0 (compatible; sp-pipeline/1; +https://gu-log.vercel.app)"
 	res, err := runner.Run(ctx, "curl", "-sSL", "--max-time", "60", "-A", ua, urlStr)
 	if err != nil {
 		return nil, fmt.Errorf("fetchgeneric: curl: %w", err)
 	}
 
-	host := hostname(urlStr)
-	date := time.Now().Format("2006-01-02")
 	body := cleanupHTML(res.Stdout)
 
 	header := fmt.Sprintf("@%s — %s\nSource URL: %s\nFetched via: curl\n\n", host, date, urlStr)
@@ -146,7 +176,6 @@ func FetchGeneric(ctx context.Context, urlStr string, opts FetchOptions) (*Fetch
 		return nil, verr
 	}
 
-	outPath := filepath.Join(opts.WorkDir, "source-tweet.md")
 	if err := os.WriteFile(outPath, payload, 0o644); err != nil {
 		return nil, fmt.Errorf("fetchgeneric: writing capture to %s: %w", outPath, err)
 	}

--- a/tools/sp-pipeline/internal/source/generic_test.go
+++ b/tools/sp-pipeline/internal/source/generic_test.go
@@ -1,6 +1,9 @@
 package source
 
 import (
+	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -89,5 +92,133 @@ func TestHostname(t *testing.T) {
 		if got := hostname(in); got != want {
 			t.Errorf("hostname(%q) = %q, want %q", in, got, want)
 		}
+	}
+}
+
+func TestFetchGeneric_UsesCurlWhenFetchArticleScriptEmpty(t *testing.T) {
+	tmp := t.TempDir()
+	binDir := filepath.Join(tmp, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeExecutable(t, filepath.Join(binDir, "curl"), `#!/usr/bin/env bash
+cat <<'HTML'
+<html><body>
+<h1>Curl Article</h1>
+<p>This fake curl article has enough prose to pass the generic source validator.</p>
+<p>It includes multiple non-empty lines so the capture shape remains realistic.</p>
+<p>The body is intentionally plain and boring because the test only checks routing.</p>
+<p>One more line pads the capture beyond the minimum length without using the network.</p>
+</body></html>
+HTML
+`)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	res, err := FetchGeneric(context.Background(), "https://example.com/article", FetchOptions{WorkDir: tmp})
+	if err != nil {
+		t.Fatalf("FetchGeneric: %v", err)
+	}
+	if res.FetchedVia != "curl" {
+		t.Fatalf("FetchedVia = %q, want curl", res.FetchedVia)
+	}
+	data, err := os.ReadFile(res.Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "Fetched via: curl") {
+		t.Fatalf("capture missing curl header:\n%s", data)
+	}
+}
+
+func TestFetchGeneric_UsesFetchArticleScriptWhenValid(t *testing.T) {
+	tmp := t.TempDir()
+	binDir := filepath.Join(tmp, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeExecutable(t, filepath.Join(binDir, "python3"), `#!/usr/bin/env bash
+cat <<'TEXT'
+Python Article
+This cleaned article text came from the Python extractor and is already readable.
+It has enough paragraphs to satisfy the article validator without HTML cleanup.
+The exact body should be preserved because the extractor did the cleanup upstream.
+This line pads the capture to a realistic size for downstream LLM prompts.
+The final line ensures there are more than five non-empty lines in the payload.
+TEXT
+`)
+	writeExecutable(t, filepath.Join(binDir, "curl"), `#!/usr/bin/env bash
+echo "curl should not run" >&2
+exit 9
+`)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	res, err := FetchGeneric(context.Background(), "https://example.com/article", FetchOptions{
+		WorkDir:            tmp,
+		FetchArticleScript: filepath.Join(tmp, "fetch-article.py"),
+	})
+	if err != nil {
+		t.Fatalf("FetchGeneric: %v", err)
+	}
+	if res.FetchedVia != "fetch-article.py" {
+		t.Fatalf("FetchedVia = %q, want fetch-article.py", res.FetchedVia)
+	}
+	data, err := os.ReadFile(res.Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(data)
+	if !strings.Contains(got, "Fetched via: fetch-article.py") {
+		t.Fatalf("capture missing python header:\n%s", got)
+	}
+	if !strings.Contains(got, "Python Article") {
+		t.Fatalf("capture missing python body:\n%s", got)
+	}
+}
+
+func TestFetchGeneric_FallsBackWhenFetchArticleOutputInvalid(t *testing.T) {
+	tmp := t.TempDir()
+	binDir := filepath.Join(tmp, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeExecutable(t, filepath.Join(binDir, "python3"), `#!/usr/bin/env bash
+echo "too short"
+`)
+	writeExecutable(t, filepath.Join(binDir, "curl"), `#!/usr/bin/env bash
+cat <<'HTML'
+<html><body>
+<h1>Fallback Article</h1>
+<p>This fake curl article is long enough to prove invalid Python output falls back.</p>
+<p>It has multiple non-empty lines and contains no blocked markers or code shell.</p>
+<p>The fetcher should validate this fallback payload and write it successfully.</p>
+<p>That keeps Python extractor failures advisory instead of making the pipeline fail.</p>
+</body></html>
+HTML
+`)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	res, err := FetchGeneric(context.Background(), "https://example.com/article", FetchOptions{
+		WorkDir:            tmp,
+		FetchArticleScript: filepath.Join(tmp, "fetch-article.py"),
+	})
+	if err != nil {
+		t.Fatalf("FetchGeneric: %v", err)
+	}
+	if res.FetchedVia != "curl" {
+		t.Fatalf("FetchedVia = %q, want curl fallback", res.FetchedVia)
+	}
+	data, err := os.ReadFile(res.Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "Fallback Article") {
+		t.Fatalf("capture missing fallback body:\n%s", data)
+	}
+}
+
+func writeExecutable(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(body), 0o755); err != nil {
+		t.Fatalf("write %s: %v", path, err)
 	}
 }


### PR DESCRIPTION
把 pipeline 裡能純程式化的步驟交給 script，減少 LLM token 消耗。源自 `~/scratch/sp-pipeline-automation-audit.md` 的 quick wins（已逐條驗證）。

## 改動

**1. `fetch-article.py` 接進 `FetchGeneric`**
- 先試 readability 抽取器（`scripts/fetch-article.py`），失敗（沒 python / 出錯 / 空 / 驗證沒過）才回退原本的 curl。
- `FetchArticleScript == ""` 時行為與舊版**完全一致**。
- 雜訊變少 → 下游 write/review/refine 少燒 token。

**2. URL 去重挪到 eval 前**
- 新增 `DedupURL` step（`StepDedupURL=12`，用 `state.go` 既有編號空檔，不重編號、不破壞 `--from-step`）。
- eval 前做 URL/推文 ID 精確去重，撞重複 → exit 13，**省下 eval 的兩次 LLM 呼叫**。
- 需 title 的主題去重維持在 eval 之後，品質不變。

**3. 評審前自動跑 deterministic fixers**
- Ralph 在 tribunal 前對該篇跑 `add-kaomoji --write` / `apply-glossary-links` / `inject-related-posts --file`。
- best-effort：fixer 失敗只記 log、不中止 pipeline。
- 缺顏文字/詞彙連結/關聯文章不再觸發 LLM 重寫。
- `inject-related-posts.mjs` 新增 `--file` 單檔模式。

## 驗證（已獨立重跑，非 cache）
- `gofmt -l .` 乾淨、`go build ./...` 過、`go test -count=1 ./...` 全綠
- 實測 `dedup-gate.mjs --url <SP-231 url> --series SP` → 正確 BLOCK
- 實測 `inject-related-posts.mjs --file <post> --dry-run` → 單檔模式正常

## 不動
- `npm run build` 維持不變（deploy.go 註解明示刻意非 pnpm）

🤖 Generated with [Claude Code](https://claude.com/claude-code)