### PR TITLE
fix(artifact): SP-245 互動小頁不再水平爆框 + CI overflow gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,6 +165,20 @@ jobs:
           retention-days: 1
           if-no-files-found: error
 
+  # Renders key pages (all /artifacts/ + home + an HTML-heavy post) at mobile
+  # and desktop widths and fails if anything blows out the viewport horizontally.
+  # Uses the Playwright dev server (npm run dev), so it does not consume dist/.
+  overflow:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-pnpm
+      - name: Install Chromium
+        run: pnpm exec playwright install chromium --with-deps
+      - name: Check horizontal overflow (mobile + desktop)
+        run: pnpm exec playwright test tests/no-horizontal-overflow.spec.ts --project="Desktop Chrome"
+
   # ─── Tier 2: jobs that consume dist/ ──────────────────────────────────────
   internal-links:
     runs-on: ubuntu-latest
@@ -213,6 +227,7 @@ jobs:
       - build
       - internal-links
       - bundle-budget
+      - overflow
     steps:
       - name: Verify every required job succeeded
         run: |

--- a/src/pages/artifacts/sp-245-trim-noop.astro
+++ b/src/pages/artifacts/sp-245-trim-noop.astro
@@ -102,8 +102,12 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
     --line: rgba(106, 71, 42, 0.18);
     --bad: #c2421f;
     --cool: #2f6f4f;
-    width: min(1040px, calc(100vw - 1.5rem));
+    width: 100%;
+    max-width: 1040px;
     margin: 1.25rem auto 3rem;
+    padding-inline: 0.25rem;
+    box-sizing: border-box;
+    overflow-x: clip;
     position: relative;
     color: var(--ink);
     font-family: 'Noto Sans TC', system-ui, sans-serif;
@@ -117,7 +121,7 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
   .artifact-page::before {
     content: '';
     position: absolute;
-    inset: -1rem -0.75rem;
+    inset: -1rem 0;
     border-radius: 32px;
     background:
       radial-gradient(circle at 18% 8%, rgba(246, 180, 75, 0.4), transparent 32%),

--- a/tests/no-horizontal-overflow.spec.ts
+++ b/tests/no-horizontal-overflow.spec.ts
@@ -1,0 +1,63 @@
+import { test, expect } from '@playwright/test';
+import { readdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+// Renders key pages at mobile + desktop widths and asserts there is NO
+// horizontal overflow — i.e. document.scrollWidth must not exceed the viewport.
+// This is the "you can scroll sideways / the layout blew out" bug. It shows up
+// most often on bespoke /artifacts/ pages and on posts that embed raw HTML,
+// where a width:100vw element or a negative-inset decoration pushes past the
+// viewport edge.
+//
+// Coverage is the high-risk subset on purpose — every /artifacts/ page (auto-
+// discovered) plus the home page and one HTML-heavy post — NOT all ~3k pages,
+// so the gate stays fast. If a blowout ever ships from somewhere else, add the
+// offending route to ROUTES rather than widening to the whole site.
+
+const here = dirname(fileURLToPath(import.meta.url));
+const artifactsDir = resolve(here, '../src/pages/artifacts');
+
+const artifactRoutes = readdirSync(artifactsDir)
+  .filter((f) => f.endsWith('.astro'))
+  .map((f) => `/artifacts/${f.replace(/\.astro$/, '')}/`);
+
+const ROUTES = ['/', '/posts/sp-245-20260624-mattpocockuk-skill-no-op/', ...artifactRoutes];
+
+const WIDTHS = [
+  { label: 'mobile-390', width: 390, height: 844 },
+  { label: 'desktop-1280', width: 1280, height: 800 },
+];
+
+for (const route of ROUTES) {
+  for (const vp of WIDTHS) {
+    test(`no horizontal overflow: ${route} @ ${vp.label}`, async ({ browser }) => {
+      const ctx = await browser.newContext({
+        viewport: { width: vp.width, height: vp.height },
+      });
+      const page = await ctx.newPage();
+      await page.goto(route, { waitUntil: 'networkidle' });
+      const { scrollW, innerW, offenders } = await page.evaluate(() => {
+        const vw = window.innerWidth;
+        const out: string[] = [];
+        document.querySelectorAll('*').forEach((el) => {
+          const r = el.getBoundingClientRect();
+          if (r.right > vw + 1 || r.left < -1) {
+            const cls = typeof el.className === 'string' ? el.className : '';
+            out.push(`${el.tagName}.${cls}`.trim().slice(0, 60));
+          }
+        });
+        return {
+          scrollW: document.documentElement.scrollWidth,
+          innerW: vw,
+          offenders: out.slice(0, 8),
+        };
+      });
+      await ctx.close();
+      expect(
+        scrollW,
+        `Horizontal overflow on ${route} @ ${vp.width}px: scrollWidth ${scrollW} > viewport ${innerW}. First offenders: ${offenders.join(' | ')}`
+      ).toBeLessThanOrEqual(innerW + 1);
+    });
+  }
+}


### PR DESCRIPTION
## 修什麼

SP-245 互動小頁在手機 + 13" laptop 都能**水平捲動**(layout blowout / horizontal overflow)。實測:iPhone 15 Pro scrollWidth 413 vs 393(+20px)、13" 1368 vs 1280(+88px)。

**Root cause**:`.artifact-page` 用 `width: min(1040px, 100vw - 1.5rem)`(**viewport** 寬)但 `margin: auto`(相對**父欄**置中)。BaseLayout 內容欄比 viewport 窄又有 padding,所以這個用 100vw 算寬的元素塞不進父欄、往右爆出去;`::before { inset: -1rem -0.75rem }` 再左右各多撐 0.75rem。

**修法**:寬度改成相對父容器 `width:100%; max-width:1040px; box-sizing:border-box; overflow-x:clip`,`::before` 拿掉水平 bleed。playwright 實測 iPhone 15 Pro / 13" 都 **scrollWidth == viewport(+0px)**。

## CI 防呆(回應你「pre-commit 或 ci?」）

新增 `tests/no-horizontal-overflow.spec.ts`:對**所有 `/artifacts/*`**(自動掃)+ 首頁 + SP-245,在 390 / 1280 兩個寬度斷言無水平溢出(`scrollWidth ≤ viewport`,並印出爆框元素)。串進 ci.yml 新 `overflow` job + `ci-passed` required gate——之後任何 PR 爆框直接擋下、合不進去。

- 放 CI 不放 pre-commit:這檢查要起瀏覽器 render,pre-commit 跑會太慢;CI job 用 Playwright dev server,per-PR gate。
- 本地 spec 10/10 PASS(5 路由 × 2 寬度)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_0142RJ7R3j3y1TzJ3y4VstZi)_