### PR TITLE
fix(SP-237): en 版補上 tribunal scores（修 sub-8 banner + 首頁過濾不一致）

### DIFF
--- a/src/content/posts/en-sp-237-20260621-simonlast-agent-coding-agent.mdx
+++ b/src/content/posts/en-sp-237-20260621-simonlast-agent-coding-agent.mdx
@@ -25,6 +25,42 @@ sourceUrl: 'https://x.com/simonlast/status/2057978156183957995'
 lang: 'en'
 summary: 'Most coding-agent best practices from six months ago are now out of date. The new playbook: bigger tasks, longer sessions, and adversarial review so the agent verifies its own work — the engineer just shovels coal into the engine.'
 tags: ['shroom-picks', 'agent', 'workflow', 'prompt-engineering']
+scores:
+  tribunalVersion: 9
+  vibe:
+    persona: 6
+    clawdNote: 8
+    vibe: 5
+    narrative: 7
+    score: 6
+    date: "2026-06-21"
+    model: "claude-opus-4-8"
+  factCheck:
+    accuracy: 8
+    fidelity: 8
+    consistency: 9
+    sourceBoundary: 9
+    commentarySeparation: 8
+    score: 8
+    date: "2026-06-21"
+    model: "claude-opus-4-8"
+  librarian:
+    glossary: 8
+    crossRef: 9
+    sourceAlign: 8
+    attribution: 8
+    score: 8
+    date: "2026-06-21"
+    model: "claude-opus-4-8"
+  freshEyes:
+    readability: 8
+    firstImpression: 8
+    payoffDensity: 8
+    lengthFit: 8
+    clarity: 6
+    score: 7
+    date: "2026-06-21"
+    model: "claude-opus-4-8"
 ---
 
 import ClawdNote from '../../components/ClawdNote.astro';

--- a/src/data/post-versions.json
+++ b/src/data/post-versions.json
@@ -1,5 +1,5 @@
 {
-  "en-sp-237-20260621-simonlast-agent-coding-agent": 2,
+  "en-sp-237-20260621-simonlast-agent-coding-agent": 3,
   "sp-237-20260621-simonlast-agent-coding-agent": 1,
   "clawd-picks-20260219-simonw-swebench-feb-leaderboard": 13,
   "en-clawd-picks-20260219-simonw-swebench-feb-leaderboard": 15,


### PR DESCRIPTION
## 問題

SP-237 的 en 版當初沒帶 `scores` block。`isBelowPublishBar()` 對「沒有 scores」回傳 false（視為 grandfathered 舊文），導致：

- sub-8 的 en 版**漏到 /en 首頁**（zh-tw 版有被正確過濾掉）
- en 版**沒有「精修中」badge**（zh-tw 版有）

兩個語言版本的狀態不一致。

## 修法

en 版鏡像 zh-tw 的 scores block（已對照既有 en/zh pair 確認慣例就是鏡像、分數完全相同）。複製同一份過去，讓兩語言一致 gate + badge。

vibe=6 / factCheck=8 / librarian=8 / freshEyes=7（誠實 tribunal 分數，sub-8 → 帶 badge、不上首頁）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wa4bfnRMouCRrEE628FLvR)_