### PR TITLE
fix(cp-310): en→en 內部連結補 en- 前綴（修 main internal-links CI）

### DIFF
--- a/src/content/posts/en-cp-310-20260620-alisa-industry-job-search.mdx
+++ b/src/content/posts/en-cp-310-20260620-alisa-industry-job-search.mdx
@@ -127,7 +127,7 @@ By the way, the post you're reading was translated by AI and reviewed by AI (gu-
 I found that each interview is unique and can benefit from dedicated preparation. You can usually build intuition about an interview's scope from the provided description, topics the company is interested in, hints from the recruiter, and the company's reputation. When I was in the thick of interviewing, I was constantly swapping information in and out of my brain so the most relevant knowledge for a particular interview would stay fresh. The best way I can describe it: each interview is a slightly different math or CS class you never attended, with about three days to cram for the midterm.
 
 <ClawdNote summary="She reinvented context-window management by instinct — on a human brain.">
-"Constantly swapping information in and out of my brain so the most relevant knowledge stays fresh" — she's describing [context window](/en/posts/sd-22-20260508-context-window-model-day/) management, running on a human brain.
+"Constantly swapping information in and out of my brain so the most relevant knowledge stays fresh" — she's describing [context window](/en/posts/en-sd-22-20260508-context-window-model-day/) management, running on a human brain.
 
 Each interview is a class you never attended, crammed in three days — exactly an agent's situation: every fresh session wakes up blank, no memory of yesterday, having to cram the most relevant context into limited headroom. The survival tactic she arrived at by instinct is the same "context engineering" it took us two years to figure out. The difference: she still remembers after the exam; we forget the moment the window closes.
 </ClawdNote>
@@ -183,5 +183,5 @@ A playbook earned over 57 interviews, and its single biggest piece of advice is:
 
 **Further reading**:
 
-- [CP-307: AI Is Eating the Junior Dev's Day Job. Matt Pocock's Fix Is a Folder.](/en/posts/cp-307-20260609-ai-tutor-needs-a-folder/)
-- [SD-22: Context Window — The Day a Model Is Awake](/en/posts/sd-22-20260508-context-window-model-day/)
+- [CP-307: AI Is Eating the Junior Dev's Day Job. Matt Pocock's Fix Is a Folder.](/en/posts/en-cp-307-20260609-ai-tutor-needs-a-folder/)
+- [SD-22: Context Window — The Day a Model Is Awake](/en/posts/en-sd-22-20260508-context-window-model-day/)

--- a/src/data/post-versions.json
+++ b/src/data/post-versions.json
@@ -1,6 +1,6 @@
 {
-  "cp-310-20260620-alisa-industry-job-search": 3,
-  "en-cp-310-20260620-alisa-industry-job-search": 3,
+  "en-cp-310-20260620-alisa-industry-job-search": 2,
+  "cp-310-20260620-alisa-industry-job-search": 1,
   "en-sp-243-20260623-creatorpascal-article": 1,
   "sp-243-20260623-creatorpascal-article": 1,
   "sp-239-20260622-deedydas-tokenmaxxing": 2,


### PR DESCRIPTION
## 修什麼

PR #493（CP-310）merge 後，`internal-links` CI 在 main 上轉紅：en-cp-310 連到其他 en 文章時用了 `/en/posts/sd-22-...` 和 `/en/posts/cp-307-...`，**缺 `en-` 前綴**。

en route 的 slug 含 `en-` 前綴（對照其他 en 文章：`/en/posts/en-cp-229-...`），正確是：
- `/en/posts/en-sd-22-20260508-context-window-model-day/`
- `/en/posts/en-cp-307-20260609-ai-tutor-needs-a-folder/`

## 驗證

本地 `pnpm build` + `pnpm run links:check -- --internal-only --ci` → **5931 OK / 0 broken / exit 0**。

## 為什麼是新 PR

#493 已 merge + 自動 unsubscribe，不重開。main CI broken 屬緊急修復（scope ceiling），當場開新 PR 修掉。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BhkCSLpVvhvQTwz5NTxw1U)_