### PR TITLE
fix(kaomoji): kaomoji 永不斷行 + pre-commit/CI gate

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -609,6 +609,22 @@ if [ -n "$CONTENT_GATE_MDX" ]; then
 fi
 echo ""
 
+# ─── Step 1.9: Kaomoji unbreakable gate ─────────────────────────
+# Kaomoji must never split across a line (prod bug: w(ﾟДﾟ)w wrapped mid-face).
+# Locks remark-kaomoji-nowrap's coverage of the known kaomoji set and flags any
+# halfwidth-katakana bracket group it doesn't protect. Cheap pure-node — runs
+# unconditionally so a plugin regression is caught even without a post staged.
+echo "🙂 Kaomoji unbreakable check..."
+if ! node "$REPO_ROOT/scripts/check-kaomoji-unbreakable.mjs"; then
+    echo ""
+    echo "❌ Kaomoji unbreakable check FAILED."
+    echo "   A kaomoji can split across lines. Add its signal glyph to KAOMOJI_CHARS"
+    echo "   in src/plugins/remark-kaomoji-nowrap.mjs and its face to CORPUS in"
+    echo "   scripts/check-kaomoji-unbreakable.mjs."
+    exit 1
+fi
+echo ""
+
 # ─── Step 2: Content integrity BDD tests (Playwright) ────────────
 # Only run when posts/*.mdx are staged (tests validate post content integrity)
 if [ -f "$REPO_ROOT/tests/content-integrity.spec.ts" ] && [ -n "$STAGED_MDX" ]; then

--- a/scripts/check-kaomoji-unbreakable.mjs
+++ b/scripts/check-kaomoji-unbreakable.mjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+/**
+ * check-kaomoji-unbreakable
+ *
+ * Guards that kaomoji never split across a line break (see the prod bug where
+ * `w(ﾟДﾟ)w` wrapped mid-face). The actual protection lives in
+ * src/plugins/remark-kaomoji-nowrap.mjs (it interleaves Word Joiners at build);
+ * this gate locks that protection so a regression — or a new kaomoji whose
+ * glyphs the plugin doesn't recognise — is caught in CI + pre-commit instead of
+ * shipping breakable.
+ *
+ * HARD failures (exit 1):
+ *   1. A curated corpus kaomoji is not detected/protected (regression lock).
+ *   2. A kaomoji the plugin DOES detect in a post still has a break opportunity
+ *      after protection (plugin output sanity).
+ *   3. A negative (ordinary parenthetical) gets wrongly modified.
+ *
+ * WARN (non-blocking): a bracketed group in a post that contains a kana /
+ * halfwidth signal and stays breakable after protection — a *possible* missed
+ * kaomoji. Not a hard fail because real Japanese parentheticals would false-
+ * positive; when a warning is a genuine kaomoji, add its glyph to the plugin's
+ * KAOMOJI_CHARS and its face to CORPUS below, which promotes it to a hard lock.
+ *
+ * Usage: node scripts/check-kaomoji-unbreakable.mjs
+ */
+
+import { readdirSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { protectKaomoji, hasBreakOpportunity } from '../src/plugins/remark-kaomoji-nowrap.mjs';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const postsDir = resolve(here, '../src/content/posts');
+
+// Curated set: the writer-prompt recommended list + faces actually used across
+// posts + every reported breakage. Add here when a new kaomoji shape appears.
+const CORPUS = [
+  '(◕‿◕)',
+  '(￣▽￣)／',
+  '╰(°▽°)╯',
+  '(๑•̀ㅂ•́)و✧',
+  '(｡◕‿◕｡)',
+  'ヽ(°〇°)ﾉ',
+  '(⌐■_■)',
+  '(╯°□°)╯',
+  '┐(￣ヘ￣)┌',
+  '(¬‿¬)',
+  '٩(◕‿◕｡)۶',
+  '(ﾉ◕ヮ◕)ﾉ*:･ﾟ✧',
+  'ʕ•ᴥ•ʔ',
+  '(ง •̀_•́)ง',
+  '(๑•́ ₃ •̀๑)',
+  'w(ﾟДﾟ)w',
+  '(´・ω・`)',
+  '(；ω；)',
+  '(⊙_⊙)',
+  '(つ﹏⊂)',
+  '(≧▽≦)',
+  '(ノಠ益ಠ)ノ',
+  '(◍˃̶ᗜ˂̶◍)ノ',
+  '(•̀ᴗ•́)و',
+  '(๑˃ᴗ˂)ﻭ',
+  '( •̀ ω •́ )✧',
+];
+
+// Ordinary parentheticals that must NEVER be treated as kaomoji. Includes
+// inline-code parens (the backtick false-positive that bit us once).
+const NEGATIVES = [
+  'This is (a normal sentence) here',
+  'console.log(value)',
+  'Step (1) is important',
+  '（99.5% → 89.5%）',
+  '（收益）',
+  '(see SP-194)',
+  '（`Cmd+D`）往右切',
+  '（例如 `SP.next: 152`）',
+  '（`agent/agent.py`）當病人',
+];
+
+// Soft-warning scan only. Halfwidth katakana (U+FF65–FF9F) almost never appears
+// in real prose, so a bracket group containing it that the plugin does NOT
+// already protect is very likely a kaomoji we forgot to cover.
+const HALFWIDTH_KATAKANA = /[･-ﾟ]/u;
+const BRACKET_GROUP = /[wWmMqQ]?[（(][^\n\r()（）]{1,28}[）)]/gu;
+
+export function check() {
+  const hard = [];
+  const warn = [];
+
+  // 1. Corpus regression lock — every known kaomoji must be detected AND atomic.
+  for (const k of CORPUS) {
+    const p = protectKaomoji(k);
+    if (p === k)
+      hard.push(
+        `corpus kaomoji NOT detected by plugin: ${JSON.stringify(k)} (add its glyph to KAOMOJI_CHARS)`
+      );
+    else if (hasBreakOpportunity(p))
+      hard.push(
+        `corpus kaomoji still breakable after protect: ${JSON.stringify(k)} -> ${JSON.stringify(p)}`
+      );
+  }
+
+  // 2. Ordinary parentheticals must stay untouched (no false positives).
+  for (const n of NEGATIVES) {
+    if (protectKaomoji(n) !== n) hard.push(`ordinary text wrongly modified: ${JSON.stringify(n)}`);
+  }
+
+  // 3. Soft scan: halfwidth-katakana bracket groups the plugin misses.
+  const files = readdirSync(postsDir).filter((f) => f.endsWith('.mdx'));
+  const warned = new Set();
+  for (const f of files) {
+    const text = readFileSync(resolve(postsDir, f), 'utf8');
+    for (const m of text.matchAll(BRACKET_GROUP)) {
+      const cand = m[0];
+      if (!HALFWIDTH_KATAKANA.test(cand)) continue;
+      if (protectKaomoji(cand) === cand && !warned.has(cand)) {
+        warned.add(cand);
+        warn.push(`possible un-protected kaomoji in ${f}: ${JSON.stringify(cand)}`);
+      }
+    }
+  }
+
+  return { ok: hard.length === 0, hard, warn };
+}
+
+// CLI
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const { ok, hard, warn } = check();
+  if (warn.length) {
+    console.warn(
+      `⚠️  ${warn.length} possible un-protected kaomoji (review; add to plugin + CORPUS if real):`
+    );
+    warn.forEach((w) => console.warn('   ' + w));
+  }
+  if (!ok) {
+    console.error(`\n❌ kaomoji unbreakable check FAILED (${hard.length}):`);
+    hard.forEach((h) => console.error('   ' + h));
+    process.exit(1);
+  }
+  console.log(
+    `✓ kaomoji unbreakable: ${CORPUS.length} corpus + all plugin-detected post kaomoji are atomic`
+  );
+}

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -609,6 +609,22 @@ if [ -n "$CONTENT_GATE_MDX" ]; then
 fi
 echo ""
 
+# ─── Step 1.9: Kaomoji unbreakable gate ─────────────────────────
+# Kaomoji must never split across a line (prod bug: w(ﾟДﾟ)w wrapped mid-face).
+# Locks remark-kaomoji-nowrap's coverage of the known kaomoji set and flags any
+# halfwidth-katakana bracket group it doesn't protect. Cheap pure-node — runs
+# unconditionally so a plugin regression is caught even without a post staged.
+echo "🙂 Kaomoji unbreakable check..."
+if ! node "$REPO_ROOT/scripts/check-kaomoji-unbreakable.mjs"; then
+    echo ""
+    echo "❌ Kaomoji unbreakable check FAILED."
+    echo "   A kaomoji can split across lines. Add its signal glyph to KAOMOJI_CHARS"
+    echo "   in src/plugins/remark-kaomoji-nowrap.mjs and its face to CORPUS in"
+    echo "   scripts/check-kaomoji-unbreakable.mjs."
+    exit 1
+fi
+echo ""
+
 # ─── Step 2: Content integrity BDD tests (Playwright) ────────────
 # Only run when posts/*.mdx are staged (tests validate post content integrity)
 if [ -f "$REPO_ROOT/tests/content-integrity.spec.ts" ] && [ -n "$STAGED_MDX" ]; then

--- a/src/plugins/remark-kaomoji-nowrap.mjs
+++ b/src/plugins/remark-kaomoji-nowrap.mjs
@@ -1,74 +1,122 @@
 /**
  * remark-kaomoji-nowrap
  *
- * Remark plugin that prevents kaomoji from being split by word-wrap.
+ * Remark plugin that stops kaomoji from being split across a line break.
  *
- * Strategy (Option 3 — content-layer fix):
- *   1. Replace ASCII spaces inside kaomoji with NBSP (\u00A0)
- *   2. Insert Word Joiner (\u2060) between closing bracket and arm characters
+ * Strategy (content-layer, zero-CSS — works in any renderer: RSS, email, …):
+ *   1. Replace ASCII spaces inside a kaomoji with NBSP (U+00A0).
+ *   2. Insert a Word Joiner (U+2060) between EVERY adjacent code point of the
+ *      kaomoji, so there is no break opportunity anywhere inside it.
  *
- * This is invisible, zero-CSS, and works in any renderer (RSS, email, etc.)
+ * Why interleave WJ everywhere instead of only at "arm" boundaries: a kaomoji
+ * that contains CJK / halfwidth-katakana / Cyrillic glyphs (e.g. w(ﾟДﾟ)w,
+ * (´・ω・`), (；ω；)) has Unicode line-break opportunities *between* those
+ * inner glyphs, not just at the arms. Joining only the arms left those mid-face
+ * breaks live. Interleaving WJ is invisible and makes the whole glyph atomic.
+ *
+ * Coverage is locked by scripts/check-kaomoji-unbreakable.mjs (CI + pre-commit):
+ * if a kaomoji isn't detected/protected here, that gate fails — add its signal
+ * glyph to KAOMOJI_CHARS (or its decoration to ARM_CHARS) and re-run.
  */
 
 import { visit } from 'unist-util-visit';
 
-const NBSP = '\u00A0';
-const WJ = '\u2060';
+const NBSP = ' ';
+const WJ = '⁠';
 
-// Characters that signal "this bracketed text is a kaomoji, not regular text"
-// Includes common face parts: eyes, mouths, cheeks, decorative marks
-/* eslint-disable no-misleading-character-class -- ᗜ̶ is intentionally a combined character (ᗜ + U+0336 strikethrough) */
-const KAOMOJI_CHARS = /[°□▽￣ᴥᴗ◍๑˃˂ᗜ̶ಠ∀ω·•‿ᵕ╥﹏☆ᴗ⁰]/;
+// Glyphs that mark a bracketed group as a kaomoji rather than ordinary
+// parenthetical prose. Only add glyphs that essentially never appear in normal
+// "(...)" text — each one here can turn a real parenthetical into a (harmless
+// but pointless) nowrap span. Eyes / mouths / cheeks / brows + halfwidth
+// katakana (U+FF65–FF9F, e.g. ﾟ ﾉ ･ ｡) + a few Cyrillic/symbol eyes.
+/* eslint-disable no-misleading-character-class -- combining marks (̀ ́ ̶) ride on base glyphs intentionally */
+// NOTE: do NOT add the backtick ` here — inline-code parentheticals like
+// （`Cmd+D`）are prose, not kaomoji. (´・ω・`) is still detected via ´ / ・ / ω.
+const KAOMOJI_CHARS = /[°□▽△￣ᴥᴗᵕ◍◔◕๑˃˂ᗜಠ∀ω·•‿╥﹏☆⁰¬⌐■ヘヮД´・⊂⊃⊙≧≦ㅂ₃ง･-ﾟ]/u;
 /* eslint-enable no-misleading-character-class */
 
-// Arm / trailing characters that follow the closing bracket
-const ARM_CHARS = '[╯ﻭ／ノ┻━"ゞ☆♪♡]';
-// Match potential kaomoji:
-//   Pattern A: ʕ ... ʔ  (bear-style)
-//   Pattern B: ( ... )  or （ ... ）  followed by optional arm chars
+// Decoration / arm glyphs that flank the bracket group (leading or trailing),
+// e.g. ╰(°▽°)╯, ヽ(°〇°)ﾉ, ٩(◕‿◕｡)۶, (ﾉ◕ヮ◕)ﾉ*:･ﾟ✧. Halfwidth katakana is
+// included via the range so ﾉ / ﾟ / ･ count as arms too.
+const ARM_CHARS = '[╯╰ノヽヾ┐┌┘└┻━ゞ☆♪♡✧＊*:。۶٩وﻭงノ／＼＾^＞＜≧≦\\uFF65-\\uFF9F]';
+
+// A kaomoji candidate:
+//   Pattern A: ʕ … ʔ                         (bear-style)
+//   Pattern B: [arms] ( … ) [arms]           (paren-based, optional flanking arms)
 const POTENTIAL_KAOMOJI = new RegExp(
   '(?:' +
-    'ʕ[^\\n\\r]{1,15}ʔ' + // bear: ʕ•ᴥ•ʔ
+    'ʕ[^\\n\\r]{1,18}ʔ' +
     '|' +
-    '[（(][^\\n\\r()（）]{1,25}[）)]' +
     ARM_CHARS +
-    '*' + // paren-based + arms
+    '{0,4}' +
+    '[（(][^\\n\\r()（）]{1,28}[）)]' +
+    ARM_CHARS +
+    '{0,8}' +
     ')',
-  'g'
+  'gu'
 );
 
 /**
- * Protect a single kaomoji match:
- *   - Replace internal ASCII spaces with NBSP
- *   - Insert WJ between closing bracket and arm characters
+ * Make a single kaomoji match unbreakable: NBSP for spaces, then a Word Joiner
+ * between every adjacent code point. Idempotent — re-running adds no extra WJ.
  */
 function protect(match) {
-  let result = match;
-
-  // 1. Replace ASCII spaces with NBSP (idempotent: NBSP stays NBSP)
-  result = result.replace(/ /g, NBSP);
-
-  // 2. Insert WJ between closing bracket and arm
-  //    e.g. )／  →  )⁠／      )╯  →  )⁠╯
-  //    Only insert if WJ not already there (idempotent)
-  result = result.replace(
-    new RegExp('([）)ʔ])(?!' + WJ + ')(' + ARM_CHARS + ')', 'g'),
-    `$1${WJ}$2`
-  );
-
-  return result;
+  const withNbsp = match.replace(/ /g, NBSP);
+  const cps = Array.from(withNbsp); // iterate by code point, not UTF-16 unit
+  let out = '';
+  for (let i = 0; i < cps.length; i++) {
+    out += cps[i];
+    const next = cps[i + 1];
+    if (next !== undefined && cps[i] !== WJ && next !== WJ) out += WJ;
+  }
+  return out;
 }
 
 /**
- * Process a text string: find kaomoji and protect them.
- * Exported for unit testing.
+ * Find kaomoji in a text string and protect them. Exported for the gate + tests.
  */
 export function protectKaomoji(text) {
   return text.replace(POTENTIAL_KAOMOJI, (match) => {
-    // Only transform if it actually looks like a kaomoji (contains face chars)
+    // Structural shape matched — only transform if it actually looks like a
+    // kaomoji (contains a face glyph), so normal "(see note)" stays untouched.
     if (!KAOMOJI_CHARS.test(match)) return match;
     return protect(match);
   });
+}
+
+// Code points whose Unicode line-break class permits a break with the glyph
+// next to them even without a space: CJK ideographs, kana (full + halfwidth),
+// Hangul, CJK symbols/punct, Thai. Latin letters / ASCII punctuation / most
+// symbols do NOT break without a space, so a kaomoji's outer "w(…)w" letter
+// boundaries are safe and must not be flagged.
+function breakable(ch) {
+  const cp = ch.codePointAt(0);
+  return (
+    (cp >= 0x3040 && cp <= 0x30ff) || // hiragana + katakana
+    (cp >= 0x3000 && cp <= 0x303f) || // CJK symbols & punctuation
+    (cp >= 0x4e00 && cp <= 0x9fff) || // CJK unified ideographs
+    (cp >= 0xac00 && cp <= 0xd7a3) || // Hangul syllables
+    (cp >= 0xff65 && cp <= 0xff9f) || // halfwidth katakana
+    (cp >= 0x0e00 && cp <= 0x0e7f) || // Thai (complex breaking)
+    /\s/.test(ch)
+  );
+}
+
+/**
+ * Reports whether a string still has a real internal line-break opportunity:
+ * two adjacent code points with no Word Joiner / NBSP between them where at
+ * least one side is in a breakable script. Exported so the gate can assert a
+ * protected kaomoji is fully atomic.
+ */
+export function hasBreakOpportunity(s) {
+  const cps = Array.from(s);
+  for (let i = 0; i < cps.length - 1; i++) {
+    const a = cps[i];
+    const b = cps[i + 1];
+    if (a === WJ || a === NBSP || b === WJ || b === NBSP) continue;
+    if (breakable(a) || breakable(b)) return true;
+  }
+  return false;
 }
 
 /**

--- a/tests/kaomoji-unbreakable.test.ts
+++ b/tests/kaomoji-unbreakable.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect } from 'vitest';
-// @ts-expect-error — .mjs gate module has no type declarations
 import { check } from '../scripts/check-kaomoji-unbreakable.mjs';
 
 // CI gate (runs in the `unit-tests` vitest job): every known kaomoji must be

--- a/tests/kaomoji-unbreakable.test.ts
+++ b/tests/kaomoji-unbreakable.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+// @ts-expect-error — .mjs gate module has no type declarations
+import { check } from '../scripts/check-kaomoji-unbreakable.mjs';
+
+// CI gate (runs in the `unit-tests` vitest job): every known kaomoji must be
+// detected and made unbreakable by remark-kaomoji-nowrap, and no ordinary
+// parenthetical may be wrongly modified. Mirrors scripts/check-kaomoji-
+// unbreakable.mjs, which also runs in pre-commit.
+describe('kaomoji never split across a line', () => {
+  const { ok, hard, warn } = check();
+
+  it('every corpus kaomoji is detected and atomic; no false positives', () => {
+    expect(hard, hard.join('\n')).toEqual([]);
+    expect(ok).toBe(true);
+  });
+
+  it('surfaces any possible un-protected kaomoji as a warning (non-blocking)', () => {
+    if (warn.length) console.warn('kaomoji warnings:\n' + warn.join('\n'));
+    expect(Array.isArray(warn)).toBe(true);
+  });
+});


### PR DESCRIPTION
## 問題

prod 上 `w(ﾟДﾟ)w` 從中間斷行(`ﾟ`|`Д`,半形片假名/CJK 字之間有 Unicode 斷點)。既有的 `remark-kaomoji-nowrap` plugin 漏了:`KAOMOJI_CHARS` 沒含 `ﾟ`/`Д` → 沒偵測到;且只保護「空格→NBSP、手臂→WJ」,擋不到括號內的字間斷點。而且那支 plugin 的 node:test 根本沒進 CI(vitest 只 glob `tests/**/*.test.ts`)。

## 改什麼

1. **plugin**(`src/plugins/remark-kaomoji-nowrap.mjs`):
   - `protect()` 改成**在 kaomoji 每個字元間插 Word Joiner (U+2060)** → 整串 atomic、任何字間都不可斷(對上你說的「含 unbreakable UTF-8 字元」)。
   - `KAOMOJI_CHARS` 補半形片假名範圍(U+FF65–FF9F)+ `Д` + 符號眼(◕⊙≧≦…);`ARM_CHARS` 補尾端裝飾。
   - **移除誤加的反引號**——`（\`Cmd+D\`）` 這種 inline-code parenthetical 是 prose 不是 kaomoji。
   - 新增 `hasBreakOpportunity()`(只在至少一邊是會斷字類時算斷點,所以 `)w` 不誤判)。
2. **gate**:
   - `scripts/check-kaomoji-unbreakable.mjs`——**corpus 鎖 26 個已知 kaomoji** 全部 protect 後不可斷 + negatives(含 inline-code paren)不被誤動 + 半形片假名漏網 soft-warn。
   - `tests/kaomoji-unbreakable.test.ts`——讓 gate 進 **CI vitest**(unit-tests job 自動跑)。
   - **pre-commit**(`.githooks/` 與 `scripts/hooks/` 同步)無條件跑 gate。

## 驗證

- corpus 26 個全 unbreakable、6+ negatives 零誤動。
- `pnpm build` 過;built sp-245 實際輸出 `w(ﾟДﾟ)w`(4 個 WJ)→ **PROTECTED**。
- vitest 2 passed;pre-commit gate 綠。

新型 kaomoji 出現時:加 glyph 到 `KAOMOJI_CHARS` + face 到 `CORPUS` → 自動升級成 hard lock。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_0142RJ7R3j3y1TzJ3y4VstZi)_