### PR TITLE
docs(openspec): 提案 Clawd → Mogu 評論 persona 命名收斂

### DIFF
--- a/openspec/changes/consolidate-clawd-to-mogu-wording/.openspec.yaml
+++ b/openspec/changes/consolidate-clawd-to-mogu-wording/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-21

--- a/openspec/changes/consolidate-clawd-to-mogu-wording/design.md
+++ b/openspec/changes/consolidate-clawd-to-mogu-wording/design.md
@@ -1,0 +1,73 @@
+## Context
+
+`Mogu` is the intended canonical name of the gu-log commentary persona. The component (`MoguNote.astro`), the glossary (`Mogu` entry, `/glossary#mogu`), and the CP series label (`Mogu Picks` in `article-counter.json`) are already on the new name. But the **authoring inputs** — the writer-prompt SSOT, `CONTRIBUTING.md`, `CLAUDE.md`, all 5 tribunal judge agents (and their `.codex` mirrors), and even the pre-commit hook's error text — still mandate "Clawd", so every new post keeps reintroducing the old name. The corpus reflects this: 1082 / 1083 posts use `ClawdNote`; only 2 use `MoguNote`; ~190 name "Clawd" in prose; 158 carry the `clawdNote` score key.
+
+The migration is therefore not just half-applied — it is **actively re-seeded** by the SSOT every time content is authored, and it is **reader-visible** (SD-26 renders both names on one page). And it is **blocked**: four content-gating files hardcode `ClawdNote` with zero `MoguNote` awareness, so naively flipping imports breaks the pronoun and redundant-prefix gates.
+
+This proposal does not implement the rename. It pins the target contract (`specs/persona-naming/spec.md`), records the open decisions with recommendations, and phases the work so the cheap, reversible SSOT/tooling edits land before any risky corpus migration.
+
+## Goals / Non-Goals
+
+**Goals:**
+- One canonical reader-facing persona name (`Mogu`), agreed across component, glossary, SSOT prompts, and tooling.
+- Stop new content from re-seeding "Clawd".
+- Make the tooling `MoguNote`-aware so migration is even *possible* without breaking gates.
+- Resolve the reader-visible SD-26 inconsistency.
+- Keep all 1082 legacy posts rendering without a forced rewrite.
+
+**Non-Goals:**
+- No `scores.vibe.clawdNote` → `moguNote` schema migration (separate, heavy change).
+- No rename of the OpenClaw / clawd-vm automation agent or the `clawd-picks-*` files.
+- No forced mass rewrite of grandfathered posts.
+- No implementation in this change — artifacts only.
+
+## Open Decisions (options + recommendation)
+
+**D1 — Scope boundary: persona only, or also the OpenClaw agent + `clawd-picks` pipeline?**
+- *Option A (recommended):* Rename the **commentary persona only**. Leave the OpenClaw / clawd-vm agent identity and the `clawd-picks-prompt.md` / `clawd-picks-config.json` filenames as "Clawd".
+- *Option B:* Also rename the VM agent and pipeline files.
+- **Recommendation: A.** The existing `secure-clawd-vm-github-operator` OpenSpec change already treats "Clawd" as a *distinct VM automation agent* (alongside Iris) with its own GitHub-operator security contract. Conflating the reader-facing persona with that operator identity would entangle a cosmetic content rename with a security-scoped agent identity and a live pipeline's filenames. Renaming `clawd-picks-*` files also touches `~/clawd/AGENTS.md` and VM cron wiring outside this repo. Keep the blast radius on reader-facing content; note that the *user-facing* CP label is already "Mogu Picks", so the reader never sees "Clawd Picks" anyway.
+
+**D2 — Component: permanent `ClawdNote` alias, or migrate all imports to `MoguNote`?**
+- *Option A:* Keep `ClawdNote` as a permanent alias forever.
+- *Option B (recommended):* Keep the alias **through grandfathering**, migrate new content to `MoguNote`, and offer an opt-in codemod — but only after Phase 0 teaches the 4 gating files about `MoguNote`.
+- **Recommendation: B.** A permanent alias leaves a second name living in 1082 import lines indefinitely and keeps the door open for mixed-prefix pages like SD-26. Migrating everything in one shot is risky (it breaks the pronoun/redundant-prefix gates until tooling is updated, and rewrites reader prose at scale). Phase 0 (teach tooling) → Phase 1 (SSOT) → opt-in codemod is the safe ordering. The alias stays until the codemod has drained the corpus, then it can be removed in a later change.
+
+**D3 — `scores.vibe.clawdNote` key: rename to `moguNote`, or keep as a stable internal name?**
+- *Option A:* Rename the key to `moguNote`.
+- *Option B (recommended):* Keep `clawdNote` as a stable internal identifier.
+- **Recommendation: B.** The key is not reader-facing (it appears in frontmatter score blocks, not rendered prose). Renaming it touches `src/content/config.ts` (Zod, two blocks), `score-floor-check.mjs`, `validate-posts.mjs`, `src/lib/tribunal-v2/{pass-bar,types,git-format,pipeline}.ts`, `frontmatter-scores.mjs`, `vibe-scoring-standard.md`, the judge agents, **and 158 post frontmatters** — a full schema migration with its own version-gating story (mirroring how `move-clarity-vibe-to-fresheyes` had to thread `tribunalVersion` through every duplicated dimension list). That belongs in its own change. Decoupling it keeps the persona rename a content/SSOT change, not a schema migration.
+
+**D4 — Existing ~1082 posts: codemod now, or grandfather?**
+- *Option A:* Mass codemod prose "Clawd"→"Mogu" + `ClawdNote`→`MoguNote` across the corpus now.
+- *Option B (recommended):* Grandfather old posts; enforce "Mogu" for new content; provide an opt-in codemod runnable in batches after Phase 0.
+- **Recommendation: B.** A 1082-file rewrite of reader prose is high-risk (changes article voice, triggers re-validation, balloons one PR) and unnecessary for the reader-facing goal once new content is correct. Grandfathering matches the repo's existing pattern (posts without scores are grandfathered; the floor gate only fires on reader-visible edits). The opt-in codemod lets the corpus drain gradually, with the SD-26 mixed-prefix pages fixed first as a small, high-value batch.
+
+**D5 — SSOT prompt edits (writer prompt / CLAUDE.md / CONTRIBUTING / agents): the actual wording.**
+- This is the Phase 1 content of the rename. The load-bearing edit is `GU-LOG_WRITER_PROMPT.md:147` 「品牌：統一叫 "Clawd"」 → 「品牌：統一叫 "Mogu"」, plus the `<ClawdNote>` usage examples pointing at `MoguNote`, the judge-agent rubric persona mentions, and the pre-commit hook's "Use specific names (ShroomDog, Clawd, …)" string. The `clawdNote` *dimension key* inside agent rubrics stays (D3).
+
+## Phasing
+
+The phases are ordered so each one is independently shippable and the risky corpus work comes last, behind the tooling fix.
+
+- **Phase 0 — Teach tooling about `MoguNote` (additive, reversible).** Update `check-pronoun-clarity.mjs`, `check-jingjing.mjs`, `tests/content-integrity.spec.ts`, `tests/content-gates.test.ts` (and `obsidian-import.mjs`'s callout map) to recognize `MoguNote` alongside `ClawdNote`. No content changes; both component names pass every gate afterward. **This unblocks Phases 2–3.**
+- **Phase 1 — Flip the SSOT prose to "Mogu" (D5).** Writer prompt, `CONTRIBUTING.md`, `CLAUDE.md`, 5 judge agents + `.codex` mirrors, pre-commit error strings. New content is now authored as Mogu. Keep the `clawdNote` dimension key.
+- **Phase 2 — Fix the reader-visible inconsistencies first.** Migrate the SD-26 zh/en pair (and any other mixed-prefix pages) to all-`MoguNote` + Mogu prose; repoint `/glossary#clawd` links to `/glossary#mogu`. Small, high-value batch — runs only after Phase 0.
+- **Phase 3 (optional, opt-in) — Drain the corpus.** Codemod legacy posts `ClawdNote`→`MoguNote` + prose "Clawd"→"Mogu" in reviewable batches. Once drained, a later change may remove the `ClawdNote.astro` alias.
+
+## Risks / Trade-offs
+
+- **Re-seeding loop.** Until Phase 1 lands, every new post the pipeline writes reintroduces "Clawd" (the writer prompt mandates it). → Phase 1 should follow Phase 0 quickly; the two are small.
+- **Pronoun-gate breakage if order is violated.** Migrating a post to `<MoguNote>` before Phase 0 makes `check-pronoun-clarity.mjs` flag every 你/我 inside the note (it only masks `<ClawdNote>`). → The spec encodes the ordering constraint as a hard requirement.
+- **Dangling `/glossary#clawd` links.** ~190 posts link to an anchor that does not exist (no `Clawd` glossary entry). → Phase 2 repoints them; the glossary-link-coverage gate already enforces that linked terms resolve.
+- **Two-name window.** During Phases 0–3 the corpus legitimately mixes both names. → Acceptable for grandfathered pages; only *single-page* mixing (SD-26) is a defect, and it is fixed first in Phase 2.
+- **Schema-key temptation.** Someone may try to "finish the job" by also renaming `scores.vibe.clawdNote`. → D3 and the spec explicitly fence it off as a separate migration.
+
+## Migration Plan
+
+No data migration in this change (proposal only). When implemented: Phase 0 and Phase 1 are code/doc edits with trivial rollback (revert). Phase 2 touches a handful of posts. Phase 3 is opt-in and batchable, so rollback is per-batch. The `ClawdNote.astro` alias guarantees no post breaks at any point; alias removal is deferred to a future change after the corpus is drained.
+
+## Open Questions
+
+- Final removal of the `ClawdNote.astro` alias (after Phase 3) — out of scope here; decide once the corpus is drained.
+- Whether the `scores.vibe.clawdNote` → `moguNote` schema migration is ever worth doing (D3 defers, does not forbid).

--- a/openspec/changes/consolidate-clawd-to-mogu-wording/proposal.md
+++ b/openspec/changes/consolidate-clawd-to-mogu-wording/proposal.md
@@ -1,0 +1,72 @@
+## Why
+
+The gu-log commentary persona — the voice that speaks inside note boxes ("Clawd：又來了，每篇論文都說自己 SOTA…") — is being renamed **Clawd → Mogu**. The migration is **half done and inconsistent**, and the inconsistency is now reader-visible.
+
+Verified state (counts taken at proposal time against `src/content/posts/`, `2026-06-21`):
+
+- **Component layer is already migrated.** `src/components/MoguNote.astro` is the real component; it renders prefixes like `Mogu 碎碎念：` and links the `Mogu` token to `/glossary#mogu`. `src/components/ClawdNote.astro` is now a thin legacy alias that wraps `MoguNote` ("New content should import MoguNote directly").
+- **The glossary already has a `Mogu` entry** (`src/data/glossary.json`, term `Mogu`, anchor `/glossary#mogu`). There is **no** `Clawd` glossary entry — yet ~190 posts link prose "Clawd" to `/glossary#clawd` (a dangling anchor) or `/about`.
+- **Everything that drives NEW content still says "Clawd".** The writer-prompt SSOT explicitly mandates it (`GU-LOG_WRITER_PROMPT.md:147` 「品牌：統一叫 "Clawd"」), as do `CONTRIBUTING.md`, `CLAUDE.md`, all 5 tribunal judge agents (`.claude/agents/*.md` + their `.codex/agents/*.toml` mirrors), and the pre-commit hook's own error text.
+- **The corpus is overwhelmingly "Clawd".** Of **1083** posts, **1082** still `import ClawdNote` / use `<ClawdNote>`; only **2** use `<MoguNote>`. **~190** posts name "Clawd" in prose. **158** carry the `scores.vibe.clawdNote` score key.
+- **The reader-visible bug is concrete.** `src/content/posts/sd-26-20260616-loop-engineering-at-gu-log.mdx` (and its `en-` pair) render **4 "Clawd …" prefixes AND 1 "Mogu …" prefix in the same article**, while the frontmatter score key reads `clawdNote: 8`. A reader sees two names for one persona on one page.
+- **The tooling cannot tell `MoguNote` apart from prose yet.** `scripts/check-pronoun-clarity.mjs`, `scripts/check-jingjing.mjs`, `tests/content-integrity.spec.ts`, and `tests/content-gates.test.ts` hardcode `ClawdNote`/`ShroomDogNote` and contain **zero** references to `MoguNote` (verified by grep). So flipping a post's import to `<MoguNote>` today *breaks the pronoun checker* (it stops masking the note body and flags every 你/我 inside) and the redundant-prefix integrity test. The tooling must learn `MoguNote` **before** any mass component migration.
+
+This change is a **proposal only**: it defines the target contract, the open decisions with recommendations, and a phased plan. It does **not** edit prompts, components, posts, or tooling.
+
+## What Changes
+
+This proposal establishes the rename as an OpenSpec contract and **phases** it so the low-risk SSOT/tooling work lands before any risky mass content migration. Concretely the proposal commits to:
+
+- **Define the scope boundary** (recommended: rename the gu-log *commentary persona* only; leave the OpenClaw / clawd-vm automation-agent identity and the `clawd-picks-*` pipeline filenames out of scope — see decision D1).
+- **Phase 0 — Tooling learns `MoguNote` (additive, non-breaking).** Teach `check-pronoun-clarity.mjs`, `check-jingjing.mjs`, `tests/content-integrity.spec.ts`, and `tests/content-gates.test.ts` to recognize `MoguNote` *in addition to* `ClawdNote`. After Phase 0, a post may use either component and pass every gate. **This unblocks everything else.**
+- **Phase 1 — SSOT prose says "Mogu".** Update the writer prompt, `CONTRIBUTING.md`, `CLAUDE.md`, the 5 judge agents + their `.codex` mirrors, and the pre-commit hook's reader-facing error strings so new content is authored as "Mogu". The component-import guidance points at `MoguNote`.
+- **Phase 2 — New content is authored as Mogu; old posts grandfathered** (recommended D4). The legacy `ClawdNote` alias stays so the 1082 existing posts keep rendering; new posts import `MoguNote` and say "Mogu" in prose. An optional opt-in codemod is provided for migrating posts in batches, gated behind Phase 0.
+- **Keep the `scores.vibe.clawdNote` schema key as a stable internal name** (recommended D3) — renaming it is a separate, heavy schema migration across 1000+ posts + 8 validators/agents and is explicitly out of scope here.
+
+## Capabilities
+
+### New Capabilities
+- `persona-naming`: Defines the single canonical reader-facing name of the gu-log commentary persona (`Mogu`), the scope boundary that separates it from the OpenClaw automation-agent identity, the component/glossary/tooling/SSOT surfaces that must agree on that name, the rule that no single rendered page may show two names for the persona, and the phasing constraint that content-gating tooling must recognize `MoguNote` before any mass component migration. The schema key `scores.vibe.clawdNote` is explicitly declared a stable internal identifier exempt from this naming rule.
+
+### Modified Capabilities
+<!-- None. The four checkers/tests this change touches in Phase 0 are not currently
+     governed by an OpenSpec capability spec (they are code with no spec contract),
+     so their behavior change is captured as new requirements under persona-naming
+     rather than as deltas to an existing capability. glossary-link-coverage is
+     affected operationally (a Clawd→Mogu link target swap) but its requirements
+     do not change. -->
+
+## Impact
+
+**SSOT prose (Phase 1 wording edits):**
+- `GU-LOG_WRITER_PROMPT.md` (~27 hits; the canonical 「品牌：統一叫 "Clawd"」 directive at :147)
+- `CONTRIBUTING.md` (~18 hits; the `ClawdNote — Clawd 吐槽/註解` component section)
+- `CLAUDE.md` (~15 hits; persona references in style guide + architecture)
+- `.claude/agents/{fact-checker,vibe-opus-scorer,fresh-eyes,librarian,tribunal-writer}.md` and the `.codex/agents/*.toml` mirrors (persona-name references in rubrics; the `clawdNote` *dimension key* stays — see D3)
+- `.githooks/pre-commit` reader-facing error strings ("Use specific names (ShroomDog, Clawd, 讀者)…")
+
+**Tooling that must learn `MoguNote` (Phase 0 — the blocking gap):**
+- `scripts/check-pronoun-clarity.mjs` (masks `<ClawdNote>` regions so 你/我 inside aren't flagged; 0 `MoguNote` refs today)
+- `scripts/check-jingjing.mjs` (component-name allowlist)
+- `tests/content-integrity.spec.ts` (redundant-prefix gate, hardcoded `<ClawdNote>`)
+- `tests/content-gates.test.ts` (pronoun-mask unit fixtures)
+- `scripts/obsidian-import.mjs` (callout→component map; should map `mogu`→`MoguNote`)
+
+**Glossary / links:**
+- `src/data/glossary.json` already has `Mogu`; ~190 posts link "Clawd"→`/glossary#clawd` (dangling) or `/about`. Reconciling these link targets to `/glossary#mogu` is part of Phase 2 content work, gated behind Phase 0.
+
+**Components (already migrated; alias retained):**
+- `src/components/MoguNote.astro` (canonical), `src/components/ClawdNote.astro` (legacy alias — kept under D4)
+
+**Schema key — explicitly OUT of scope for renaming (D3):**
+- `scores.vibe.clawdNote` lives in `src/content/config.ts`, `scripts/score-floor-check.mjs`, `scripts/validate-posts.mjs`, `src/lib/tribunal-v2/{pass-bar,types,git-format,pipeline}.ts`, `scripts/frontmatter-scores.mjs`, `scripts/vibe-scoring-standard.md`, the judge agents, and **158** post frontmatters. Renaming it is a separate heavy migration; this change keeps it stable.
+
+**Explicitly OUT of scope (D1):**
+- The OpenClaw / clawd-vm "Clawd" automation-agent identity (`CLAUDE.md` 「Clawd (OpenClaw)」; the existing `secure-clawd-vm-github-operator` OpenSpec change treats Clawd as a distinct VM agent alongside Iris).
+- The `scripts/clawd-picks-prompt.md` / `scripts/clawd-picks-config.json` pipeline filenames. (Note: the CP *series label* is already "Mogu Picks" in `scripts/article-counter.json`; the pipeline *files* keep their names.)
+
+**Non-goals:**
+- No edits to prompts/components/posts/tooling in *this* change — proposal artifacts only.
+- No `scores.vibe.clawdNote` → `moguNote` schema rename.
+- No rename of the OpenClaw VM agent or `clawd-picks-*` files.
+- No forced mass rewrite of the 1082 grandfathered posts (codemod is opt-in).

--- a/openspec/changes/consolidate-clawd-to-mogu-wording/specs/persona-naming/spec.md
+++ b/openspec/changes/consolidate-clawd-to-mogu-wording/specs/persona-naming/spec.md
@@ -1,0 +1,102 @@
+## ADDED Requirements
+
+### Requirement: The gu-log commentary persona SHALL have exactly one canonical reader-facing name
+
+The voice that speaks inside commentary note boxes SHALL be named `Mogu` in all reader-facing surfaces (rendered note prefixes, prose mentions, glossary entry, and author/about references). `Clawd` SHALL NOT be used as the reader-facing name of this persona in new content.
+
+#### Scenario: New content uses the canonical name
+
+- **WHEN** a new post or SSOT prompt authors a commentary note or names the persona in prose
+- **THEN** it SHALL use `Mogu`
+- **AND** SHALL NOT introduce a new reader-facing `Clawd` persona mention
+
+#### Scenario: The glossary anchor resolves
+
+- **WHEN** prose links the persona name to the glossary
+- **THEN** the link target SHALL be `/glossary#mogu` (or `/en/glossary#mogu`)
+- **AND** SHALL NOT target `/glossary#clawd`, which has no glossary entry
+
+### Requirement: A single rendered page SHALL NOT show two names for the persona
+
+No single rendered article page SHALL simultaneously display a `Mogu …` note prefix and a `Clawd …` note prefix (or prose persona mention) for the same commentary persona. When a page mixes `<MoguNote>` and `<ClawdNote>`, the rendered prefixes diverge into two names, which the reader cannot reconcile.
+
+#### Scenario: Mixed-component page is a violation
+
+- **WHEN** a post uses both `<MoguNote>` and `<ClawdNote>` in its body
+- **THEN** this SHALL be treated as a naming-consistency violation to be resolved
+- **AND** the resolution SHALL converge the page on a single persona name (`Mogu`)
+
+#### Scenario: The known mixed page is named
+
+- **WHEN** the consolidation work enumerates reader-visible inconsistencies
+- **THEN** `src/content/posts/sd-26-20260616-loop-engineering-at-gu-log.mdx` and its `en-` pair SHALL be listed as mixed-prefix pages (4 `Clawd` prefixes + 1 `Mogu` prefix each at proposal time)
+
+### Requirement: Content-gating tooling SHALL recognize MoguNote before any mass component migration
+
+The content-gating checkers and tests that special-case the commentary component — `scripts/check-pronoun-clarity.mjs`, `scripts/check-jingjing.mjs`, `tests/content-integrity.spec.ts`, and `tests/content-gates.test.ts` — SHALL recognize `MoguNote` in addition to the legacy `ClawdNote`. This recognition SHALL land (Phase 0) before any change that migrates post imports from `ClawdNote` to `MoguNote` at scale.
+
+#### Scenario: Pronoun checker masks MoguNote bodies
+
+- **WHEN** a zh-tw post wraps `你`/`我` inside `<MoguNote> … </MoguNote>`
+- **THEN** the pronoun-clarity checker SHALL mask that region (the speaker is explicit)
+- **AND** SHALL NOT flag those pronouns as violations
+
+#### Scenario: Redundant-prefix gate covers MoguNote
+
+- **WHEN** a post writes a redundant `Mogu：` prefix immediately inside a `<MoguNote>` block (which the component already adds)
+- **THEN** the content-integrity redundant-prefix check SHALL flag it
+- **AND** the check SHALL apply the same rule it currently applies to `<ClawdNote>`
+
+#### Scenario: Migration is gated on tooling readiness
+
+- **WHEN** a change proposes to migrate post imports from `ClawdNote` to `MoguNote` in bulk
+- **THEN** Phase 0 tooling recognition SHALL already be in place
+- **AND** migrating before Phase 0 SHALL be rejected as it would break the pronoun and redundant-prefix gates
+
+### Requirement: The persona rename SHALL NOT change the OpenClaw automation-agent identity
+
+The rename SHALL apply to the gu-log commentary persona only. The OpenClaw / clawd-vm automation-agent identity ("Clawd (OpenClaw)") and the `scripts/clawd-picks-prompt.md` / `scripts/clawd-picks-config.json` pipeline filenames SHALL remain unchanged by this rename.
+
+#### Scenario: VM agent identity untouched
+
+- **WHEN** the rename is applied
+- **THEN** references to the OpenClaw / clawd-vm agent (e.g. in `CLAUDE.md` and `secure-clawd-vm-github-operator`) SHALL remain `Clawd`
+- **AND** the `clawd-picks-*` pipeline filenames SHALL NOT be renamed
+
+#### Scenario: Series label already consistent
+
+- **WHEN** the CP series label is read from `scripts/article-counter.json`
+- **THEN** it SHALL already read `Mogu Picks`
+- **AND** the rename SHALL NOT require changing it
+
+### Requirement: The scores.vibe.clawdNote schema key SHALL remain a stable internal identifier
+
+The frontmatter score-dimension key `scores.vibe.clawdNote` SHALL be treated as a stable internal identifier, exempt from the reader-facing naming rule. This change SHALL NOT rename it to `moguNote`.
+
+#### Scenario: Schema key is not renamed
+
+- **WHEN** the persona rename is applied
+- **THEN** the `scores.vibe.clawdNote` key SHALL remain `clawdNote` in the Zod schema, validators, tribunal v2 types, frontmatter tooling, and the ~158 existing scored posts
+- **AND** renaming it to `moguNote` SHALL be deferred to a separate schema-migration change
+
+#### Scenario: Existing scored posts still validate
+
+- **WHEN** an existing post carrying `scores.vibe.clawdNote` is validated after the rename
+- **THEN** validation SHALL pass unchanged
+- **AND** the post SHALL NOT be re-gated solely because the persona was renamed
+
+### Requirement: Existing posts SHALL remain renderable via the legacy alias during grandfathering
+
+Posts that still `import ClawdNote` SHALL continue to render unchanged. The `src/components/ClawdNote.astro` legacy alias (which wraps `MoguNote`) SHALL be retained for the grandfathering period so the ~1082 legacy posts are not force-migrated.
+
+#### Scenario: Legacy post renders
+
+- **WHEN** a grandfathered post imports and uses `<ClawdNote>`
+- **THEN** it SHALL render via the legacy alias
+- **AND** SHALL NOT require migration to `<MoguNote>` to remain valid
+
+#### Scenario: Bulk codemod is opt-in and gated
+
+- **WHEN** a maintainer chooses to migrate a batch of legacy posts to `<MoguNote>` plus Mogu prose
+- **THEN** the codemod SHALL be opt-in (not a forced mass rewrite)
+- **AND** SHALL run only after Phase 0 tooling recognition is in place

--- a/openspec/changes/consolidate-clawd-to-mogu-wording/tasks.md
+++ b/openspec/changes/consolidate-clawd-to-mogu-wording/tasks.md
@@ -1,0 +1,39 @@
+## 0. Phase 0 — Teach content-gating tooling about MoguNote (additive, must land first)
+
+- [ ] 0.1 `scripts/check-pronoun-clarity.mjs`: recognize `<MoguNote>` / `</MoguNote>` regions for masking, alongside the existing `<ClawdNote>` handling, so 你/我 inside a MoguNote is not flagged.
+- [ ] 0.2 `tests/content-gates.test.ts`: add `MoguNote` fixtures to the `buildMask` and "does NOT flag 你/我 inside the note" tests so the mask behavior is pinned for the new component too.
+- [ ] 0.3 `scripts/check-jingjing.mjs`: add `MoguNote` to the component-name allowlist; refresh the stale `// ...ClawdNote is:` comment.
+- [ ] 0.4 `tests/content-integrity.spec.ts`: extend the redundant-prefix gate to cover `<MoguNote>` (flag a redundant `Mogu：` immediately inside the block), keeping the existing `<ClawdNote>` cases.
+- [ ] 0.5 `scripts/obsidian-import.mjs`: map the `mogu` / `mogunote` callout to `MoguNote` and emit the `MoguNote` import; keep `clawd`→`ClawdNote` for backward compat.
+- [ ] 0.6 Verify: a post using `<MoguNote>` passes pronoun, jingjing, and content-integrity gates; a post using `<ClawdNote>` still passes unchanged.
+
+## 1. Phase 1 — Flip SSOT prose to "Mogu" (after Phase 0)
+
+- [ ] 1.1 `GU-LOG_WRITER_PROMPT.md`: change 「品牌：統一叫 "Clawd"」(:147) to "Mogu"; update the `<ClawdNote>` usage examples/imports to `MoguNote`; update persona prose mentions. Keep the `clawdNote` *score-dimension* references (D3).
+- [ ] 1.2 `CONTRIBUTING.md`: rename the `ClawdNote — Clawd 吐槽/註解` section to MoguNote; point the import guidance at `MoguNote`.
+- [ ] 1.3 `CLAUDE.md`: update reader-facing persona mentions and the architecture note for the note component; leave the OpenClaw / clawd-vm agent identity and `clawd-picks-*` references untouched (D1).
+- [ ] 1.4 `.claude/agents/{fact-checker,vibe-opus-scorer,fresh-eyes,librarian,tribunal-writer}.md` AND `.codex/agents/*.toml`: change persona-name prose ("Clawd commentary", "you don't know Clawd", "link Clawd to /about") to Mogu; KEEP the `clawdNote` dimension key and its rubric.
+- [ ] 1.5 `.githooks/pre-commit`: update reader-facing error strings ("Use specific names (ShroomDog, Clawd, 讀者)…", "你/我 found … outside ClawdNote/blockquote") to reference Mogu / MoguNote.
+- [ ] 1.6 Verify: a freshly authored post follows the Mogu name end-to-end and passes all gates.
+
+## 2. Phase 2 — Fix reader-visible inconsistencies first (after Phase 0)
+
+- [ ] 2.1 `src/content/posts/sd-26-20260616-loop-engineering-at-gu-log.mdx` + `en-sd-26-…`: migrate the 4 `<ClawdNote>` blocks to `<MoguNote>` (single import), so the page renders one persona name. Re-score is only required if reader-visible content changes beyond the component swap.
+- [ ] 2.2 Repoint any `/glossary#clawd` (and `/en/glossary#clawd`) prose links in those posts to `/glossary#mogu`.
+- [ ] 2.3 Sweep for any other single-page mixed-prefix posts (both `<MoguNote>` and `<ClawdNote>` in one file) and fix them in this batch.
+- [ ] 2.4 Verify: SD-26 zh/en render only "Mogu …" prefixes; glossary-link-coverage gate passes.
+
+## 3. Phase 3 — Optional opt-in corpus drain (after Phases 0–1)
+
+- [ ] 3.1 Provide an opt-in codemod that, per batch of legacy posts, swaps `ClawdNote`→`MoguNote` imports/tags and prose "Clawd"→"Mogu", repointing `/glossary#clawd`→`/glossary#mogu`.
+- [ ] 3.2 Run it in reviewable batches; respect the floor/score gate on any post whose reader-visible content changes.
+- [ ] 3.3 Defer removal of the `src/components/ClawdNote.astro` alias to a future change, once the corpus is drained.
+
+## 4. Explicitly deferred (NOT in this change)
+
+- [ ] 4.1 `scores.vibe.clawdNote` → `moguNote` schema migration (separate change; touches Zod schema, 4 validators, tribunal v2 types, frontmatter tooling, agents, and ~158 post frontmatters — version-gated like `move-clarity-vibe-to-fresheyes`). — D3
+- [ ] 4.2 Rename of the OpenClaw / clawd-vm automation agent and `clawd-picks-prompt.md` / `clawd-picks-config.json`. — D1
+
+## 5. Validate the proposal
+
+- [ ] 5.1 `openspec validate consolidate-clawd-to-mogu-wording --strict` passes.


### PR DESCRIPTION
## 這是什麼

**Proposal only** 的 OpenSpec change：把 gu-log 評論 persona「Clawd → Mogu」改名收斂成一份正式的 spec 契約。**不動** prompt / component / post / tooling，只新增 `openspec/changes/consolidate-clawd-to-mogu-wording/` 的 artifacts。

Change-id: `consolidate-clawd-to-mogu-wording`
`openspec validate --strict` ✅ 通過。

## 為什麼

改名工作**半完成而且 reader-visible 不一致**：

- **Component 層已經改完**：`MoguNote.astro` 是真元件（render `Mogu 碎碎念：`），`ClawdNote.astro` 已變成包 MoguNote 的 legacy alias。
- **但所有「驅動新內容」的東西還在說 Clawd**：writer prompt SSOT 明文 `GU-LOG_WRITER_PROMPT.md:147`「品牌：統一叫 Clawd」、`CONTRIBUTING.md`、`CLAUDE.md`、5 個 tribunal judge agents（含 `.codex/*.toml` mirror）、連 pre-commit hook 的錯誤訊息都是。所以每寫一篇新文章就 re-seed 一次舊名。
- **語料壓倒性是 Clawd**：1083 篇文章裡 **1082** 篇還用 `ClawdNote`，只有 **2** 篇用 `MoguNote`；**~190** 篇 prose 出現「Clawd」；**158** 篇帶 `scores.vibe.clawdNote` 評分 key。
- **具體的讀者可見 bug**：`sd-26-…-loop-engineering`（中英文版）**同一頁同時 render 4 個「Clawd …」prefix + 1 個「Mogu …」prefix**，frontmatter 還寫 `clawdNote: 8`。
- **Tooling 還分不出 MoguNote**：`check-pronoun-clarity.mjs` / `check-jingjing.mjs` / `content-integrity.spec.ts` / `content-gates.test.ts` 全部 hardcode `ClawdNote`、**零** `MoguNote`（grep 驗證）。所以今天把 import 換成 `<MoguNote>` 會弄壞 pronoun checker（停止 mask note body、把裡面每個 你/我 都 flag）跟 redundant-prefix test。**Tooling 必須先學會 MoguNote，才能動 mass migration。**

## 5 個 open decisions（proposal 裡有完整選項 + 建議）

| # | 決策 | 建議 |
|---|---|---|
| **D1** | Scope：只改評論 persona，還是連 OpenClaw VM agent + `clawd-picks` pipeline 一起？ | **只改評論 persona**。OpenClaw / clawd-vm 的「Clawd」是另一個 agent 身份（既有 `secure-clawd-vm-github-operator` change 就把它當獨立 VM agent），不要混進來。CP 的 user-facing label 本來就已經是「Mogu Picks」。 |
| **D2** | Component：永久保留 `ClawdNote` alias，還是全 migrate 到 `MoguNote`？ | **grandfather 期間保留 alias、新內容用 MoguNote、提供 opt-in codemod**——但要 Phase 0 先教 tooling。 |
| **D3** | `scores.vibe.clawdNote` schema key：改名 `moguNote`，還是當 stable 內部名？ | **保留 `clawdNote`**。它不是 reader-facing，改名要動 Zod + 4 個 validator + tribunal v2 types + 158 篇 frontmatter，是另一個 heavy schema migration。 |
| **D4** | 現有 1082 篇：現在 mass codemod，還是 grandfather？ | **grandfather 舊文、只對新文強制 Mogu、codemod 做成 opt-in 分批跑**。 |
| **D5** | SSOT prompt 改字 | Phase 1 的內容；load-bearing edit 是 writer prompt 那句「統一叫 Clawd」。 |

## Phasing（先低風險、後高風險）

- **Phase 0** — 教 4 個 gating 檔認得 `MoguNote`（additive、可逆）。**解鎖後面所有 phase。**
- **Phase 1** — SSOT prose 改成 Mogu（writer prompt / CONTRIBUTING / CLAUDE / 5 agents + codex / hook 訊息）。
- **Phase 2** — 先修 reader-visible 不一致（SD-26 中英文 + repoint `/glossary#clawd`→`/glossary#mogu`）。
- **Phase 3（optional）** — opt-in codemod 分批排空語料，之後再開另一個 change 移除 alias。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HLqKwN8nqQK9ZEFqsrL7iL

---
_Generated by [Claude Code](https://claude.ai/code/session_01HLqKwN8nqQK9ZEFqsrL7iL)_