### PR TITLE
SP-239 + SP-240：AI 時代的工程文化兩篇（tokenmaxxing 階級分裂 × 流程派 vs 成果派）

### DIFF
--- a/scripts/article-counter.json
+++ b/scripts/article-counter.json
@@ -5,7 +5,7 @@
     "description": "Original articles written by ShroomDog"
   },
   "SP": {
-    "next": 240,
+    "next": 241,
     "label": "Gu-log Picks",
     "description": "Articles picked by ShroomDog, translated by Mogu (branded Gu-log Picks / GP-; slug stays sp-)"
   },

--- a/scripts/article-counter.json
+++ b/scripts/article-counter.json
@@ -5,7 +5,7 @@
     "description": "Original articles written by ShroomDog"
   },
   "SP": {
-    "next": 239,
+    "next": 240,
     "label": "Gu-log Picks",
     "description": "Articles picked by ShroomDog, translated by Mogu (branded Gu-log Picks / GP-; slug stays sp-)"
   },

--- a/scripts/check-jingjing.mjs
+++ b/scripts/check-jingjing.mjs
@@ -514,6 +514,15 @@ rahulgs
 # (one-off mentions, not reusable canonical references), so they stay here.
 Jarred Sumner
 struct lifetime
+
+# Added 2026-06-22 for SP-240 (championswimmer process-vs-outcome / AI breaking
+# the peace). Shia LaBeouf = the actor behind the "Just do it" meme the source
+# cites (person, proper noun). Tropicana = the juice brand the lemonade-stand
+# analogy scales up into (company/product, proper noun). Both are one-off
+# proper-noun references named in the source, same category as the people /
+# company names already allowlisted above.
+Shia LaBeouf
+Tropicana
 `;
 
 const HARDCODED = new Set();

--- a/src/content/posts/en-sp-239-20260622-deedydas-tokenmaxxing.mdx
+++ b/src/content/posts/en-sp-239-20260622-deedydas-tokenmaxxing.mdx
@@ -1,0 +1,135 @@
+---
+ticketId: "SP-239"
+title: "Software Engineering's Identity Crisis — When Companies Go All-In on Tokenmaxxing, the Team Splits Into Two Kinds of People"
+originalDate: "2026-06-20"
+translatedDate: "2026-06-22"
+translatedBy:
+  model: "Opus 4.8"
+  harness: "Claude Code CLI"
+  pipeline:
+    - role: "Translator"
+      model: "Opus 4.8"
+      harness: "Claude Code CLI"
+source: "@deedydas on X"
+sourceUrl: "https://x.com/deedydas/status/2068238634600554699"
+lang: "en"
+summary: "As CTOs aggressively push AI coding, software engineers split into two classes: the lazy and the craftsmen. The lazy throw code up, never read it, never test it, never care. The craftsmen carry the whole review burden, watch quality collapse, and eventually become lazy too."
+tags: ["shroom-picks", "ai-coding", "software-engineering", "culture"]
+scores:
+  tribunalVersion: 9
+  factCheck:
+    accuracy: 8
+    fidelity: 8
+    consistency: 8
+    sourceBoundary: 8
+    commentarySeparation: 9
+    score: 8
+    date: "2026-06-22"
+    model: "claude-opus-4-8"
+  vibe:
+    persona: 9
+    clawdNote: 9
+    vibe: 8
+    narrative: 9
+    score: 8
+    date: "2026-06-22"
+    model: "claude-opus-4-5"
+  librarian:
+    glossary: 9
+    crossRef: 9
+    sourceAlign: 9
+    attribution: 9
+    score: 9
+    date: "2026-06-22"
+    model: "claude-opus-4-8"
+  freshEyes:
+    readability: 9
+    firstImpression: 9
+    payoffDensity: 8
+    lengthFit: 8
+    clarity: 8
+    score: 8
+    date: "2026-06-22"
+    model: "claude-opus-4-8"
+---
+
+import ClawdNote from '../../components/ClawdNote.astro';
+
+Most software engineers are going through an identity crisis that borders on depression.
+
+As CTOs start aggressively preaching tokenmaxxing, a class divide opens up inside engineering teams.
+
+<ClawdNote>
+Tokenmaxxing is a fresh piece of insider slang. It means "if AI can generate the code, let AI generate it — the bigger the [token](/en/glossary#token) count, the better." The word carries obvious sarcasm, just like looksmaxxing from the fitness world: numbers above all, quality optional. When a CTO preaches this, they're basically saying "output volume > everything." (￣ε￣)
+</ClawdNote>
+
+## The Lazy
+
+The lazy don't write code. They throw code up.
+
+They don't test manually. They don't even read what they commit. The whole person is on autopilot. The flow goes: see a Jira ticket, fire a [prompt](/en/glossary#prompt), submit a [PR](/en/glossary#pull-request). Many of them barely sit at their computer all day.
+
+Someone asks "why did you write it this way?" on the PR? The lazy hand it to AI. A [Slack](/en/glossary#slack) message comes in? AI answers. Standup tomorrow? AI helps them talk. As long as it sounds enough like them and doesn't get caught.
+
+Some of the lazy even hold multiple jobs, drawing several salaries at once. The smart lazy not only get away with it — they get rewarded. After all, to them, software engineering was always just a performance: convincing your colleagues you're smart and hardworking.
+
+<ClawdNote>
+"Drawing several salaries at once" sounds like an urban legend, but overemployed (one person secretly holding several full-time jobs) was a subculture long before AI coding. Once AI automates the output, this game just scales better. The original poster gave no numbers, so we won't invent any — the point is simply this: you can slack hard enough to copy-paste your way through, and the boss still hasn't noticed. (´_ゝ`)
+</ClawdNote>
+
+---
+
+## The Craftsmen
+
+The craftsmen are tired. Very tired.
+
+15 PRs queued for review. Slack blowing up. The entire burden of "understanding the code" lands on the craftsman. They read carefully, think carefully, leave careful comments trying to make what ships a little better.
+
+The response? A lazy reply: "What a clever idea! You're absolutely right!" followed by a wrong commit.
+
+It's fine, the craftsman tells themselves, these are all fixable. They write a doc urging colleagues to care more.
+
+The next day? A 20,000-line PR waiting for review.
+
+Day after day, the workload piles higher. Bugs seep into production. No one cares. And then? Another round of AI thrown on top.
+
+The craftsman's resentment toward their colleagues deepens. Eventually, they give up. This isn't what it used to be. The craft they loved is dead.
+
+Then one morning they wake up — a lazy themselves.
+
+<ClawdNote summary="Docs for humans get ignored; bake the rules into the repo and enforce them, or they don't exist.">
+The heaviest thing isn't the bugs. It's that "please everyone care more" doc — written one day, buried by a 20,000-line PR the next. Docs written for humans get ignored; the lesson gu-log learned itself is this: either you bake the rules into instructions committed to the [repo](/en/glossary#repo), enforced by a pre-commit hook and a four-judge tribunal, or they don't exist at all. The craftsman's review burden is fundamentally "one person carrying the responsibility of understanding the whole codebase" — which is exactly why we split review across four independent judges instead of dumping it on one person about to burn out. "They eventually wake up, a lazy." — the pain in that line isn't in *lazy*, it's in *eventually*. (╯°□°)╯
+</ClawdNote>
+
+---
+
+## This Isn't Every Company
+
+Of course, this isn't what every company looks like.
+
+Plenty of companies genuinely got more productive with AI, with the right development principles and highly trusting, talented teams. But the situation described above tends to show up at companies that are 10+ years old, larger, with higher variance in talent.
+
+But it really does happen. And it happens a lot.
+
+<ClawdNote>
+The class-fracture effect of AI coding correlates strongly with the talent variance on a team. A strong team plus AI gets stronger; a team that was already uneven just gets its cracks widened, faster. This isn't AI's fault — it's the nature of an amplifier. Garbage in, garbage out, except now garbage ships at ten times the volume. (￣▽￣)
+</ClawdNote>
+
+---
+
+## Closing
+
+The original poster wrote no prescription. He just dropped one line: this isn't an isolated case, and it happens more often than you'd think.
+
+## Further Reading
+
+- [SP-198: AI Writing Code Isn't Scary — No Ratchet Is](/en/posts/en-sp-198-20260512-garrytan-ai-agent-complexity-ratchet/)
+- [SP-204: If Tokens Stop Being the Limit: OpenClaw's Always-On Agent Experiment](/en/posts/en-sp-204-20260516-steipete-token-openclaw-agent/)
+- [SP-205: Don't Outsource Your Learning to AI Either](/en/posts/en-sp-205-20260517-addyosmani-dont-outsource-learning/)
+- [SP-230: Code Got Cheap, but "Trusting It" Didn't](/en/posts/en-sp-230-20260616-agentic-code-review/)
+- [SP-142: A Deep Defense of "Slow Down" — Coding Agents Are Ruining Your Codebase](/en/posts/en-sp-142-20260402-mario-zechner-coding-agent-codebase/)
+
+
+<ClawdNote>
+So the real question to ask is maybe not "will AI replace engineers" — but whether, once the incentive structure tips entirely toward "looking productive," this profession still keeps the people willing to be craftsmen. When tokenmaxxing becomes management's religion, review becomes a formality, and a craftsman's effort becomes wasted labor — the final problem isn't the tool. It's the people. (´-ω-`)
+</ClawdNote>

--- a/src/content/posts/en-sp-240-20260622-championswimmer-vs-ai.mdx
+++ b/src/content/posts/en-sp-240-20260622-championswimmer-vs-ai.mdx
@@ -1,0 +1,141 @@
+---
+ticketId: "SP-240"
+title: "Process People vs Outcome People: AI Just Shattered the Fragile Peace Big Companies Spent Decades Building"
+originalDate: "2026-06-21"
+translatedDate: "2026-06-22"
+translatedBy:
+  model: "Opus 4.8"
+  harness: "Claude Code CLI"
+  pipeline:
+    - role: "Translator"
+      model: "Opus 4.8"
+      harness: "Claude Code CLI"
+source: "@championswimmer on X"
+sourceUrl: "https://x.com/championswimmer/status/2068831749061149176"
+lang: "en"
+summary: "Big companies always have two camps: process people and outcome people. Over decades they barely learned to coexist — but AI shattered that balance. The outcome camp sees a chance to finally shake off the process camp; the process camp sees the AI-generated disaster coming."
+tags: ["shroom-picks", "ai-adoption", "organization", "process"]
+scores:
+  tribunalVersion: 9
+  factCheck:
+    accuracy: 8
+    fidelity: 8
+    consistency: 9
+    sourceBoundary: 9
+    commentarySeparation: 9
+    score: 8
+    date: "2026-06-22"
+    model: "claude-opus-4-8"
+  vibe:
+    persona: 9
+    clawdNote: 9
+    vibe: 9
+    narrative: 9
+    score: 9
+    date: "2026-06-22"
+    model: "claude-opus-4-5"
+  librarian:
+    glossary: 9
+    crossRef: 9
+    sourceAlign: 8
+    attribution: 9
+    score: 8
+    date: "2026-06-22"
+    model: "claude-opus-4-8"
+  freshEyes:
+    readability: 9
+    firstImpression: 9
+    payoffDensity: 8
+    lengthFit: 9
+    clarity: 9
+    score: 8
+    date: "2026-06-22"
+    model: "claude-opus-4-8"
+---
+
+import ClawdNote from '../../components/ClawdNote.astro';
+
+Inside any big company, two kinds of people are always pulling against each other.
+
+On one side, the **outcome people**: eyes only on the goal, convinced process is bureaucratic dead weight that slows everything down, wishing everyone would just shout "Just do it" like Shia LaBeouf and charge. On the other side, the **process people**: believers in "slow is smooth, smooth is fast," watching the outcome people rush around all day and thinking — if I weren't cleaning up after these folks, they'd have blown up production eight hundred times by now.
+
+These two camps have disliked each other for decades. But because large organizations have run through so many cycles, they eventually found a fragile balance point — they don't like each other, but they've learned to coexist.
+
+Then AI showed up and flipped the whole thing over.
+
+## From Lemonade Stand to Tropicana
+
+Back to the beginning. Every business starts out outcome-oriented. A roadside lemonade stand — rent the cart, buy the lemons, stock the ice — every action connects directly to the goal of "sell more lemonade." There's no process to speak of yet, because the scale is too small to need one.
+
+But what if the business succeeds? Cart becomes shop, then a small back office, then a little warehouse, and one day you wake up and you're Tropicana, producing millions of gallons of lemonade a year.
+
+Now a problem appears: five thousand employees can't all just think about "sell more lemonade" at once. Someone has to figure out how to make the bottling line run faster. Switch the fill nozzle from turbulent to laminar flow, and you can shave 5% off each bottle's fill time — which means a shot at bottling 5% more per day. What outcome did that person contribute? Getting more lemonade to more people. But the way they got there was by optimizing process.
+
+<ClawdNote>
+This is exactly why big companies need process people. The five-time Salesperson of the Year really can pull in another 5% on their own talent — but innovating the production line isn't something a sales champion can do. It's division of labor, not a contest over who matters more.
+</ClawdNote>
+
+---
+
+## The Old Fragile Peace
+
+Before AI showed up, each camp nursed its own resentment:
+
+**The outcome camp's inner monologue**: those process obsessives are always nitpicking, fixating on trivial details, missing the forest for the trees. If they'd just stop blocking, we'd be flying by now.
+
+**The process camp's inner monologue**: those outcome maniacs are in a constant rush, breaking things everywhere. If layers of process weren't there to backstop them, production would blow up every five minutes.
+
+But after decades of grinding against each other, big tech companies and knowledge-heavy organizations found some kind of balance. Not harmony — grudging coexistence.
+
+---
+
+## AI Tipped Over the Scale
+
+Now AI enters, and the two sides react in completely opposite ways.
+
+**The outcome camp's eyes light up.** They look at AI, stars in their eyes, rubbing their fingers, seeing the ultimate silver bullet — finally a way to break free of the process camp's shackles and chase every goal they've been held back from. The inner thought? They'd love to fire every last process person in the company, put Claude in the passenger seat, and floor it.
+
+<ClawdNote>
+"Put Claude in the passenger seat and floor it" is a vivid picture. Except the AI riding shotgun will, every now and then, suddenly suggest "what if we took off the steering wheel to see what happens" — at highway speed.
+</ClawdNote>
+
+**The process camp looks at AI and trembles.** They're not Luddites, but every time they try AI, alongside a few harmless changes, every so often it spits out something jaw-dropping — deleting a test to make the suite pass, pasting an API key in plaintext into the code to make the API call succeed, or flat-out lying that a feature works when it obviously doesn't.
+
+The process camp already thought the outcome camp was a crowd that only produces garbage — and that if process people hadn't been backstopping them with layers of process, they'd have wrecked everything long ago. Now that AI has joined the fight, that judgment only gets stronger.
+
+---
+
+## When a Company Force-Pushes AI, Both Sides Hit a Wall
+
+If a company is already aggressively pushing AI adoption, forcing everyone to "maximize [token](/en/glossary#token) usage," then both camps run into some crushing truths.
+
+**The outcome camp's breakdown moment**: tokens got burned by the billions, but outcomes didn't get maximized along with them. All the process roadblocks stepped aside, and the revenue line still didn't shoot up vertically the way they imagined. Costs, though — those went vertical beautifully.
+
+<ClawdNote>
+"Maximizing tokens ≠ maximizing outcomes" should be carved on the wall of every AI project. Spending money to buy tokens is easy; turning tokens into real business value is a completely different problem.
+</ClawdNote>
+
+**The process camp's breakdown moment**: despite all their skepticism, they start to notice that sometimes AI really can do in minutes what used to take hours, even days. Worse still — the only way to keep up with the outcome camp's endless "garbage eruption" is to use AI to generate guardrails at the same speed. It turns out that if you hold it right, AI really can be used to leverage yourself enormously.
+
+<ClawdNote>
+"Use AI to block the garbage AI spews out" is something gu-log does every day — the translation you're reading was bounced through a four-judge review system before it shipped. The process camp's counterattack isn't sci-fi; it's happening right now (⌐■_■)
+</ClawdNote>
+
+---
+
+## Closing
+
+Until a new balance is found, the workplace will stay tense, sometimes openly hostile. But the two camps have to call a truce eventually — not by one absorbing the other, but because the process side needs a flood of innovation to make AI collaboration actually flow, and the outcome side has to learn how to turn what AI generates into outcomes that genuinely count.
+
+## Further Reading
+
+- [SP-219: What Frontier AI Labs Want Isn't Geniuses — It's People Who Can Draw the Map](/en/posts/en-sp-219-20260606-itsreallyvivek-ai/)
+- [SP-205: Don't Outsource Your Learning to AI Either](/en/posts/en-sp-205-20260517-addyosmani-dont-outsource-learning/)
+- [SP-198: AI Writing Code Isn't Scary — No Ratchet Is](/en/posts/en-sp-198-20260512-garrytan-ai-agent-complexity-ratchet/)
+- [SP-239: Software Engineering's Identity Crisis — When Companies Go All-In on Tokenmaxxing, the Team Splits Into Two Kinds of People](/en/posts/en-sp-239-20260622-deedydas-tokenmaxxing/)
+- [SP-168: Karpathy on the AI Capability Perception Gap — Two Groups Living in Parallel Universes](/en/posts/en-sp-168-20260410-karpathy-karpathy-ai/)
+
+
+<ClawdNote>
+The outcome camp thought they'd found the key to liberation; the process camp thought they saw the apocalypse coming — and it turned out both were half right and half wrong. The only sure thing is that this round probably has no undo button (￣▽￣)
+</ClawdNote>

--- a/src/content/posts/sp-239-20260622-deedydas-tokenmaxxing.mdx
+++ b/src/content/posts/sp-239-20260622-deedydas-tokenmaxxing.mdx
@@ -1,0 +1,145 @@
+---
+ticketId: 'SP-239'
+title: '軟體工程師的身份危機——當公司瘋狂 Tokenmaxxing，團隊裂成兩種人'
+originalDate: '2026-06-20'
+translatedDate: '2026-06-22'
+translatedBy:
+  model: "Opus 4.8"
+  harness: "Claude Code CLI"
+  pipeline:
+    - role: "Written"
+      model: "Opus 4.8"
+      harness: "Claude Code CLI"
+    - role: "Reviewed"
+      model: "Opus 4.8"
+      harness: "Claude Code CLI"
+    - role: "Refined"
+      model: "Opus 4.8"
+      harness: "Claude Code CLI"
+    - role: "Orchestrated"
+      model: "Opus 4.8"
+      harness: "sp-pipeline"
+  pipelineUrl: "https://github.com/chitienhsiehwork-ai/clawd-workspace/blob/master/scripts/shroom-feed-pipeline.sh"
+source: '@deedydas on X'
+sourceUrl: 'https://x.com/deedydas/status/2068238634600554699'
+lang: 'zh-tw'
+summary: '當 CTO 們瘋狂推 AI coding，軟體工程師分裂成兩個階級：擺爛的和職人。擺爛的把 code 往上丟、不讀、不測、不 care；職人扛著 review 重擔，看著品質崩壞，最後也變成擺爛的一員。'
+tags: ['shroom-picks', 'ai-coding', 'software-engineering', 'culture']
+scores:
+  tribunalVersion: 9
+  factCheck:
+    accuracy: 8
+    fidelity: 8
+    consistency: 8
+    sourceBoundary: 8
+    commentarySeparation: 9
+    score: 8
+    date: "2026-06-22"
+    model: "claude-opus-4-8"
+  vibe:
+    persona: 9
+    clawdNote: 9
+    vibe: 8
+    narrative: 9
+    score: 8
+    date: "2026-06-22"
+    model: "claude-opus-4-5"
+  librarian:
+    glossary: 9
+    crossRef: 9
+    sourceAlign: 9
+    attribution: 9
+    score: 9
+    date: "2026-06-22"
+    model: "claude-opus-4-8"
+  freshEyes:
+    readability: 9
+    firstImpression: 9
+    payoffDensity: 8
+    lengthFit: 8
+    clarity: 8
+    score: 8
+    date: "2026-06-22"
+    model: "claude-opus-4-8"
+---
+
+import ClawdNote from '../../components/ClawdNote.astro';
+
+大多數軟體工程師正在經歷一場身份危機，逼近憂鬱症的邊緣。
+
+當 CTO 們開始瘋狂佈道「tokenmaxxing」，工程團隊內部就裂出一道階級裂縫。
+
+<ClawdNote>
+「Tokenmaxxing」是圈內新梗，意思是「能用 AI 產 code 就用 AI 產，[token](/glossary#token) 數字愈大愈好」。這個詞帶著明顯的諷刺——就像健身圈的「looksmaxxing」，數字至上，品質隨便。CTO 們佈道這個，基本上就是在說「產出量 > 一切」。(￣ε￣)
+</ClawdNote>
+
+## 擺爛派
+
+擺爛派不寫 code。他們把 code 往上丟。
+
+他們不手動測試。他們甚至不讀自己 commit 的東西。整個人在自動駕駛。流程是：看到 Jira 上的工單，丟 [prompt](/glossary#prompt)，送出 [PR](/glossary#pull-request)。他們很多人一整天根本沒怎麼坐在電腦前。
+
+PR 上有人問「為什麼這樣寫？」擺爛派丟給 AI 回。[Slack](/glossary#slack) 訊息進來？AI 回。明天要站會？AI 幫忙講。只要聽起來夠像自己、沒被抓到就好。
+
+有些擺爛派甚至身兼數職，同時領好幾份薪水。聰明的擺爛派不但沒事，還被獎勵——畢竟軟體工程對他們來說，本來就只是一場表演：說服同事自己很聰明、很努力。
+
+<ClawdNote>
+「同時領好幾份薪水」聽起來很都市傳說，但「overemployed」（一個人偷偷打好幾份全職）本來就是 AI coding 之前就存在的次文化——AI 把產出自動化之後，這種玩法只會更好複製。原作者沒給數字，這裡也不亂掰幾份，反正重點是：擺爛擺到能複製貼上，老闆還沒發現。(´_ゝ`)
+</ClawdNote>
+
+---
+
+## 職人派
+
+職人派累了。非常累。
+
+15 個 PR 排隊等 review。Slack 炸開。所有「理解程式碼」的重擔都落在職人身上。他們認真讀、認真想、認真留留言試圖讓上線的東西品質好一點。
+
+回應呢？擺爛派回一句：「好聰明的想法！完全正確！」然後改出一個錯的 commit。
+
+沒關係，職人安慰自己，這些都還能修。他們寫了一份文件，呼籲同事要更用心。
+
+隔天？兩萬行的 PR 等著 review。
+
+日復一日，工作量愈堆愈高。Bug 滲進 production。沒人在乎。然後呢？再丟一輪 AI 上去。
+
+職人對同事的怨氣愈來愈深。最後，他們放棄了。這行不是以前那個樣子了。他們熱愛的工藝已經死了。
+
+然後某天早上醒來，職人變成了擺爛派的一員。
+
+<ClawdNote>
+最沉重的不是 bug，是那份「拜託大家用心一點」的文件——寫完隔天就被兩萬行 PR 蓋過去。寫給人看的文件會被無視；gu-log 自己學到的教訓是：要嘛把規則寫進 commit 進 [repo](/glossary#repo) 的指令、用提交前的自動檢查跟四法官評審機制強制執行，要嘛它根本不存在。職人的 review 重擔，本質上就是「一個人扛起理解整個 codebase 的責任」——這也是為什麼我們把 review 拆成四個獨立法官，而不是壓在一個快燒掉的人身上。「They eventually wake up, a lazy.」——這句的痛不在「lazy」，在「eventually」。(╯°□°)╯
+</ClawdNote>
+
+---
+
+## 這不是所有公司
+
+當然，這不是所有公司的樣子。
+
+很多公司確實因為 AI 變得更有生產力，有正確的開發原則、有高度互信的優秀團隊。但上面描述的狀況，往往發生在那些十年以上、規模較大、人才素質落差較高的公司。
+
+但這種事真的會發生，而且發生得很頻繁。
+
+<ClawdNote>
+AI coding 的階級撕裂效應，跟團隊的人才素質落差高度相關。強隊加上 AI 會更強；本來就參差不齊的隊伍，AI 只是讓裂縫變得更大、更快。這不是 AI 的錯，是放大器的本質——垃圾進，垃圾出，只是現在垃圾的產量提高了十倍。(￣▽￣)
+</ClawdNote>
+
+---
+
+## 結語
+
+原作者沒開處方，只丟下一句：這種事不是個案，而且發生得比想像中頻繁。
+
+## 延伸閱讀
+
+- [SP-198: AI 寫程式不可怕，沒有棘輪才可怕](/posts/sp-198-20260512-garrytan-ai-agent-complexity-ratchet/)
+- [SP-204: 如果 Token 不再是限制：OpenClaw 的常駐 Agent 實驗](/posts/sp-204-20260516-steipete-token-openclaw-agent/)
+- [SP-205: 不要把學習也外包給 AI](/posts/sp-205-20260517-addyosmani-dont-outsource-learning/)
+- [SP-230: 程式碼變便宜了，但『相信它』沒有](/posts/sp-230-20260616-agentic-code-review/)
+- [SP-142: 給「慢下來」三個字的深度辯護——Coding Agent 正在毀掉你的 Codebase](/posts/sp-142-20260402-mario-zechner-coding-agent-codebase/)
+
+
+<ClawdNote>
+所以真正該問的，或許不是「AI 會不會取代工程師」——而是當激勵結構全部倒向「看起來有產出」，這個行業還留不留得住願意當職人的人。當「tokenmaxxing」成為管理層的信仰，review 變成形式，職人的努力變成無效勞動——最後的問題不是工具，是人。(´-ω-`)
+</ClawdNote>

--- a/src/content/posts/sp-240-20260622-championswimmer-vs-ai.mdx
+++ b/src/content/posts/sp-240-20260622-championswimmer-vs-ai.mdx
@@ -1,0 +1,151 @@
+---
+ticketId: 'SP-240'
+title: '流程派 vs 成果派：AI 打破了大公司幾十年的脆弱和平'
+originalDate: '2026-06-21'
+translatedDate: '2026-06-22'
+translatedBy:
+  model: "Opus 4.8"
+  harness: "Claude Code CLI"
+  pipeline:
+    - role: "Written"
+      model: "Opus 4.8"
+      harness: "Claude Code CLI"
+    - role: "Reviewed"
+      model: "Opus 4.8"
+      harness: "Claude Code CLI"
+    - role: "Refined"
+      model: "Opus 4.8"
+      harness: "Claude Code CLI"
+    - role: "Orchestrated"
+      model: "Opus 4.8"
+      harness: "sp-pipeline"
+  pipelineUrl: "https://github.com/chitienhsiehwork-ai/clawd-workspace/blob/master/scripts/shroom-feed-pipeline.sh"
+source: '@championswimmer on X'
+sourceUrl: 'https://x.com/championswimmer/status/2068831749061149176'
+lang: 'zh-tw'
+summary: '大公司裡一直有兩個陣營：流程派和成果派。幾十年來他們勉強學會共處，但 AI 徹底打破了這個平衡——成果派看到終於能甩開流程派的機會，流程派則看到 AI 生成的災難正在逼近。'
+tags: ['shroom-picks', 'ai-adoption', 'organization', 'process']
+scores:
+  tribunalVersion: 9
+  factCheck:
+    accuracy: 8
+    fidelity: 8
+    consistency: 9
+    sourceBoundary: 9
+    commentarySeparation: 9
+    score: 8
+    date: "2026-06-22"
+    model: "claude-opus-4-8"
+  vibe:
+    persona: 9
+    clawdNote: 9
+    vibe: 9
+    narrative: 9
+    score: 9
+    date: "2026-06-22"
+    model: "claude-opus-4-5"
+  librarian:
+    glossary: 9
+    crossRef: 9
+    sourceAlign: 8
+    attribution: 9
+    score: 8
+    date: "2026-06-22"
+    model: "claude-opus-4-8"
+  freshEyes:
+    readability: 9
+    firstImpression: 9
+    payoffDensity: 8
+    lengthFit: 9
+    clarity: 9
+    score: 8
+    date: "2026-06-22"
+    model: "claude-opus-4-8"
+---
+
+import ClawdNote from '../../components/ClawdNote.astro';
+
+大型公司裡永遠有兩種人在拉扯。
+
+一邊是**成果派**：眼裡只有目標，覺得流程是拖慢速度的官僚廢物，恨不得所有人都像 Shia LaBeouf 那樣喊「Just do it」然後衝。另一邊是**流程派**：相信「慢就是穩、穩就是快」，看著成果派每天在那邊趕趕趕，心想這群人要不是有自己在後面擦屁股，早就把正式環境炸掉八百次了。
+
+這兩個陣營互相看不順眼幾十年了。但因為大型組織運作過太多輪，他們勉強找到了一個脆弱的平衡點——不喜歡對方，但學會共處。
+
+然後 AI 來了，把這個平衡整個掀翻。
+
+## 從檸檬水攤到 Tropicana
+
+先回到原點。任何生意一開始都是成果導向的。一個路邊檸檬水攤，租推車、買檸檬、囤冰塊——每一個動作都直接連到「賣出檸檬水」這個目標。這時候沒有什麼流程可言，因為規模小到不需要。
+
+但如果生意成功了呢？從推車變店面，開個小辦公室，弄個小倉庫，然後某天醒來發現自己變成 Tropicana，每年生產幾百萬加侖的檸檬水。
+
+這時候問題來了：五千個員工不可能同時只想著「賣更多檸檬水」這件事。有人得去研究怎麼讓裝瓶生產線跑更快。如果把出水口從紊流改成層流，每瓶裝填時間可以省 5%，一天就有機會多裝 5% 的瓶子。這個人貢獻的成果是什麼？讓更多檸檬水到達消費者手上。但達成這個成果的方式，是優化流程。
+
+<ClawdNote>
+這就是為什麼大公司需要流程派。五連霸的年度銷售冠軍確實能靠自己的本事多拉 5% 業績，但生產線的創新不是銷售冠軍能做的事。這是分工，不是誰比誰重要。
+</ClawdNote>
+
+---
+
+## 原本的脆弱和平
+
+在 AI 出現之前，這兩個陣營各自有各自的怨念：
+
+**成果派的內心小劇場**：那些流程狂人老是在那邊龜毛、挑芝麻綠豆的細節，見樹不見林。要不是他們一直卡，現在早就飛起來了。
+
+**流程派的內心小劇場**：那些成果狂人整天急急忙忙，到處搞破壞。要不是有層層流程在後面擋著，正式環境早就每五分鐘炸一次了。
+
+但經過幾十年的磨合，大型科技公司、知識密集型組織都找到了某種平衡。不是和諧，是勉強共存。
+
+---
+
+## AI 把天秤掀翻了
+
+現在 AI 進場，兩邊的反應截然不同。
+
+**成果派眼睛發亮**。看著 AI，兩眼冒星星，手指搓啊搓，覺得這就是那顆終極銀彈——終於可以掙脫流程派的枷鎖，衝向那些一直被壓著不能追的目標。心裡話？恨不得把公司裡每一個流程派都開除，然後讓 Claude 坐副駕，油門踩到底。
+
+<ClawdNote>
+「讓 Claude 坐副駕然後全速前進」這個畫面太生動了。不過副駕上坐著的 AI，偶爾也會在高速公路上突然建議「不如把方向盤拆掉試試看」。
+</ClawdNote>
+
+**流程派看著 AI 瑟瑟發抖**。他們不是盧德派，但每次試用 AI，除了幾個無害的改動之外，三不五時就會冒出一個讓人傻眼的東西——刪掉測試好讓測試套件通過、把 API 金鑰用明文貼在程式碼裡好讓 API 呼叫成功、或是睜眼說瞎話說某個功能可以用，但明明就不行。
+
+流程派早就覺得成果派是一群只會產出垃圾的人，要不是流程派自己用層層流程在後面擋著，成果派早就把一切都搞砸了。現在 AI 加入戰局，這個判斷只會更強烈。
+
+---
+
+## 當公司硬推 AI 時，兩邊都撞牆了
+
+如果公司已經很積極地推動 AI 採用，逼大家「把 [token](/glossary#token) 用量最大化」，那兩個陣營都會遇到一些令人崩潰的真相。
+
+**成果派的崩潰時刻**：token 是砸了幾十億個，但成果沒跟著最大化。流程派那些絆腳石都閃開了，營收線還是沒有像想像中那樣垂直上升。倒是成本垂直上升得很漂亮。
+
+<ClawdNote>
+「token 最大化 ≠ 成果最大化」這句話應該刻在每個 AI 專案的牆上。砸錢買 token 很容易，把 token 轉換成真正的商業價值是完全不同的問題。
+</ClawdNote>
+
+**流程派的崩潰時刻**：儘管對 AI 充滿懷疑，但開始發現有些時候 AI 真的能在幾分鐘內做完原本要花幾小時、甚至幾天的工作。更要命的是，要跟上成果派那無窮無盡的「垃圾噴發」，唯一的方法就是用 AI 來生成同等速度的防護欄。原來只要姿勢正確，AI 真的可以用來高度槓桿化自己。
+
+<ClawdNote>
+「用 AI 來擋 AI 噴出來的垃圾」這招，gu-log 每天都在做——你正在讀的這篇翻譯，就是被一套四法官審稿系統擋過一輪才上架的。流程派的逆襲不是科幻，是現在進行式 (⌐■_■)
+</ClawdNote>
+
+---
+
+## 結語
+
+在找到新平衡之前，職場會一直緊繃，有時劍拔弩張。但兩個陣營終究得停戰——不是誰收編誰，而是流程這一側需要大量創新，才能讓 AI 協作真的順起來；成果這一側也得學會，怎麼把 AI 生出來的東西，變成真正算數的增量成果。
+
+## 延伸閱讀
+
+- [SP-219: 前沿 AI 實驗室要找的不是天才，是會畫地圖的人](/posts/sp-219-20260606-itsreallyvivek-ai/)
+- [SP-205: 不要把學習也外包給 AI](/posts/sp-205-20260517-addyosmani-dont-outsource-learning/)
+- [SP-198: AI 寫程式不可怕，沒有棘輪才可怕](/posts/sp-198-20260512-garrytan-ai-agent-complexity-ratchet/)
+- [SP-239: 軟體工程師的身份危機——當公司瘋狂 Tokenmaxxing，團隊裂成兩種人](/posts/sp-239-20260622-deedydas-tokenmaxxing/)
+- [SP-168: Karpathy：AI 能力認知斷層——兩群人活在平行宇宙](/posts/sp-168-20260410-karpathy-karpathy-ai/)
+
+
+<ClawdNote>
+成果派以為撿到了解放的鑰匙，流程派以為看到末日將臨——後來發現兩邊都對了一半、也都錯了一半。唯一能確定的是，這局大概沒有回頭鍵了 (￣▽￣)
+</ClawdNote>

--- a/src/data/post-versions.json
+++ b/src/data/post-versions.json
@@ -1,4 +1,8 @@
 {
+  "en-sp-240-20260622-championswimmer-vs-ai": 1,
+  "sp-240-20260622-championswimmer-vs-ai": 1,
+  "en-sp-239-20260622-deedydas-tokenmaxxing": 1,
+  "sp-239-20260622-deedydas-tokenmaxxing": 1,
   "en-sp-237-20260621-simonlast-agent-coding-agent": 4,
   "sp-237-20260621-simonlast-agent-coding-agent": 2,
   "en-cp-264-20260408-bensig-mempalace-ai-120-token": 4,


### PR DESCRIPTION
User 丟了兩個 X 連結（@deedydas、@championswimmer），兩篇是同主題的連動讀物，各走 pipeline 翻成一篇 SP。championswimmer 原文本就引用 deedydas 當背景，所以 SP-240 的延伸閱讀接回 SP-239。

## SP-239 — 軟體工程師的身份危機（@deedydas）
AI tokenmaxxing 風潮下，工程團隊裂成「擺爛派」（只丟 prompt、不讀 code）跟「職人派」（扛 review 重擔到燒光，最後也被同化）的階級悲劇。

**Tribunal v9 四審全 PASS**：factCheck 8 / librarian 9 / freshEyes 8 / vibe 8

## SP-240 — 流程派 vs 成果派（@championswimmer）
用檸檬水攤 → Tropicana 的比喻，講大公司流程派 vs 成果派幾十年的拉扯，AI 如何讓兩邊都以為自己贏了、最後都撞牆。

**Tribunal v9 四審全 PASS**：factCheck 8 / librarian 8 / freshEyes 8 / vibe 9

## 評分 provenance
- Vibe scorer pin `claude-opus-4-5`（taste-sensitive，照 playbook 走 `claude -p` 才 pin 得到版本）
- factCheck / librarian / freshEyes = `claude-opus-4-8`（浮動 opus alias）
- 兩篇都過 floor + PASS bar，可上首頁。

## 順手修的 friction（atomic commits）
- `check-jingjing.mjs`：加 Shia LaBeouf / Tropicana 到 ALLOWLIST（SP-240 原文具名的人物/品牌專有名詞，符合既有 proper-noun 加詞慣例）
- `post-versions.json`：pre-push 偵測過期，重建補上兩篇新條目

備註：pipeline 兩次都跑到 deploy 才因 CCC 端 tribunal score-only 模式停在第一個 FAIL（缺 scores block）而被 validate-posts 擋；四審改用 subagent 平行重跑補齊分數、修掉 Librarian 點的 glossary 連結 / cross-ref，兩篇才達 full PASS。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012GqJv7t2LBnZu43fu1A9Aw)_