### PR TITLE
ci: 加上 OpenSpec archive-before-merge gate

### DIFF
--- a/.github/workflows/openspec-archive-gate.yml
+++ b/.github/workflows/openspec-archive-gate.yml
@@ -1,0 +1,44 @@
+name: OpenSpec Archive Gate
+
+# Branch protection note:
+# This standalone workflow is intentionally separate from PR Fast Gate because
+# it must run on ready_for_review. GitHub Actions cannot aggregate jobs across
+# workflow files, so branch protection must require this job's stable check
+# name as well as the existing `ci-passed` aggregate:
+#   OpenSpec Archive Gate / openspec-archive-gate
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]
+
+concurrency:
+  group: openspec-archive-gate-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  openspec-archive-gate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Draft PR defer
+        if: github.event.pull_request.draft == true
+        run: echo "draft — archive gate deferred until ready"
+
+      - uses: actions/checkout@v6
+        if: github.event.pull_request.draft == false
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/setup-pnpm
+        if: github.event.pull_request.draft == false
+
+      - name: Fetch base branch
+        if: github.event.pull_request.draft == false
+        run: git fetch origin main
+
+      - name: Check OpenSpec archive-before-merge
+        if: github.event.pull_request.draft == false
+        run: node scripts/check-openspec-archive.mjs

--- a/scripts/check-openspec-archive.mjs
+++ b/scripts/check-openspec-archive.mjs
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const DEFAULT_BASE_REF = 'origin/main';
+const ACTIVE_CHANGES_DIR = path.join('openspec', 'changes');
+
+export function findUnarchivedNewChanges(baseActiveNames, headActiveNames) {
+  const base = new Set(baseActiveNames);
+  return [...new Set(headActiveNames)].filter((name) => !base.has(name)).sort();
+}
+
+function gitLsTreeActiveNames(baseRef) {
+  try {
+    const output = execFileSync(
+      'git',
+      ['ls-tree', '-d', '--name-only', `${baseRef}:${ACTIVE_CHANGES_DIR}`],
+      {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+      }
+    );
+
+    return parseActiveNames(output);
+  } catch (error) {
+    const message = String(error.stderr ?? error.message ?? '');
+    if (
+      message.includes('Not a valid object name') ||
+      message.includes('does not exist') ||
+      message.includes('not found')
+    ) {
+      return [];
+    }
+
+    throw error;
+  }
+}
+
+function workingTreeActiveNames(repoRoot) {
+  const changesPath = path.join(repoRoot, ACTIVE_CHANGES_DIR);
+  if (!fs.existsSync(changesPath)) {
+    return [];
+  }
+
+  return fs
+    .readdirSync(changesPath, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .filter(isActiveChangeName)
+    .sort();
+}
+
+function parseActiveNames(output) {
+  return output
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(isActiveChangeName)
+    .sort();
+}
+
+function isActiveChangeName(name) {
+  return Boolean(name) && name !== 'archive';
+}
+
+function printPass(baseActiveNames, headActiveNames) {
+  console.log('✓ OpenSpec archive gate passed.');
+  console.log(`Base active changes: ${baseActiveNames.length}`);
+  console.log(`HEAD active changes: ${headActiveNames.length}`);
+  console.log('No newly introduced active OpenSpec change remains un-archived.');
+}
+
+function printFailure(unarchivedChanges) {
+  console.error('✗ OpenSpec archive gate failed.');
+  console.error('');
+  console.error('This PR introduces active OpenSpec change(s) that are still un-archived:');
+  for (const name of unarchivedChanges) {
+    console.error(`- openspec/changes/${name}/`);
+  }
+  console.error('');
+  console.error('Archive each change before marking this PR ready to merge.');
+  console.error('Workflow SSOT: .agents/openspec-sdlc.md');
+  console.error('Skill: source-command-opsx-archive');
+  console.error('');
+  console.error('Manual archive shape:');
+  console.error('- sync the spec delta into openspec/specs/<capability>/spec.md');
+  console.error('- move the active dir to openspec/changes/archive/YYYY-MM-DD-<name>/');
+}
+
+export function main({ baseRef = DEFAULT_BASE_REF, repoRoot = process.cwd() } = {}) {
+  const baseActiveNames = gitLsTreeActiveNames(baseRef);
+  const headActiveNames = workingTreeActiveNames(repoRoot);
+  const unarchivedChanges = findUnarchivedNewChanges(baseActiveNames, headActiveNames);
+
+  if (unarchivedChanges.length > 0) {
+    printFailure(unarchivedChanges);
+    return 1;
+  }
+
+  printPass(baseActiveNames, headActiveNames);
+  return 0;
+}
+
+const isDirectRun = process.argv[1] === fileURLToPath(import.meta.url);
+
+if (isDirectRun) {
+  process.exitCode = main();
+}

--- a/tests/openspec-archive-gate.test.ts
+++ b/tests/openspec-archive-gate.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { findUnarchivedNewChanges } from '../scripts/check-openspec-archive.mjs';
+
+describe('findUnarchivedNewChanges', () => {
+  it('passes on an empty diff', () => {
+    expect(findUnarchivedNewChanges(['existing-change'], ['existing-change'])).toEqual([]);
+  });
+
+  it('fails with one newly introduced active change', () => {
+    expect(findUnarchivedNewChanges([], ['new-change'])).toEqual(['new-change']);
+  });
+
+  it('passes when a newly introduced change was archived', () => {
+    expect(findUnarchivedNewChanges([], [])).toEqual([]);
+  });
+
+  it('passes for a grandfathered active change present in base and head', () => {
+    expect(findUnarchivedNewChanges(['grandfathered-change'], ['grandfathered-change'])).toEqual(
+      []
+    );
+  });
+
+  it('lists every newly introduced active change in sorted order', () => {
+    expect(
+      findUnarchivedNewChanges(
+        ['grandfathered-change'],
+        ['z-new-change', 'grandfathered-change', 'a-new-change']
+      )
+    ).toEqual(['a-new-change', 'z-new-change']);
+  });
+});


### PR DESCRIPTION
## 變更

- 新增 `scripts/check-openspec-archive.mjs`，用 pure function 比對 `origin/main` 與 PR HEAD 的 active OpenSpec change 目錄。
- 新增 standalone workflow `OpenSpec Archive Gate`，包含 `ready_for_review` trigger；draft PR 只印 defer 訊息並直接 pass。
- 新增 Vitest unit tests，鎖住 grandfathered backlog、新增 active change、已 archive change 等語意。

## Required check wiring

`ci.yml` 的 `ci-passed` aggregator 只能聚合同一個 workflow 裡的 jobs。這個 gate 必須 standalone 才能掛 `ready_for_review`，所以無法塞進既有 `ci-passed.needs`。

要讓它實際擋 merge，branch protection 需要額外要求這個 stable check name：

`OpenSpec Archive Gate / openspec-archive-gate`

## 驗證

- `node scripts/check-openspec-archive.mjs`
- `pnpm exec vitest run tests/openspec-archive-gate.test.ts`
- `pnpm exec vitest run`
- `pnpm exec prettier --check scripts/check-openspec-archive.mjs .github/workflows/openspec-archive-gate.yml tests/openspec-archive-gate.test.ts`
- `.githooks/pre-commit`
- `.githooks/pre-push`