### PR TITLE
docs(level-up): 記錄 founder framework 全破 + gu-log 輕小說 thread

### DIFF
--- a/.claude/skills/level-up/learning/INDEX.md
+++ b/.claude/skills/level-up/learning/INDEX.md
@@ -9,5 +9,6 @@
 | Tribunal 24/7 readiness | mastered (Lv.1–9 full clear) | 9/9 MCQ 一次過；自己推出 claim 必須共享、用單機/clawd-vm 決策繞 boss | 2026-06-19 | topics/tribunal-24-7.md |
 | Spec-driven SDLC (openspec + multi-agent) | mastered (full clear) | 自己推導出 coach(macro) vs players(micro)、spec-altitude、reviewer+simplifier+implementor loop(=tribunal 形狀)、explore-first escalation；核心：一條 spec scenario = gate+rubric+邊界 | 2026-06-22 | topics/spec-driven-sdlc.md |
 | Self-help / 行為改變概念（Dan Koe 拆解） | mastered（判準+angle 層 full clear） | Lv.1–4 全一次過；自己挖 cybernetics↔Kubernetes 字根、提出「niche=angle 函數」、逼出 agent 三層定義 | 2026-06-20 | topics/self-help-concepts.md |
+| Founder framework〈Before It Was Obvious〉 | mastered (Lv.1–5 full clear) | 5/5 MCQ 一次過；自己把 yin/wedge/hair-on-fire 套到 gu-log 並用無職轉生當 benchmark 自評 | 2026-06-20 | topics/founder-framework-before-obvious.md |
 
 Learner profile（taste / framing / 語氣）：`learner-profile.md`

--- a/.claude/skills/level-up/learning/topics/founder-framework-before-obvious.md
+++ b/.claude/skills/level-up/learning/topics/founder-framework-before-obvious.md
@@ -1,0 +1,32 @@
+# Founder Framework〈Before It Was Obvious〉(@lmrankhan)
+
+## Current Level
+- Status: mastered (Lv.1–5 full clear)
+- Last updated: 2026-06-20
+- Confidence: high
+
+## Evidence
+- 2026-06-20: 五關 MCQ 全部一次答對（C/B/B/B/B）。
+  - Lv1 死因＝腦內提前判輸（不是能力/飽和/funding）。
+  - Lv2 yin-to-the-yang：選「從龍頭因強項裸露的破口切進」，排除比性能/等自爆/找空白。
+  - Lv3 power user + hair-on-fire：選「痛到睡不著但要泡進去當重度使用者」，排除 marginal 5%。
+  - Lv4 MVP wedge：選「找最尖單點打磨到 10x」，排除全都要/模仿龍頭。
+  - Lv5 distribution>product：抓到「以為夠好就有人來」是最大盲點。
+- 自己把框架套到 gu-log：正確指出 gu-log = 英文母語/AI-slop 圈的 yin 線（非母語友善＋好玩＋透明評分攻三破洞）。
+- 自己鍛出楔子：止痛藥＝「X posts 缺背景知識/文化脈絡讀不懂」，上癮（漫畫/輕小說式）＝留存倍率器。能區分 push painkiller vs pull addiction。
+- 用《無職轉生》當最殘忍 benchmark 自評 gu-log「還不夠上癮」——精準的 hair-on-fire 自我診斷。
+
+## Known Gaps
+- 一開始不熟 PMF / DMF 術語（已補定義）、不確定 ff=forfeit（已補）。非概念缺口，是詞彙。
+
+## Teaching Notes
+- Vainglory 類比全程命中（Kraken commit→裸側、vision/rotation=distribution、不 ff=grit）。沿用。
+- 這位 learner 會主動把框架套到自己的專案並自我批判——丟「應用到你的產品」型問題最有效。
+- 講術語（PMF/DMF）要先定義再用，他會抓。
+
+## Open product thread (非 level-up 範圍，但記著)
+- learner 想試「gu-log 輕小說系列」：原創角色（Clawd/ShroomDog 已是 proto-character），現有 SP/SD/CP/Lv 當 backbone 或番外。
+- 框架建議：別 commit 整個連載（=全都要），做一篇 pilot MVP 去撞無職轉生的尺。屬 critical design decision，等 user 拍板才動 repo。
+
+## Next Suggested Levels
+- 全破。可延伸：secular shift 的時機判斷（太早 vs 太晚）、distribution channel 的具體選擇框架。


### PR DESCRIPTION
## 這 PR 在幹嘛

一場 `level-up` 教學的學習紀錄存檔，主題是 @lmrankhan 〈Before It Was Obvious〉的 founder 框架（secular shift / yin-to-the-yang / power user / hair-on-fire / MVP wedge / distribution-market fit / grit）。

純 `.claude/skills/level-up/learning/` 下的 markdown，不碰任何文章、component、pipeline。

## 改了什麼
- `INDEX.md`：新增一筆 mastered 紀錄
- `topics/founder-framework-before-obvious.md`：五關全破的證據 + learner 自己把框架套回 gu-log 的洞察（用《無職轉生》當 benchmark 自評「還不夠上癮」）+ 一條 open product thread（gu-log 輕小說系列點子，待 user 拍板）

## 為什麼存
讓下個 session 接得上那條輕小說 pilot 的 open thread，不用重講框架。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TJ4J4SBYARLPNqobemjk1q)_