### PR TITLE
content(SP-245): no-op MoguNote 結尾口語化 + kaomoji

### DIFF
--- a/src/content/posts/en-sp-245-20260624-mattpocockuk-skill-no-op.mdx
+++ b/src/content/posts/en-sp-245-20260624-mattpocockuk-skill-no-op.mdx
@@ -84,7 +84,7 @@ What do these lines have in common?
 They're **no-ops**—they look like they're handing out instructions, but they have zero effect on the model's behavior. An [agent](/en/glossary#agent) already writes good commit messages, already tries to be thorough, already tries to keep the implementation readable. These are its defaults; you don't need a line to ask for them.
 
 <MoguNote>
-Bit of trivia: no-op is short for `no-operation`, borrowed from the `NOP` instruction in assembly — the CPU hits it, burns one cycle, and does nothing, used purely for timing or memory alignment. So asking whether a prompt line is a no-op is the same question: does it actually _operate_ on anything, or is it just a placeholder spinning in place?
+Bit of trivia: no-op is short for `no-operation`, borrowed from the `NOP` instruction in assembly — the CPU hits it, burns one cycle, and does nothing, used purely for timing or memory alignment. So asking whether a prompt line is a no-op is the same question: does it actually _operate_ on anything, or is it just a placeholder spinning in place? w(ﾟДﾟ)w
 </MoguNote>
 
 The test is simple: delete the line, run it once, and check whether the output changes. It didn't? Then that line was pure decoration.

--- a/src/content/posts/sp-245-20260624-mattpocockuk-skill-no-op.mdx
+++ b/src/content/posts/sp-245-20260624-mattpocockuk-skill-no-op.mdx
@@ -86,7 +86,7 @@ import ShroomDogNote from '../../components/ShroomDogNote.astro';
 它們是 **no-op**——看起來很像在交代事情，實際上對模型行為零影響。[Agent](/glossary#agent) 本來就會寫好的 commit 訊息、本來就會盡量徹底、本來就會盡量讓實作好讀。這些是它的預設值，不需要特地寫一行去要求它。
 
 <MoguNote>
-插個冷知識：no-op 全名是 `no-operation`，借自組合語言那個叫 `NOP` 的指令——CPU 跑到它就佔一個週期、什麼都不做，純拿來湊時間或記憶體對齊。所以判一行 prompt 是不是 no-op，本質就是問：它到底有沒有真的「動到」什麼，還是只是佔個位子的空轉。
+插個冷知識：no-op 全名是 `no-operation`，借自組合語言那個叫 `NOP` 的指令——CPU 跑到它就佔一個週期、什麼都不做，純拿來湊時間或記憶體對齊。所以判一行 prompt 是不是 no-op，本質就是問：它到底有沒有真的「動到」什麼，還是只是個佔位仔w(ﾟДﾟ)w
 </MoguNote>
 
 測試方法很簡單：把那行刪掉，跑一次，看輸出有沒有變。沒變？那行就是純粹的擺設。

--- a/src/data/post-versions.json
+++ b/src/data/post-versions.json
@@ -1,6 +1,6 @@
 {
-  "en-sp-245-20260624-mattpocockuk-skill-no-op": 5,
-  "sp-245-20260624-mattpocockuk-skill-no-op": 5,
+  "en-sp-245-20260624-mattpocockuk-skill-no-op": 6,
+  "sp-245-20260624-mattpocockuk-skill-no-op": 6,
   "en-cp-311-20260624-mikenevermiss-one-person-company-claude": 2,
   "cp-311-20260624-mikenevermiss-one-person-company-claude": 1,
   "en-sp-242-20260622-sakana-fugu-orchestration-sovereignty": 2,


### PR DESCRIPTION
SP-245 no-op 命名由來 MoguNote 結尾改口語：「佔個位子的空轉」→「個佔位仔 w(ﾟДﾟ)w」，en 結尾也補上同一個 kaomoji。zh + en 雙版，gate 全綠。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0142RJ7R3j3y1TzJ3y4VstZi)_