### PR TITLE
content(SP-245): no-op 命名由來 MoguNote + writer prompt 記下 ShroomDog 偏好

### DIFF
--- a/GU-LOG_WRITER_PROMPT.md
+++ b/GU-LOG_WRITER_PROMPT.md
@@ -161,6 +161,7 @@ tags: ['shroom-picks', 'tag2', 'tag3']
 - 補充 context
 - 加入梗/笑點
 - 用類比解釋術語
+- 點出術語的全名 / 出處（尤其縮寫、行話）——ShroomDog 喜歡這樣理解名詞：知道 no-op 是 `no-operation`、來自組合語言的 `NOP` 指令，比死背縮寫好記。遇到專業縮寫時，順手給一次全名 + 由來（一句話、別變維基），讀者會 get 得更深。
 
 **黃金準則**：
 
@@ -332,7 +333,7 @@ gu-log 很多文章（尤其 AI/agent 圈）會引用「寫給模型的指令」
 
 **範例**：
 
-````
+```
 ❌ zh-tw 版直接貼英文 prompt（讀者要在腦中翻譯一次）：
 > When you have enough information to act, act. Do not re-derive facts already
 > established in the conversation...
@@ -341,7 +342,7 @@ gu-log 很多文章（尤其 AI/agent 圈）會引用「寫給模型的指令」
 > 當你掌握的資訊足以行動，就行動。不要重新推導對話裡已經確立的事實、不要
 > 重翻使用者已經拍板的決定，也不要在面向使用者的訊息裡細數你不會採用的選項。
 > 要在幾個做法之間取捨時，給出一個建議，而不是一份完整清單。
-````
+```
 
 ### 文化梗 / Idioms / Reference
 

--- a/src/content/posts/en-sp-245-20260624-mattpocockuk-skill-no-op.mdx
+++ b/src/content/posts/en-sp-245-20260624-mattpocockuk-skill-no-op.mdx
@@ -83,6 +83,10 @@ What do these lines have in common?
 
 They're **no-ops**—they look like they're handing out instructions, but they have zero effect on the model's behavior. An [agent](/en/glossary#agent) already writes good commit messages, already tries to be thorough, already tries to keep the implementation readable. These are its defaults; you don't need a line to ask for them.
 
+<MoguNote>
+Bit of trivia: no-op is short for `no-operation`, borrowed from the `NOP` instruction in assembly — the CPU hits it, burns one cycle, and does nothing, used purely for timing or memory alignment. So asking whether a prompt line is a no-op is the same question: does it actually _operate_ on anything, or is it just a placeholder spinning in place?
+</MoguNote>
+
 The test is simple: delete the line, run it once, and check whether the output changes. It didn't? Then that line was pure decoration.
 
 <MoguNote>

--- a/src/content/posts/sp-245-20260624-mattpocockuk-skill-no-op.mdx
+++ b/src/content/posts/sp-245-20260624-mattpocockuk-skill-no-op.mdx
@@ -85,6 +85,10 @@ import ShroomDogNote from '../../components/ShroomDogNote.astro';
 
 它們是 **no-op**——看起來很像在交代事情，實際上對模型行為零影響。[Agent](/glossary#agent) 本來就會寫好的 commit 訊息、本來就會盡量徹底、本來就會盡量讓實作好讀。這些是它的預設值，不需要特地寫一行去要求它。
 
+<MoguNote>
+插個冷知識：no-op 全名是 `no-operation`，借自組合語言那個叫 `NOP` 的指令——CPU 跑到它就佔一個週期、什麼都不做，純拿來湊時間或記憶體對齊。所以判一行 prompt 是不是 no-op，本質就是問：它到底有沒有真的「動到」什麼，還是只是佔個位子的空轉。
+</MoguNote>
+
 測試方法很簡單：把那行刪掉，跑一次，看輸出有沒有變。沒變？那行就是純粹的擺設。
 
 <MoguNote>

--- a/src/data/post-versions.json
+++ b/src/data/post-versions.json
@@ -1,7 +1,7 @@
 {
+  "en-sp-245-20260624-mattpocockuk-skill-no-op": 5,
+  "sp-245-20260624-mattpocockuk-skill-no-op": 5,
   "en-cp-311-20260624-mikenevermiss-one-person-company-claude": 2,
-  "en-sp-245-20260624-mattpocockuk-skill-no-op": 4,
-  "sp-245-20260624-mattpocockuk-skill-no-op": 4,
   "cp-311-20260624-mikenevermiss-one-person-company-claude": 1,
   "en-sp-242-20260622-sakana-fugu-orchestration-sovereignty": 2,
   "sp-242-20260622-sakana-fugu-orchestration-sovereignty": 2,


### PR DESCRIPTION
## 改什麼

1. **SP-245(zh+en)**:首段定義後加一個 MoguNote,點出 **no-op = `no-operation`**——借自組合語言的 `NOP` 指令(CPU 跑到它佔一個週期、什麼都不做,純拿來湊時間 / 記憶體對齊)。補上術語全名 + 由來,讀者(跟 ShroomDog 一樣)更 get。
2. **`GU-LOG_WRITER_PROMPT.md`**:MoguNote 用途清單加一條——點出術語全名 / 出處(尤其縮寫、行話),**ShroomDog 喜歡這樣理解名詞**;遇縮寫順手給一次全名 + 由來(一句話、別變維基)。

## 備註

- gate 全綠(jingjing / pronoun / prettier / validate-posts / content-integrity);`no-operation` / `NOP` 用 backtick 避晶晶體。
- post-tribunal 追加(一個 MoguNote),frontmatter 分數沿用上次 PASS。內容是純加值(術語解釋),不改既有論點;要重評讓 badge 反映最終版我可以再跑一次 tribunal。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_0142RJ7R3j3y1TzJ3y4VstZi)_