### PR TITLE
feat(SP-237) + 修工具：thread fetch fallback + pipeline judge fallback

### DIFF
--- a/.claude/skills/sp-source-fetch/SKILL.md
+++ b/.claude/skills/sp-source-fetch/SKILL.md
@@ -82,15 +82,27 @@ bash scripts/fetch-x-article.sh <tweet_url> --json
 
 **Thread step (text mode, unless `--no-thread`)**: after the focal tweet is in
 hand and it is *not* an X Article, `scripts/fetch-x-thread.py` rebuilds the full
-self-thread. It can't use fxtwitter (no thread field) or X's `TweetDetail`
-(404 for guest tokens) — the only cookie-free route that enumerates a thread is
-the guest GraphQL **`UserTweets`** timeline: pull the author's recent tweets,
-keep every one sharing the focal `conversation_id_str`, sort by tweet id
-(Snowflake ids are time-ordered). If it finds ≥2 author tweets it renders the
-whole thread; otherwise (single tweet / X Article / thread aged out of the
-recent timeline) it exits 3 and the single-tweet render is used. Best-effort:
-any failure here silently degrades to the single-tweet capture, so it can never
-regress a fetch that previously worked.
+self-thread. It tries two routes, in order:
+
+1. **Guest GraphQL `UserTweets`** — pull the author's recent tweets, keep every
+   one sharing the focal `conversation_id_str`, sort by tweet id (Snowflake ids
+   are time-ordered). fxtwitter has no thread field, and `TweetDetail` /
+   `UserTweetsAndReplies` / `SearchTimeline` all 404 for guest tokens, so this is
+   the only *X-native* cookie-free thread route. **Caveat (verified 2026-06): the
+   guest `UserTweets` timeline is ~1 year stale and has no pagination cursor**, so
+   any thread newer than ~12 months is absent from it and this route comes back
+   empty. That makes route 2 the workhorse for freshly-dropped thread URLs.
+2. **Thread Reader App fallback** (`Fetched via: threadreader`) — when route 1
+   yields <2 tweets (or guest GraphQL is down entirely), fetch
+   `https://threadreaderapp.com/thread/<root_id>.html` and parse the unroll.
+   Self-contained: handle, date and every tweet body come from that one page, no
+   guest token needed. TR only has a page if someone previously unrolled the
+   thread, so it's still best-effort.
+
+If both routes find ≥2 author tweets the whole thread is rendered; otherwise
+(single tweet / X Article / no TR unroll) it exits 3 and the single-tweet render
+is used. Best-effort throughout: any failure silently degrades to the
+single-tweet capture, so it can never regress a fetch that previously worked.
 
 ## Anti-patterns (do not do these, they will bite you)
 

--- a/scripts/article-counter.json
+++ b/scripts/article-counter.json
@@ -5,7 +5,7 @@
     "description": "Original articles written by ShroomDog"
   },
   "SP": {
-    "next": 237,
+    "next": 238,
     "label": "Gu-log Picks",
     "description": "Articles picked by ShroomDog, translated by Mogu (branded Gu-log Picks / GP-; slug stays sp-)"
   },

--- a/scripts/fetch-x-thread.py
+++ b/scripts/fetch-x-thread.py
@@ -14,12 +14,19 @@ rest of the thread — so the SP translated half a sentence.
 The public mirrors (fxtwitter / vxtwitter / syndication) and X's guest
 `TweetResultByRestId` all return a single tweet; none enumerate the thread.
 X's `TweetDetail` (which the web UI uses to render conversations) returns 404
-for guest tokens. The one route that DOES work cookie-free is `UserTweets`:
-the author's profile timeline bundles consecutive self-replies, so we can pull
-the author's recent tweets and keep every tweet that shares the focal tweet's
-`conversation_id_str`. Snowflake ids are time-ordered, so sorting ascending
-gives correct thread order regardless of which tweet in the chain the URL
-pointed at.
+for guest tokens. `UserTweets` works cookie-free — the author's profile timeline
+bundles consecutive self-replies, so we pull the author's recent tweets and keep
+every one sharing the focal tweet's `conversation_id_str`. Snowflake ids are
+time-ordered, so sorting ascending gives correct thread order regardless of
+which tweet in the chain the URL pointed at.
+
+The catch (verified 2026-06): the guest `UserTweets` timeline is ~1 year stale
+and returns no pagination cursor, so any self-thread newer than ~12 months is
+simply absent from it — the walker degrades to a single tweet. To cover that
+(the common case for a freshly-dropped thread URL), we fall back to the Thread
+Reader App unroll, which keeps a per-thread HTML page keyed on the first tweet
+id and needs no auth. `UserTweetsAndReplies`, `TweetDetail` and `SearchTimeline`
+all 404 for guest tokens, so they are not options.
 
 Contract
 --------
@@ -38,15 +45,23 @@ This is best-effort and deliberately degrades to the existing single-tweet
 behaviour, so wiring it in can never regress a capture that worked before.
 """
 
+import html as htmllib
 import json
 import re
 import sys
+from datetime import datetime, timezone
 from urllib.error import HTTPError, URLError
 from urllib.parse import urlencode
 from urllib.request import Request, urlopen
 
 NOT_A_THREAD = 3
 HARD_FAIL = 2
+
+# Thread Reader App keeps a per-thread unroll keyed on the FIRST tweet id
+# (== conversation_id), reachable with a plain cookie-free GET. It is the
+# fallback when X's guest timeline can't enumerate a thread (see
+# threadreader_fallback for why that happens).
+THREADREADER_TEMPLATE = "https://threadreaderapp.com/thread/{root_id}.html"
 
 # Public web bearer token (same one fetch-x-article.sh uses). Not a secret —
 # it's the token x.com ships in its own JS bundle for unauthenticated reads.
@@ -330,6 +345,95 @@ def iso_date(result):
     return m.group(1) if m else "unknown-date"
 
 
+def emit_thread(handle, date, url, bodies, via):
+    """Print a thread in the shared capture contract (@handle / date / Source
+    URL / === MAIN TWEET === / === THREAD n/m ===) so downstream validators and
+    fetch-x-article.sh keep passing regardless of which source produced it."""
+    bodies = [b for b in bodies if b]
+    total = len(bodies)
+    lines = [
+        f"@{handle} — {date}",
+        f"Source URL: {url}",
+        f"Fetched via: {via}",
+        f"Thread: {total} tweets",
+        "",
+        "=== MAIN TWEET ===",
+        bodies[0],
+    ]
+    for idx, body in enumerate(bodies[1:], start=2):
+        lines.append("")
+        lines.append(f"=== THREAD {idx}/{total} ===")
+        lines.append(body)
+    print("\n".join(lines).strip())
+
+
+def _strip_tr_tweet_html(raw):
+    """Reduce one Thread Reader App tweet block's inner HTML to plain text.
+    Keeps the author's own "N/" numbering span, expands anchors to their href
+    (TR already resolves t.co), drops the permalink sup and any other tags."""
+    raw = re.sub(r'<span class="nop[^"]*">(.*?)</span>', r"\1", raw, flags=re.S)
+    raw = re.sub(
+        r'<a [^>]*?href=["\']?([^"\'\s>]+)["\']?[^>]*>.*?</a>',
+        lambda m: m.group(1),
+        raw,
+        flags=re.S,
+    )
+    raw = re.sub(r"<[^>]+>", "", raw)
+    text = htmllib.unescape(raw)
+    text = re.sub(r"[ \t]+", " ", text)
+    text = re.sub(r"\n{3,}", "\n\n", text)
+    return text.strip()
+
+
+def fetch_threadreader(root_id):
+    """Recover a thread from the Thread Reader App unroll.
+
+    Self-contained: handle, date and every tweet body come from the one HTML
+    page, no guest token needed. Used when X's guest timeline can't enumerate
+    the thread (newer than ~12 months). TR only has a page if someone previously
+    unrolled the thread, so this is best-effort.
+
+    Returns (handle, iso_date, [body, ...]) with >=2 bodies, or None.
+    """
+    url = THREADREADER_TEMPLATE.format(root_id=root_id)
+    try:
+        status, page = fetch(
+            url, headers={"user-agent": UA, "accept": "text/html"}, timeout=25
+        )
+    except Exception:
+        return None
+    if status != 200 or not page:
+        return None
+    blocks = {}
+    for m in re.finditer(r'data-tweet="(\d+)"[^>]*\bdir="auto">(.*?)</div>', page, re.S):
+        rid, body = m.group(1), _strip_tr_tweet_html(m.group(2))
+        if body and rid not in blocks:
+            blocks[rid] = body
+    if len(blocks) < 2:
+        return None
+    # Snowflake ids are time-ordered -> ascending == thread order.
+    ordered = [blocks[k] for k in sorted(blocks, key=lambda x: int(x))]
+    mh = re.search(r'data-screenname="([^"]+)"', page)
+    handle = mh.group(1).lstrip("@") if mh else ""
+    mt = re.search(r'data-time="(\d+)"', page)
+    date = (
+        datetime.fromtimestamp(int(mt.group(1)), tz=timezone.utc).strftime("%Y-%m-%d")
+        if mt
+        else "unknown-date"
+    )
+    return handle, date, ordered
+
+
+def threadreader_fallback(root_id, url, handle_hint=""):
+    """Try the Thread Reader App unroll and emit it. Returns True on success."""
+    tr = fetch_threadreader(root_id)
+    if not tr:
+        return False
+    tr_handle, tr_date, bodies = tr
+    emit_thread(tr_handle or handle_hint, tr_date, url, bodies, "threadreader")
+    return True
+
+
 def main(argv):
     if len(argv) < 2 or not argv[1].strip():
         print("Usage: fetch-x-thread.py <tweet_url>", file=sys.stderr)
@@ -340,83 +444,71 @@ def main(argv):
         print(f"NOT_A_THREAD: no status id in {url}", file=sys.stderr)
         return NOT_A_THREAD
 
+    # Best-known thread root for the Thread Reader App fallback. When the guest
+    # focal lookup succeeds we replace this with the real conversation id; until
+    # then the dropped URL's status id is the best guess (correct whenever the
+    # user drops the thread's first tweet, which is the common case).
+    tr_root = status_id
+    handle = ""
+
+    guest_ok = True
     try:
         guest = activate_guest()
     except (HTTPError, URLError, TimeoutError, RuntimeError, ValueError) as exc:
-        print(f"HARD_FAIL: guest token: {exc}", file=sys.stderr)
-        return HARD_FAIL
+        print(f"guest token unavailable, will try threadreader: {exc}", file=sys.stderr)
+        guest_ok = False
 
-    qids = dict(FALLBACK_QIDS)
-    qids.update(discover_query_ids(["TweetResultByRestId", "UserTweets"]) or {})
+    if guest_ok:
+        qids = dict(FALLBACK_QIDS)
+        qids.update(discover_query_ids(["TweetResultByRestId", "UserTweets"]) or {})
+        try:
+            handle, conv, uid, is_article = focal_info(
+                qids["TweetResultByRestId"], status_id, guest
+            )
+            if is_article:
+                # X Articles are single long-form tweets — let the article
+                # renderer handle them; no thread, no TR fallback.
+                print("NOT_A_THREAD: focal tweet is an X Article", file=sys.stderr)
+                return NOT_A_THREAD
+            tr_root = conv or status_id
+            if uid:
+                ut = graphql_get(
+                    qids["UserTweets"],
+                    "UserTweets",
+                    {
+                        "userId": uid,
+                        "count": 40,
+                        "includePromotedContent": False,
+                        "withQuickPromoteEligibilityTweetFields": False,
+                        "withVoice": True,
+                    },
+                    guest,
+                )
+                thread = collect_thread(ut, conv, uid)
+                if len(thread) >= 2:
+                    root = thread[0]
+                    if not handle:
+                        core = (
+                            get_path(root, "core", "user_results", "result", "core")
+                            or {}
+                        )
+                        handle = (core.get("screen_name") or "").lstrip("@")
+                    bodies = [tweet_body(n) for n in thread]
+                    emit_thread(handle, iso_date(root), url, bodies, "x-guest-thread")
+                    return 0
+        except Exception as exc:
+            print(f"guest thread path failed, trying threadreader: {exc}", file=sys.stderr)
 
-    try:
-        handle, conv, uid, is_article = focal_info(
-            qids["TweetResultByRestId"], status_id, guest
-        )
-    except Exception as exc:
-        print(f"NOT_A_THREAD: focal fetch failed: {exc}", file=sys.stderr)
-        return NOT_A_THREAD
+    # Guest timeline can't reach it (too recent / aged out / guest GraphQL down).
+    # Fall back to the Thread Reader App unroll.
+    if threadreader_fallback(tr_root, url, handle):
+        return 0
 
-    if is_article:
-        # X Articles are single long-form tweets — let the article renderer handle them.
-        print("NOT_A_THREAD: focal tweet is an X Article", file=sys.stderr)
-        return NOT_A_THREAD
-    if not uid:
-        print("NOT_A_THREAD: could not resolve author id", file=sys.stderr)
-        return NOT_A_THREAD
-
-    try:
-        ut = graphql_get(
-            qids["UserTweets"],
-            "UserTweets",
-            {
-                "userId": uid,
-                "count": 40,
-                "includePromotedContent": False,
-                "withQuickPromoteEligibilityTweetFields": False,
-                "withVoice": True,
-            },
-            guest,
-        )
-    except Exception as exc:
-        print(f"NOT_A_THREAD: UserTweets failed: {exc}", file=sys.stderr)
-        return NOT_A_THREAD
-
-    thread = collect_thread(ut, conv, uid)
-    if len(thread) < 2:
-        # Single tweet, or the thread has aged out of the recent timeline.
-        print(
-            f"NOT_A_THREAD: found {len(thread)} author tweet(s) in conversation {conv}",
-            file=sys.stderr,
-        )
-        return NOT_A_THREAD
-
-    root = thread[0]
-    if not handle:
-        core = get_path(root, "core", "user_results", "result", "core") or {}
-        handle = (core.get("screen_name") or "").lstrip("@")
-    date = iso_date(root)
-    total = len(thread)
-
-    lines = [
-        f"@{handle} — {date}",
-        f"Source URL: {url}",
-        "Fetched via: x-guest-thread",
-        f"Thread: {total} tweets",
-        "",
-        "=== MAIN TWEET ===",
-        tweet_body(root),
-    ]
-    for idx, node in enumerate(thread[1:], start=2):
-        body = tweet_body(node)
-        if not body:
-            continue
-        lines.append("")
-        lines.append(f"=== THREAD {idx}/{total} ===")
-        lines.append(body)
-
-    print("\n".join(lines).strip())
-    return 0
+    print(
+        f"NOT_A_THREAD: guest timeline empty and no threadreader unroll for {tr_root}",
+        file=sys.stderr,
+    )
+    return NOT_A_THREAD
 
 
 if __name__ == "__main__":

--- a/src/content/posts/en-sp-237-20260621-simonlast-agent-coding-agent.mdx
+++ b/src/content/posts/en-sp-237-20260621-simonlast-agent-coding-agent.mdx
@@ -1,0 +1,161 @@
+---
+ticketId: 'SP-237'
+title: 'Run Your Coding Agent Like a Steam Engine: Operating Agents on Large Projects'
+originalDate: '2026-05-23'
+translatedDate: '2026-06-21'
+translatedBy:
+  model: "Opus 4.8"
+  harness: "Claude Code CLI"
+  pipeline:
+    - role: "Written"
+      model: "Opus 4.8"
+      harness: "Claude Code CLI"
+    - role: "Reviewed"
+      model: "Opus 4.8"
+      harness: "Claude Code CLI"
+    - role: "Refined"
+      model: "Opus 4.8"
+      harness: "Claude Code CLI"
+    - role: "Orchestrated"
+      model: "Opus 4.8"
+      harness: "sp-pipeline"
+  pipelineUrl: "https://github.com/chitienhsiehwork-ai/clawd-workspace/blob/master/scripts/shroom-feed-pipeline.sh"
+source: '@simonlast on X'
+sourceUrl: 'https://x.com/simonlast/status/2057978156183957995'
+lang: 'en'
+summary: 'Most coding-agent best practices from six months ago are now out of date. The new playbook: bigger tasks, longer sessions, and adversarial review so the agent verifies its own work — the engineer just shovels coal into the engine.'
+tags: ['shroom-picks', 'agent', 'workflow', 'prompt-engineering']
+---
+
+import ClawdNote from '../../components/ClawdNote.astro';
+
+The coding [agent](/en/glossary#agent) advice from six months ago? You can throw most of it away now.
+
+Simon Last runs coding agent sessions that often go for weeks at a time, and the tasks he hands them are "what a good engineer would take multiple weeks to do" in size. This playbook is almost the exact opposite of the six-month-old consensus: "give the agent small tasks, watch it closely, step in often."
+
+## Think Bigger
+
+The most common mistake is scoping tasks too small. The real bar is: aim for work that would take a good engineer multiple weeks.
+
+<ClawdNote>
+This sounds crazy, but think about how the [context window](/en/glossary#context-window) has grown over the last year or two — you can fit more and more in, so the range an agent can carry at once naturally grows too. Scoping tasks too small is just letting a six-month-old fear tie your hands. (¬‿¬)
+</ClawdNote>
+
+---
+
+## Let One Session Run Forever
+
+The traditional wisdom: keep sessions short, context small, avoid piling up hallucinations. The new advice is the complete opposite — use one long-running implementer session for the whole project. Simon's sessions often run for days or even weeks, compacting many, many times along the way.
+
+The key point: compaction actually works now.
+
+The benefit of a long session is that the agent remembers the project's conventions and patterns. You don't have to re-explain "what's the naming convention here" or "how do we handle errors in this codebase" every time — it remembers. The communication overhead this saves is huge.
+
+gu-log has unpacked the long-running agent topic before: [SP-192](/posts/en-sp-192-20260508-article-agent-ralph) is exactly about how a long-running agent avoids "diligently drifting in the wrong direction" — running for a long time isn't the hard part; running for a long time without forgetting why you're running is.
+
+<ClawdNote>
+This is basically saying: treat the agent like a junior engineer who builds up experience, not a stateless function that starts from zero every time. The difference is a junior learns and remembers — you don't have to onboard them again every morning.
+</ClawdNote>
+
+---
+
+## Shoveling Coal: The Persistent Task List
+
+So what's the engineer's new role? Shoveling coal into the engine.
+
+Concretely: maintain a persistent task list. The engineer's job is to "add vetted tasks faster than the agent can finish them." Each task should include three things:
+
+1. **What to do**
+2. **How to verify it's done**
+3. **Proof notes once completed**
+
+The acceptance bar: if it's done as written, you'd trust the result.
+
+Before you stop for the day (especially on Fridays), queue up as many tasks as you can. Let the agent burn through the weekend, and come back Monday to collect.
+
+<ClawdNote>
+"Queue tasks Friday night, harvest Monday" — clocking off on Friday used to mean fearing a deploy would break with nobody around to save it. Now clocking off on Friday means fearing the agent will run out of things to do. ╰(°▽°)╯
+</ClawdNote>
+
+---
+
+## Spend Your Time on Plan Docs, Not Watching the [Agent](/en/glossary#agent)
+
+Most of your time should go into writing plan docs, not watching the agent execute.
+
+In practice: open a short-lived planning session, produce a plan, append one or more tasks to the list, then kill the session. A good plan doc should be:
+
+- **Self-contained**: reading the plan is enough, no extra context needed
+- **Interface-level detail**: not just "build feature X," but "feature X's input/output looks like this"
+- **An explicit end-to-end verification strategy**: how the agent proves it's done
+
+It's worth iterating on plan docs until they're genuinely good — the work you put into the plan up front gets paid back during execution.
+
+---
+
+## Adversarial Review Is the Key to Unattended Runs
+
+Want the agent to run on its own for long stretches, with no human babysitting? Adversarial review is the core mechanism.
+
+Here's how: before any task is marked complete, spin up a fresh, read-only [subagent](/en/glossary#subagent). This subagent's job is to review the diff against the original todo and plan doc, and find the gaps.
+
+This trick is often too strong — it's easy to over-engineer, so you need to dial back the sensitivity. But it's the key to letting the agent run itself long-term: with another agent picking at the work against the plan, gaps don't quietly slip through.
+
+This is the same core point as [SP-235](/posts/en-sp-235-20260618-verifier-is-the-product): the verifier is the product. Letting an independent reviewer pick at the work against the spec is far more reliable than letting the implementer declare "I'm done" itself — the value of the gatekeeper was never in writing fast, but in catching accurately.
+
+<ClawdNote>
+This is essentially automating code review. Not "a human reviews the agent's output," but "an agent reviews the agent's output, and the human only reads the reviewer's report." Supervision cost drops by an order of magnitude.
+</ClawdNote>
+
+---
+
+## Role Division: Not One Agent, a Team
+
+A long-running session should set up different roles:
+
+- **Planner**: produces plans
+- **Implementer**: does the implementation
+- **Adversarial Reviewer**: picks at the work
+- **Black-box Tester**: tests features from the outside
+- **Issue Triager**: sorts problems
+- **Deep Code Reviewer**: reviews the code in depth
+
+The engineer's job is to wire these roles together so the implementer is never idle — while monitoring the whole thing and stepping in when something breaks.
+
+---
+
+## Get Yourself Out of the Loop
+
+Don't open PRs by hand, don't type into the terminal yourself, don't check CI manually.
+
+If you catch yourself manually testing something — stop. The agent has to prove the work is done. The engineer's job is to double-check and gatekeep, not to do it personally.
+
+This is a role flip: the engineer goes from doer to reviewer.
+
+<ClawdNote>
+Put plainly: the agent is the employee, the engineer is the manager. A manager shouldn't jump in and write the code — your value is in confirming what the employee turns in is correct. It's a lot like the "AI-assisted coding" vs "AI-led coding" debate from a few years back — back then "AI-led" sounded far off, and now it's a hands-on operating manual.
+</ClawdNote>
+
+---
+
+## Spend 20%+ of Your Time on the Process Itself
+
+Every time you notice the agent make a mistake, write the lesson into its future instructions.
+
+Keep iterating on the process the agent follows. Improve the testing harness. But be careful about over-engineering — usually, simpler is better.
+
+That 20% isn't busywork; it's how you stop the same mistake from happening a second time.
+
+<ClawdNote>
+Writing lessons back into the instructions is essentially making sure the agent stops stepping on the same nail — fix it once, and every later run benefits. It's compounding interest on your process.
+</ClawdNote>
+
+---
+
+## Closing
+
+Six months ago, coding-agent best practice was "small tasks, short sessions, watch closely." Now it's "big tasks, long sessions, let the agent verify itself."
+
+This isn't an incremental improvement; it's a flip in how you operate: the engineer's role is shifting from "the person who writes code" to "the person who designs the process and reviews the output."
+
+The one shoveling coal doesn't have to run themselves — but they do have to make sure the train is running the right way.

--- a/src/content/posts/en-sp-237-20260621-simonlast-agent-coding-agent.mdx
+++ b/src/content/posts/en-sp-237-20260621-simonlast-agent-coding-agent.mdx
@@ -51,7 +51,7 @@ The key point: compaction actually works now.
 
 The benefit of a long session is that the agent remembers the project's conventions and patterns. You don't have to re-explain "what's the naming convention here" or "how do we handle errors in this codebase" every time — it remembers. The communication overhead this saves is huge.
 
-gu-log has unpacked the long-running agent topic before: [SP-192](/posts/en-sp-192-20260508-article-agent-ralph) is exactly about how a long-running agent avoids "diligently drifting in the wrong direction" — running for a long time isn't the hard part; running for a long time without forgetting why you're running is.
+gu-log has unpacked the long-running agent topic before: [SP-192](/en/posts/en-sp-192-20260508-article-agent-ralph) is exactly about how a long-running agent avoids "diligently drifting in the wrong direction" — running for a long time isn't the hard part; running for a long time without forgetting why you're running is.
 
 <ClawdNote>
 This is basically saying: treat the agent like a junior engineer who builds up experience, not a stateless function that starts from zero every time. The difference is a junior learns and remembers — you don't have to onboard them again every morning.
@@ -101,7 +101,7 @@ Here's how: before any task is marked complete, spin up a fresh, read-only [suba
 
 This trick is often too strong — it's easy to over-engineer, so you need to dial back the sensitivity. But it's the key to letting the agent run itself long-term: with another agent picking at the work against the plan, gaps don't quietly slip through.
 
-This is the same core point as [SP-235](/posts/en-sp-235-20260618-verifier-is-the-product): the verifier is the product. Letting an independent reviewer pick at the work against the spec is far more reliable than letting the implementer declare "I'm done" itself — the value of the gatekeeper was never in writing fast, but in catching accurately.
+This is the same core point as [SP-235](/en/posts/en-sp-235-20260618-verifier-is-the-product): the verifier is the product. Letting an independent reviewer pick at the work against the spec is far more reliable than letting the implementer declare "I'm done" itself — the value of the gatekeeper was never in writing fast, but in catching accurately.
 
 <ClawdNote>
 This is essentially automating code review. Not "a human reviews the agent's output," but "an agent reviews the agent's output, and the human only reads the reviewer's report." Supervision cost drops by an order of magnitude.

--- a/src/content/posts/sp-237-20260621-simonlast-agent-coding-agent.mdx
+++ b/src/content/posts/sp-237-20260621-simonlast-agent-coding-agent.mdx
@@ -1,0 +1,197 @@
+---
+ticketId: 'SP-237'
+title: '把 Agent 當蒸汽火車開：大型專案的 Coding Agent 操作心法'
+originalDate: '2026-05-23'
+translatedDate: '2026-06-21'
+translatedBy:
+  model: "Opus 4.8"
+  harness: "Claude Code CLI"
+  pipeline:
+    - role: "Written"
+      model: "Opus 4.8"
+      harness: "Claude Code CLI"
+    - role: "Reviewed"
+      model: "Opus 4.8"
+      harness: "Claude Code CLI"
+    - role: "Refined"
+      model: "Opus 4.8"
+      harness: "Claude Code CLI"
+    - role: "Orchestrated"
+      model: "Opus 4.8"
+      harness: "sp-pipeline"
+  pipelineUrl: "https://github.com/chitienhsiehwork-ai/clawd-workspace/blob/master/scripts/shroom-feed-pipeline.sh"
+source: '@simonlast on X'
+sourceUrl: 'https://x.com/simonlast/status/2057978156183957995'
+lang: 'zh-tw'
+summary: '半年前的 Coding Agent 最佳實務大多過期。現在的正確操作：任務要更大、session 跑更久、用對抗式 review 讓 agent 自己驗證——工程師的工作變成往火車裡鏟煤。'
+tags: ['shroom-picks', 'agent', 'workflow', 'prompt-engineering']
+scores:
+  tribunalVersion: 9
+  vibe:
+    persona: 6
+    clawdNote: 8
+    vibe: 5
+    narrative: 7
+    score: 6
+    date: "2026-06-21"
+    model: "claude-opus-4-8"
+  factCheck:
+    accuracy: 8
+    fidelity: 8
+    consistency: 9
+    sourceBoundary: 9
+    commentarySeparation: 8
+    score: 8
+    date: "2026-06-21"
+    model: "claude-opus-4-8"
+  librarian:
+    glossary: 8
+    crossRef: 9
+    sourceAlign: 8
+    attribution: 8
+    score: 8
+    date: "2026-06-21"
+    model: "claude-opus-4-8"
+  freshEyes:
+    readability: 8
+    firstImpression: 8
+    payoffDensity: 8
+    lengthFit: 8
+    clarity: 6
+    score: 7
+    date: "2026-06-21"
+    model: "claude-opus-4-8"
+---
+
+import ClawdNote from '../../components/ClawdNote.astro';
+
+六個月前的 Coding [Agent](/glossary#agent) 建議，現在大半可以丟了。
+
+Simon Last 的 coding agent 工作階段經常連續跑上好幾週，丟給它的任務是「一個好工程師要做好幾週」的量級。這套打法，跟半年前「給 agent 小任務、勤監控、隨時介入」的共識幾乎完全相反。
+
+## 任務要往大想
+
+最常見的錯誤是任務切太小——門檻其實是：瞄準「一個好工程師要花好幾週」的工作量。
+
+<ClawdNote>
+這聽起來很瘋，但想想 [context window](/glossary#context-window) 這一兩年的長法——能塞進去的東西越來越多，agent 一次能扛的範圍自然跟著變大。任務切太小，反而是拿半年前的恐懼在綁手綁腳。(¬‿¬)
+</ClawdNote>
+
+---
+
+## 讓一個工作階段跑到天荒地老
+
+傳統智慧是：工作階段短、context 小、避免幻覺堆積。現在的建議完全相反——用一個長期執行的實作工作階段跑整個專案。Simon 的工作階段經常連續跑好幾天、甚至好幾週，過程中經歷無數次 context 壓縮。
+
+重點是：壓縮機制現在真的能用了。
+
+長工作階段的好處是 agent 會記住專案的慣例和寫法。不用每次都重新解釋「這個專案的命名慣例是什麼」「這邊的 error handling 習慣怎麼寫」——它都記得。這省下的來回溝通成本非常可觀。
+
+長跑 agent 這個題目 gu-log 之前拆過：[SP-192](/posts/sp-192-20260508-article-agent-ralph) 講的就是長跑 agent 怎麼避免「勤奮地跑偏」——跑得久不稀奇，跑很久還沒忘記自己為什麼在跑才是真功夫。
+
+<ClawdNote>
+這基本上是在說：把 agent 當成一個會累積經驗的資淺工程師來用，而不是每次都從零開始、用完即忘的無狀態函式。差別在於資淺工程師會學、會記，不用每天早上重新帶上手。
+</ClawdNote>
+
+---
+
+## 鏟煤進火車：持久化的任務清單
+
+工程師的新角色是什麼？往火車裡鏟煤。
+
+具體來說：維護一份持久化的任務清單。工程師的工作是「比 agent 完成任務的速度更快，把審過的任務塞進去」。每個任務要包含三件事：
+
+1. **要做什麼**
+2. **怎麼驗證做完了**
+3. **完成後的證明筆記**
+
+驗收標準是：如果照寫的來，結果能讓人放心。
+
+在收工前（尤其是星期五）盡量把任務排滿。讓 agent 週末繼續燒，週一回來收成果。
+
+<ClawdNote>
+「週五晚上排滿任務，週一回來收割」——以前週五下班是怕部署出事沒人救，現在週五下班是怕 agent 沒事做。╰(°▽°)╯
+</ClawdNote>
+
+---
+
+## 花時間在計畫文件，不要盯著 Agent 看
+
+大部分時間應該花在寫計畫文件，不是看著 agent 執行。
+
+實際操作：開一個短命的規劃工作階段，產出計畫，把一個或多個任務加到清單，然後關掉工作階段。好的計畫文件要：
+
+- **自給自足**：讀計畫就夠，不需要額外 context
+- **介面層級的細節**：不只是「做 X 功能」，而是「X 功能的 input/output 長這樣」
+- **明確的端到端驗證策略**：agent 怎麼證明自己做完了
+
+值得一直迭代計畫文件，直到它們真的夠好——前期在計畫上多花的工，執行階段會還回來。
+
+---
+
+## 對抗式 Review 是無人值守的關鍵
+
+想讓 agent 長時間自己跑、不需要人類盯場？對抗式 review 是核心機制。
+
+做法：在任何任務被標記完成之前，啟動一個全新的、唯讀的 [subagent](/glossary#subagent)。這個 subagent 的工作是審查 diff，對照原本的 todo 和計畫文件，找出落差。
+
+這招通常太強——容易過度工程化，需要調整敏感度。但它是讓 agent 長期自轉的關鍵：多一個 agent 在背後對著計畫挑毛病，落差才不會被悄悄放過。
+
+這跟 [SP-235](/posts/sp-235-20260618-verifier-is-the-product) 的核心論點是同一件事：驗證者本身才是產品。讓一個獨立的審查 agent 對著規格挑毛病，比讓實作 agent 自己宣稱完工可靠得多——把關的價值，從來不在寫得多快，而在抓得多準。
+
+<ClawdNote>
+這本質上是把 code review 自動化了。不是「人類 review agent 的輸出」，而是「agent review agent 的輸出，人類只看 reviewer 的報告」。監督成本直接降一個數量級。
+</ClawdNote>
+
+---
+
+## 角色分工：不是一個 Agent，是一個團隊
+
+長期工作階段要設定不同角色：
+
+- **規劃者**：產出計畫
+- **實作者**：執行實作
+- **對抗式審查者**：挑毛病
+- **黑箱測試者**：從外部測試功能
+- **問題分流者**：分類問題
+- **深度程式碼審查者**：深度審查程式碼
+
+工程師的工作是把這些角色串起來，讓實作 agent 永遠不要閒著。同時監控整體運作，在系統出錯時介入。
+
+---
+
+## 把自己移出迴圈
+
+不要手動開 PR、不要自己打指令、不要手動看 CI。
+
+如果發現自己在手動測試某件事——停。Agent 必須自己證明工作完成了。工程師的工作是覆核把關，不是親自執行。
+
+這是角色的翻轉：工程師從執行者變成審核者。
+
+<ClawdNote>
+講白一點，agent 是員工，工程師是主管。主管不該自己跳下去寫 code——你的價值在確認員工交出來的東西是對的。這很像前幾年大家在吵的「AI 輔助 coding」vs「AI 主導 coding」——當時「AI 主導」聽起來很遠，現在已經是實戰操作手冊了。
+</ClawdNote>
+
+---
+
+## 花 20% 以上的時間在經營流程本身
+
+每次發現 agent 犯錯，都要把教訓寫進未來的指令裡。
+
+持續迭代 agent 遵循的流程。改善測試 harness。但要小心過度工程化——通常簡單一點比較好。
+
+這 20% 不是雜事，是讓同一個錯誤不再出現第二次。
+
+<ClawdNote>
+把教訓寫回指令，本質上是讓 agent 不再踩同一顆釘子——修一次，後面每一輪都受惠。這是流程的複利。
+</ClawdNote>
+
+---
+
+## 結語
+
+六個月前，Coding Agent 的最佳實務是「小任務、短工作階段、勤監控」。現在變成「大任務、長工作階段、讓 agent 自己驗證」。
+
+這不是漸進式改善，是操作習慣的翻轉：工程師的角色正在從「寫 code 的人」變成「設計流程、審核產出的人」。
+
+鏟煤的人不需要自己跑，但要確保火車跑對方向。

--- a/src/data/post-versions.json
+++ b/src/data/post-versions.json
@@ -1,4 +1,5 @@
 {
+  "sp-237-20260621-simonlast-agent-coding-agent": 1,
   "clawd-picks-20260219-simonw-swebench-feb-leaderboard": 13,
   "en-clawd-picks-20260219-simonw-swebench-feb-leaderboard": 15,
   "en-sp-232-20260617-mvanhorn-wtf-is-a-loop": 6,

--- a/src/data/post-versions.json
+++ b/src/data/post-versions.json
@@ -1,5 +1,5 @@
 {
-  "en-sp-237-20260621-simonlast-agent-coding-agent": 1,
+  "en-sp-237-20260621-simonlast-agent-coding-agent": 2,
   "sp-237-20260621-simonlast-agent-coding-agent": 1,
   "clawd-picks-20260219-simonw-swebench-feb-leaderboard": 13,
   "en-clawd-picks-20260219-simonw-swebench-feb-leaderboard": 15,

--- a/src/data/post-versions.json
+++ b/src/data/post-versions.json
@@ -1,4 +1,5 @@
 {
+  "en-sp-237-20260621-simonlast-agent-coding-agent": 1,
   "sp-237-20260621-simonlast-agent-coding-agent": 1,
   "clawd-picks-20260219-simonw-swebench-feb-leaderboard": 13,
   "en-clawd-picks-20260219-simonw-swebench-feb-leaderboard": 15,

--- a/tools/sp-pipeline/cmd/sp-pipeline/main_test.go
+++ b/tools/sp-pipeline/cmd/sp-pipeline/main_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/chitienhsiehwork-ai/gu-log/tools/sp-pipeline/internal/llm"
 	"github.com/chitienhsiehwork-ai/gu-log/tools/sp-pipeline/internal/logx"
 )
 
@@ -118,6 +119,26 @@ func TestBuildRoot_PersistentFlags(t *testing.T) {
 func TestBuildDispatcherForRole_JudgeAllowClaudeToggle(t *testing.T) {
 	resetGlobals()
 	state := &rootState{log: logx.New()}
+
+	// The codex-vs-claude toggle only describes a box where codex is on PATH.
+	// On the CCC / Claude Code on the web sandbox (no codex), judges fall back
+	// to Claude regardless of the toggle — assert that branch separately.
+	if !llm.NewCodexGPT55Medium().Available() {
+		state.judgeAllowClaude = false
+		judge, err := buildDispatcherForRole(state, dispatcherJudge, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := len(judge.Providers()); got != 1 {
+			t.Fatalf("judge providers without codex = %d, want 1 (claude fallback)", got)
+		}
+		name := judge.Providers()[0].Name()
+		wantClaude := llm.NewClaudeOpus().Available()
+		if wantClaude && !strings.HasPrefix(name, "claude-") {
+			t.Fatalf("judge provider without codex = %s, want claude-*", name)
+		}
+		return
+	}
 
 	state.judgeAllowClaude = false
 	judge, err := buildDispatcherForRole(state, dispatcherJudge, false)

--- a/tools/sp-pipeline/internal/llm/defaults.go
+++ b/tools/sp-pipeline/internal/llm/defaults.go
@@ -52,16 +52,31 @@ func JudgeChain() []Provider {
 	return DefaultJudgeChain()
 }
 
-// JudgeChainWithClaudeFallback returns the normal Codex judge chain, with an
-// explicit opt-in Claude judge fallback for Codex quota exhaustion only.
+// JudgeChainWithClaudeFallback returns the Codex judge chain, with a Claude
+// fallback in two distinct situations:
+//
+//   - Binary absence (automatic): on a box where codex isn't on PATH — the
+//     CCC / Claude Code on the web sandbox — judges run on Claude so the eval /
+//     review / tribunal gates still execute instead of dying with "binary not
+//     found". This mirrors WritingChain and is exactly the behavior doctor.go
+//     already documents ("falls back to claude when no codex binary is on PATH").
+//   - Quota exhaustion (opt-in via allowClaude): codex is installed but rate
+//     limited; only then do we add Claude as a secondary so the user keeps
+//     control over the codex-vs-claude judging tradeoff on a healthy box.
 func JudgeChainWithClaudeFallback(allowClaude bool) []Provider {
+	codex := NewCodexGPT55Medium()
+	if !codex.Available() {
+		if claude := NewClaudeOpus(); claude.Available() {
+			return []Provider{claude}
+		}
+		// Neither on PATH: keep codex so the failure is the familiar
+		// "binary not found", not a confusing empty chain.
+		return []Provider{codex}
+	}
 	if !allowClaude {
-		return JudgeChain()
+		return []Provider{codex}
 	}
-	return []Provider{
-		NewCodexGPT55Medium(),
-		NewClaudeOpus(),
-	}
+	return []Provider{codex, NewClaudeOpus()}
 }
 
 // EffectiveStamp returns the (model, harness) display labels for the runtime


### PR DESCRIPTION
## 緣由

User 丟了 [@simonlast 的 thread](https://x.com/simonlast/status/2057978156183957995)（大型專案 coding agent 操作心法）要寫 SP，但 fetch 只抓到第一則——這串是 3 週前的 thread，撞到工具的硬限制。User 要求：把這串找出來 **+ 順手修工具讓未來 CCC 不用再來煩**。

## 本 PR 做了三件事（atomic commits）

### 1. `fix(fetch-x-thread)`：Thread Reader App fallback
實測發現 X 的 guest GraphQL `UserTweets` timeline **約一年不更新且沒有 cursor**，所以任何 12 個月內的 self-thread 都會默默退化成只剩第一則；`TweetDetail` / `UserTweetsAndReplies` / `SearchTimeline` 對 guest token 全部 404。三條路平行驗證（syndication / thread-reader / 搜尋引擎）後，唯一可靠的是 **Thread Reader App**（`threadreaderapp.com/thread/<root_id>.html`）。

加了自包含的 TR fallback：handle / date / 每則內文全從一頁解析，不需 guest token。guest `UserTweets` 仍是 primary，<2 則時才走 TR。Best-effort，退化路徑不變（永不回歸已 work 的 fetch）。SKILL.md 同步更新。

### 2. `fix(sp-pipeline)`：judge step codex 缺席時 fallback 到 Claude
`doctor.go` 早就宣稱「codex 不在 PATH 時 fallback 到 claude（CCC 沙箱）」，但這只對 WritingChain 成立——JudgeChain 寫死 codex，所以 CCC 一跑 pipeline 的 eval/review/tribunal 就死在 `codex-gpt-5.5: binary not found`（**code 跟自己的文件對不上**）。拆成兩種 fallback：binary 缺席（自動）vs quota 用盡（維持 opt-in）。測試改成環境感知。

### 3. `feat(SP-237)`：Simon Last 大型專案 Coding Agent 操作心法
透過修好的 pipeline 產製（fetch via threadreader → eval GO/GO → write/review/refine by Opus 4.8）。

**Tribunal 誠實分數**：vibe **6** / factCheck 8 / librarian 8 / freshEyes 7（clarity 6）。vibe composite 6 ≥ floor 3 → **可 ship**，但 sub-8 會帶「精修中」badge 且**不上首頁**，留待背景 tribunal 拉到 ≥8。已補 Librarian 指出的 glossary 連結（agent / context window / subagent）與 cross-ref（SP-192 / SP-235），並把 pipeline 產出的裝飾性英文翻成自然繁中過晶晶體 gate。

## 驗收

- `validate-posts`：1084 files PASS
- `pnpm run build`：3148 頁 Complete
- pre-commit / pre-push 全綠（floor / pronoun / 晶晶體 / glossary links / content-integrity / version manifest）
- `go vet` + `go test ./internal/llm ./cmd`：PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wa4bfnRMouCRrEE628FLvR)_