### PR TITLE
feat(skills): trim — sub-agent 系統化掃 no-op + 把 no-op test 寫進紀律 SSOT

### DIFF
--- a/.claude/skills/trim/SKILL.md
+++ b/.claude/skills/trim/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: trim
+description: Hunt and cut no-ops from a skill / prompt / agent-instruction file using fresh-eyes sub-agents. Use when the user wants to simplify, trim, declutter, or shrink a skill or prompt, or asks "is this prompt bloated", "remove the no-ops", "this skill is too verbose". Spawns one skeptic sub-agent per target file that runs the no-op test line by line (delete it — does the agent's behavior change? no → cut) and returns a punch list of candidate cuts; the main agent reviews and applies via PR, never silently. Named `trim` to not collide with the built-in `/simplify` (which trims CODE, not prompt prose).
+---
+
+# trim
+
+砍掉 skill / prompt / agent-instruction 檔裡的 **no-op**——那些不管刪不刪、都不會改變 agent 行為的句子。原則（no-op test vs drift、典型 no-op 長相）是 `docs/agent-discipline.md` §📐 的 SSOT，**這裡不複述**，只定義怎麼用 sub-agent 系統化地跑。
+
+## 何時用 / 不用
+
+- **用**：user 說某個 skill/prompt 太肥、要精簡、要 declutter；或剛寫完一個 skill 想自我審查；或定期掃 `.claude/skills/*`。
+- **不用**：改 **code** 的精簡 → 內建 `/simplify`。文章散文 → tribunal。這把刀只對 **agent 指令類散文**（SKILL.md、playbook、prompt、CLAUDE.md/AGENTS.md 這種）。
+
+## Workflow
+
+1. **定目標**。User 指定哪個檔 / 哪個 skill；沒指就問或掃整個 `.claude/skills/`。一個目標檔 = 一個 sub-agent。
+2. **Fan-out skeptic sub-agents**（`Agent` tool，`general-purpose` 或 `Explore` 皆可；無 model-pin 需求所以不必走 script）。每個 sub-agent 拿**一個檔 + 下面的 brief**，**零 parent context**——它不該知道每行「為什麼在那」，才測得出哪行其實是空話。多檔就一個 message 多個 Agent call 並行。
+3. **收 punch list**，自己過一遍（sub-agent 會誤殺 load-bearing 行——尤其專案特有事實、指回 SSOT 的值）。
+4. **改動走 PR**，逐項列「砍什麼 / 為什麼是 no-op / 省多少」，**絕不靜默亂砍**。爭議行留著、標記、問 user。
+
+## 交給每個 sub-agent 的 brief（逐字給，別加 parent context）
+
+> 你是審稿 skeptic。這個檔是 agent 指令（skill / prompt / playbook）。**預設每一行都是 no-op，要它自己證明 load-bearing。** 逐行 / 逐段分類：
+>
+> - **CUT — no-op**：刪掉 agent 行為不會變的句子。典型 = agent 預設本來就會做的事（「要 thorough」「commit 要詳細」「實作要好讀」「仔細思考」「注意 edge case」）、客套、把通用 best-practice 再講一遍。
+> - **CUT — drift**：把抄自別處 SSOT 的具體值（計數、路徑、版本、event 名、套件名）留在散文裡的——該指回來源、不留第二份。
+> - **KEEP — load-bearing**：刪了 agent 行為**會變**的才留。專案特有事實、非顯而易見的 policy、具體指令 / 旗標 / 路徑、明確的反例與 gotcha、改變預設行為的指示。
+>
+> 判準只有一條：**「刪掉這行，agent 輸出會不會變？」** 不變就 CUT。不確定就標 UNSURE 別亂砍。
+>
+> 回傳每個 candidate：被引用的原文（一句或一段）+ verdict（CUT-noop / CUT-drift / KEEP / UNSURE）+ 一句理由 + 粗估省下 token。最後給「原檔約 N 行 → 砍後約 M 行」。
+
+## 鐵規
+
+- **Sub-agent 是 recommender，不是 committer**——它回報 candidate，砍不砍主 agent 決定。
+- **寧可漏砍別誤殺**：load-bearing 行被砍會讓 skill 壞掉、比留個 no-op 嚴重得多。UNSURE 一律留。
+- **吃自己狗糧**：這份 SKILL.md 本身也該過 no-op test。

--- a/docs/agent-discipline.md
+++ b/docs/agent-discipline.md
@@ -74,3 +74,4 @@
 
 - **散文只講 policy / 為什麼**；event 名、套件名、計數、路徑、deny 哪個工具這類具體值一律**指回 code / YAML**，不在散文留第二份（複製事實 = 製造 drift，見上面〈SSOT 紀律〉）。
 - **審查用 Keep / Simplify / Drop**：transient 環境狀態（「本機目前沒裝」）→ Drop；複製 SSOT 的值 → 指回 SSOT；一個原則被一堆特例埋住 → Simplify 成原則。目標是**少而通用、不易過期**，不是加更多條款。
+- **no-op test（Pocock 的刀，跟 drift 互補）**：drift 砍的是「會過期的具體值」，no-op 砍的是「不管過不過期、根本不改變 agent 行為的句子」。檢驗法：把那行刪掉，agent 輸出會變嗎？不變 = no-op，Drop。典型 no-op = agent 預設本來就會做的事——「要 thorough」「commit message 要詳細」「實作要好讀」「仔細思考」。agent 寫的 skill 特別容易整段都是這種空話，難評估、難維護、白燒 token。寫完 prompt / skill 自己過一遍，或用 `/trim` 讓 sub-agent 逐行測。（來源：https://x.com/mattpocockuk/status/2069784839474032896）


### PR DESCRIPTION
## 為什麼

來自 [@mattpocockuk 這則 tweet](https://x.com/mattpocockuk/status/2069784839474032896)：agent 自己寫的 skill 充滿 **no-op**——「要 thorough」「commit 要詳細」「實作要好讀」這種句子。agent 預設本來就會做，刪掉行為不變 = 純燒 token、難評估、難維護。User 想要一套**讓 sub-agent 系統化迭代精簡 skill** 的方法（手動審 prompt 不現實）。

## 改了什麼

1. **`docs/agent-discipline.md` §📐**：把 no-op test 加成 Keep/Simplify/Drop 旁邊的第三把刀。跟現有 drift 審查互補——drift 砍「會過期的具體值」，no-op 砍「不管過不過期都不改變行為的句子」。原則的 SSOT 單一家放這，指回 source tweet。

2. **`.claude/skills/trim/SKILL.md`**（新 skill）：薄 wrapper，fan-out skeptic sub-agent 對 skill/prompt/playbook 逐行跑 no-op test（刪掉行為會變嗎？不變就砍），回 candidate punch list，主 agent review 後**走 PR 套用、絕不靜默亂砍**。
   - 命名避開內建 `/simplify`（那把砍 **code**，不是 prompt 散文）。
   - 原則指回 `agent-discipline.md` §📐 不複述（SSOT 紀律）。

## Smoke test 證據

照 skill workflow 拿 `uiux-auditor`（198 行）當真實目標跑一次 sub-agent，產出乾淨 punch list：
- 抓出 **~380–420 token no-op**，最肥是兩段純設計格言（Core philosophy、Jobs Filter）——不產生任何具體 finding。
- 正確區分 **no-op / drift / KEEP**，~18-20 條 load-bearing 行全留沒誤殺。
- 需查證的標 **UNSURE**（如 `scripts/check-contrast.mjs` 是否存在、L38 引述的 CLAUDE.md 措辭已 drift），不亂砍。

> 本 PR **只建工具 + 驗證**，沒有套用 uiux-auditor 的那些砍法（那是另一個 trim PR 的事）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_0142RJ7R3j3y1TzJ3y4VstZi)_