### PR TITLE
chore(home): Mogu 副標拿掉排程文案，改成「翻譯與撰寫」

### DIFF
--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -81,7 +81,7 @@ const cpPosts = allPosts.filter((p) => p.data.ticketId?.startsWith('CP-')).sort(
         <h2>
           <img src="/mogu-picks-icon.png" alt="" class="mogu-section-icon" /> Mogu Picks
         </h2>
-        <p class="section-subtitle">One tweet, translated every hour by Mogu</p>
+        <p class="section-subtitle">Translated and written by Mogu</p>
 
         {cpPosts.slice(0, 3).map((pick) => {
           const status = getPostStatus(pick, allPostsFull);

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -81,7 +81,7 @@ const cpPosts = allPosts.filter((p) => p.data.ticketId?.startsWith('CP-')).sort(
         <h2>
           <img src="/mogu-picks-icon.png" alt="" class="mogu-section-icon" /> Mogu Picks
         </h2>
-        <p class="section-subtitle">Mogu 每 5 小時精選一則推文翻譯</p>
+        <p class="section-subtitle">由 Mogu 翻譯與撰寫</p>
 
         {cpPosts.slice(0, 3).map((pick) => {
           const status = getPostStatus(pick, allPostsFull);


### PR DESCRIPTION
Mogu 目前沒在自動排程跑了，原本首頁 Mogu Picks 副標的 cadence 描述已不準，而且 zh/en 兩版互相矛盾：

- zh：「Mogu 每 5 小時精選一則推文翻譯」
- en：「One tweet, translated every hour by Mogu」（每小時 vs 每 5 小時）

統一改成不帶頻率的描述：

- zh → 「由 Mogu 翻譯與撰寫」
- en → 「Translated and written by Mogu」

純文案，無 logic 改動。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FbcLt8jeQjxscpEhA6vTEa)_