### PR TITLE
content(SP-246): mitchellh〈Defining Taste〉— 品味在 AI 時代成為關鍵差異化

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,7 +1,17 @@
+import { existsSync } from 'node:fs';
 import { defineConfig, devices } from '@playwright/test';
 
 const baseURL = process.env.PLAYWRIGHT_BASE_URL || 'http://127.0.0.1:4321';
 const useRemoteBaseURL = Boolean(process.env.PLAYWRIGHT_BASE_URL);
+
+// CCC sandboxes pre-install a pinned Chromium under PLAYWRIGHT_BROWSERS_PATH whose
+// build number can lag what playwright-core wants, and the on-demand download is
+// blocked by the sandbox proxy (ECONNREFUSED). When that pre-installed binary
+// exists, point Chromium projects at it instead of letting Playwright resolve a
+// missing build. On mac / CI (where the path is absent) executablePath stays
+// undefined and Playwright's default resolution is untouched.
+const preinstalledChromium = '/opt/pw-browsers/chromium';
+const chromiumExecutablePath = existsSync(preinstalledChromium) ? preinstalledChromium : undefined;
 
 const reporter = [['list']] as NonNullable<ReturnType<typeof defineConfig>['reporter']>;
 
@@ -48,12 +58,18 @@ export default defineConfig({
       name: 'Desktop Chrome',
       use: {
         ...devices['Desktop Chrome'],
-        launchOptions: { args: ['--no-sandbox', '--disable-setuid-sandbox'] },
+        launchOptions: {
+          args: ['--no-sandbox', '--disable-setuid-sandbox'],
+          executablePath: chromiumExecutablePath,
+        },
       },
     },
     {
       name: 'Mobile Chrome',
-      use: { ...devices['Pixel 5'] },
+      use: {
+        ...devices['Pixel 5'],
+        launchOptions: { executablePath: chromiumExecutablePath },
+      },
     },
     {
       name: 'Mobile Safari',

--- a/scripts/article-counter.json
+++ b/scripts/article-counter.json
@@ -5,7 +5,7 @@
     "description": "Original articles written by ShroomDog"
   },
   "SP": {
-    "next": 246,
+    "next": 247,
     "label": "Gu-log Picks",
     "description": "Articles picked by ShroomDog, translated by Mogu (branded Gu-log Picks / GP-; slug stays sp-)"
   },

--- a/src/content/posts/en-sp-246-20260628-mitchellh-defining-taste.mdx
+++ b/src/content/posts/en-sp-246-20260628-mitchellh-defining-taste.mdx
@@ -1,0 +1,148 @@
+---
+ticketId: 'SP-246'
+title: "Taste Isn't Valuable Because You Can't Copy It — It's Valuable Because It Defines What Everyone Else Chooses to Copy"
+originalDate: '2026-06-27'
+translatedDate: '2026-06-28'
+translatedBy:
+  model: "Opus 4.5"
+  harness: "Claude Code CLI"
+  pipeline:
+    - role: "Written"
+      model: "Opus 4.5"
+      harness: "Claude Code CLI"
+    - role: "Translated"
+      model: "Opus 4.5"
+      harness: "Claude Code CLI"
+source: '@mitchellh on X'
+sourceUrl: 'https://x.com/mitchellh/status/2070665127331037290'
+lang: 'en'
+summary: 'Mitchell Hashimoto tries to define "taste": consistently making high-quality qualitative judgments where no objective metric exists. People say taste is worthless because it is easy to copy — but that proves the opposite: without someone with taste making the thing first, there is nothing to copy.'
+tags: ['shroom-picks', 'taste', 'ai', 'production']
+scores:
+  tribunalVersion: 9
+  vibe:
+    persona: 8
+    clawdNote: 9
+    vibe: 8
+    narrative: 8
+    score: 8
+    date: "2026-06-28"
+    model: "claude-opus-4-5"
+  factCheck:
+    accuracy: 9
+    fidelity: 9
+    consistency: 9
+    sourceBoundary: 9
+    commentarySeparation: 9
+    score: 9
+    date: "2026-06-28"
+    model: "claude-opus-4-8"
+  librarian:
+    glossary: 8
+    crossRef: 9
+    sourceAlign: 9
+    attribution: 9
+    score: 8
+    date: "2026-06-28"
+    model: "claude-opus-4-8"
+  freshEyes:
+    readability: 9
+    firstImpression: 8
+    payoffDensity: 8
+    lengthFit: 9
+    clarity: 9
+    score: 8
+    date: "2026-06-28"
+    model: "claude-opus-4-8"
+---
+
+import ClawdNote from '../../components/ClawdNote.astro';
+
+The word "taste" has been coming up in AI circles with suspicious frequency lately.
+
+From [Andrej Karpathy](/glossary#andrej-karpathy) to Y Combinator partners, everyone is saying "taste is the scarcest thing in the AI era," "the future belongs to taste," "execution will be eaten by AI, taste is the moat." But when you press them on what taste actually *is*, the answers start to slip — they talk about feelings, experience, you-know-it-when-you-see-it. As if taste is a gift you either have or you don't, nothing more to say.
+
+Mitchell Hashimoto doesn't think so. He dropped a long post on X, trying to give the word an operational definition — and in the process, punctured a popular illusion.
+
+## An Operational Definition of Taste
+
+The definition fits in one sentence, but it's packed:
+
+> Taste is the ability to consistently make high-quality qualitative judgments where no objective metric exists.
+
+The key word is "consistently" — a person with taste doesn't just get lucky once and bet right. They can, again and again, make decisions that feel right in places where there's no standard answer. The thing they produce feels intuitively correct, but if you ask "why is it correct," you'd struggle to give a quantifiable proof.
+
+But here's an observation that trips people up:
+
+> The funny thing about taste is that it's hard to create, but its result is very easy to copy. Once someone makes a tasteful decision, others can imitate it almost immediately.
+
+The result of taste is extremely easy to copy. Once someone with taste makes a decision, others can imitate it almost instantly. This is usually wheeled out as evidence that taste is worthless — no matter how much style you put into something, someone else can copy it in a week or two, so what's the big deal?
+
+<ClawdNote summary="In the AI era the cost of copying has collapsed — which is exactly the anxiety Mitchell is about to answer.">
+This "easy to copy" observation gets scarier in the AI era. Copying a tasteful product used to require a whole team reverse-engineering for months; now you hand Claude a screenshot and a description, and a few hours later you might get something 80% as good. The cost of copying has collapsed faster than people realize, which is why so many people are anxious: if even the stuff I make can be instantly copied, what do I have left? What Mitchell says next is exactly the antidote to this anxiety — but the antidote isn't "how to make it uncopyable." It's a different angle on the whole thing.
+</ClawdNote>
+
+---
+
+## "Easy to Copy" Proves the Opposite
+
+The logic actually flips:
+
+> This is usually an argument against the existence of taste: "look how easy I can copy your work!" And yet, you couldn't create the work without first having someone to copy it from. One has taste, the other doesn't.
+
+Copying is fast, so taste is worthless? Flip it around: if no one with taste made the thing first, everyone else would have no idea what to copy. It doesn't matter how fast you can copy — someone had to blaze the trail first. That person has taste; the copier doesn't.
+
+<ClawdNote>
+This is a clean counterpunch. "Easy to copy" isn't evidence that taste is worthless — quite the opposite. "Easy to copy" proves taste exists and only a few people can do it. If taste didn't exist, if anyone could produce the same quality, there would be nothing to copy. It's precisely because taste is scarce that so many people are copying.
+</ClawdNote>
+
+---
+
+## Production Is Being Commoditized. Taste Isn't.
+
+Taste has always existed. So why is it suddenly becoming a critical differentiator?
+
+> There have always been people with consistently good taste. But taste is coming up more regularly than ever before. It is becoming a critical differentiator.
+
+> For most of history, the ability to convert an idea to reality was itself valuable. Today, production is arguably rapidly becoming abundant. A single person with a defined vision (from anyone) can create what once required an entire team. This is, of course, largely driven by AI and partially driven simply by higher levels of abstraction.
+
+For most of history, the ability to turn an idea into reality was itself valuable. Not many people could code, not many could design, even fewer could ship a product end-to-end — so if you could build, you were valuable. But today, production is rapidly becoming abundant. A single person with a clear vision, armed with AI and higher levels of abstraction, can create what used to require an entire team.
+
+And here's the key asymmetry:
+
+> Production is being commoditized much much faster than taste. It's an open question of whether AI will be able to produce "taste." For now, the ability to create qualitatively new judgments remains distinctly human.
+
+Production is being commoditized much faster than taste. Whether AI will be able to produce taste is still an open question; but for now, the ability to create qualitatively new judgments remains distinctly human. AI can generate code, design mockups, copy, a hundred candidate options — but "picking the right one out of a hundred" is still a human job.
+
+<ClawdNote summary="When everyone can execute with AI, what wins is the judgment calls made where there's no standard answer.">
+Reading this on gu-log feels like being called out. This site is living proof of what Mitchell is describing: one person plus a bunch of agents, producing at a scale and quality that used to be impossible. But flip it around: if everyone can do that, what actually decides who wins? The answer isn't how well you use AI — it's the choices you make in places with no standard answer. Whether to write this piece, whether that angle is worth pushing, how hard to roast in the ClawdNote. The number of people who can execute went up; the number of people who can judge didn't follow.
+
+By the way, "qualitatively new" is a subtle phrase — not judging "good" or "bad," but making judgments that are qualitatively new. Taste isn't just picking the best from existing options; it's being able to open a road no one has walked yet. That ability is far scarcer than "choosing between A and B."
+</ClawdNote>
+
+---
+
+## Taste Defines What to Copy
+
+The final blow:
+
+> Taste isn't valuable because it's impossible to copy. Taste is valuable exactly because it defines what everyone else chooses to copy. Taste has always existed! But now we value it more.
+
+Taste isn't valuable because it can't be copied. Taste is valuable precisely because it defines what everyone else chooses to copy. Taste is the trailblazer — the first person in the world to make a certain decision defines the direction an entire crowd follows. The followers can be many, fast, nearly identical — but the spot at the front of the trail only fits one.
+
+<ClawdNote>
+The question of whether AI can produce taste is a bit like asking whether AI can be funny. Today's AI can generate text that fits the structure of a joke, can mimic a certain style of humor — but have you ever actually laughed at an AI's original joke? Taste might be the same thing: AI can imitate decisions that tasteful people have made, but can it make the "first" tasteful decision? That's a different matter. Mitchell says "for now," meaning that door isn't locked forever — but for now, it's still shut.
+</ClawdNote>
+
+One last detail: this post was written on a plane, with no WiFi, in Apple Notes, entirely by hand. Mitchell makes a point of emphasizing he wrote it himself every time he posts — in an era where AI can generate anything, "handwritten" has become a kind of declaration.
+
+## Conclusion
+
+Next time someone says "the future belongs to taste," you can follow up: that's not because taste can't be copied — it's because taste defines what to copy (｡•̀ᴗ-)✧
+
+---
+
+## Further Reading
+
+- [SP-241: Mitchell Hashimoto on Ghostty's Startup Speed Tradeoffs](/en/posts/en-sp-241-20260622-mitchellh-ghostty-startup-tradeoffs/) — same author, another masterclass in tradeoffs
+- [SP-228: Turning Research Taste Into a Deliberate Loop](/en/posts/en-sp-228-20260610-research-taste-loop/) — if taste can be practiced deliberately, what does the loop look like

--- a/src/content/posts/sp-246-20260628-mitchellh-defining-taste.mdx
+++ b/src/content/posts/sp-246-20260628-mitchellh-defining-taste.mdx
@@ -1,0 +1,145 @@
+---
+ticketId: 'SP-246'
+title: '品味的真正價值不是「抄不走」，而是它決定了所有人選擇去抄什麼'
+originalDate: '2026-06-27'
+translatedDate: '2026-06-28'
+translatedBy:
+  model: "Opus 4.5"
+  harness: "Claude Code CLI"
+  pipeline:
+    - role: "Written"
+      model: "Opus 4.5"
+      harness: "Claude Code CLI"
+source: '@mitchellh on X'
+sourceUrl: 'https://x.com/mitchellh/status/2070665127331037290'
+lang: 'zh-tw'
+summary: 'Mitchell Hashimoto 試著定義「品味」這個越來越常被提起、卻越來越難說清楚的詞：在沒有客觀指標可衡量的地方，持續做出高品質的主觀判斷。有人說品味的結果太好抄了所以不值錢——但這恰恰證明了相反的事：沒有第一個有品味的人先做出來，其他人根本不知道該抄什麼。'
+tags: ['shroom-picks', 'taste', 'ai', 'production']
+scores:
+  tribunalVersion: 9
+  vibe:
+    persona: 8
+    clawdNote: 9
+    vibe: 8
+    narrative: 8
+    score: 8
+    date: "2026-06-28"
+    model: "claude-opus-4-5"
+  factCheck:
+    accuracy: 9
+    fidelity: 9
+    consistency: 9
+    sourceBoundary: 9
+    commentarySeparation: 9
+    score: 9
+    date: "2026-06-28"
+    model: "claude-opus-4-8"
+  librarian:
+    glossary: 8
+    crossRef: 9
+    sourceAlign: 9
+    attribution: 9
+    score: 8
+    date: "2026-06-28"
+    model: "claude-opus-4-8"
+  freshEyes:
+    readability: 9
+    firstImpression: 8
+    payoffDensity: 8
+    lengthFit: 9
+    clarity: 9
+    score: 8
+    date: "2026-06-28"
+    model: "claude-opus-4-8"
+---
+
+import ClawdNote from '../../components/ClawdNote.astro';
+
+品味這個詞，最近在 AI 圈被提到的頻率高得有點詭異。
+
+從 [Andrej Karpathy](/glossary#andrej-karpathy) 到 Y Combinator 的合夥人，每個人都在說「AI 時代最稀缺的是品味」、「未來拼的是品味」、「執行力會被 AI 吃掉，品味才是護城河」。但當追問「品味到底是什麼？」的時候，多數人的回答就開始打滑——講感覺、講經驗、講一看就知道。好像品味是一種要嘛有、要嘛沒有的天賦，沒什麼可說的。
+
+Mitchell Hashimoto 不這樣覺得。他在 X 上丟了一則長推，嘗試給這個詞一個可以拿來操作的定義——然後在定義的過程中，順便戳破了一個很流行的錯覺。
+
+## 品味的操作型定義
+
+定義只有一句，但資訊量很滿：
+
+> Taste is the ability to consistently make high-quality qualitative judgments where no objective metric exists.
+
+品味是在沒有客觀指標存在的地方，持續做出高品質的質性判斷的能力。關鍵字是「consistently」——有品味的人，不是某次運氣好賭對一個選擇，而是能夠一次又一次地在「沒有標準答案」的地方，做出讓人覺得對的決定。那種做出來的東西，感覺直覺上就是對的，但真的問「為什麼對」，很難給出一個可以量化的證明。
+
+但這裡有個會讓人誤判的觀察：
+
+> The funny thing about taste is that it's hard to create, but its result is very easy to copy. Once someone makes a tasteful decision, others can imitate it almost immediately.
+
+品味的結果極其好抄。一旦某個有品味的人做出了一個決定，其他人幾乎可以馬上模仿。這通常被拿來當成「品味不值錢」的論據——東西做得再有格調，別人一兩週就抄完了，那品味有什麼了不起？
+
+<ClawdNote>
+這個「好抄」的觀察，放到 AI 時代變得更嚇人。以前抄一個有品味的產品要請一整個團隊逆向工程幾個月；現在丟給 Claude 一個截圖加一段描述，可能幾個小時就能端出八成像的東西。抄的成本塌得比想像中快，所以才有那麼多人在焦慮：要是連我做的東西都能被秒抄，那我還剩什麼？Mitchell 接下來要講的，剛好是這個焦慮的解藥——但解藥不是「怎麼讓人抄不走」，而是換一個角度重新看待這件事。
+</ClawdNote>
+
+---
+
+## 「好抄」恰恰證明了相反的事
+
+這個邏輯其實可以翻過來：
+
+> This is usually an argument against the existence of taste: "look how easy I can copy your work!" And yet, you couldn't create the work without first having someone to copy it from. One has taste, the other doesn't.
+
+抄很快，所以品味沒價值？那倒著想一下：如果沒有第一個有品味的人做出那個東西，其他所有人根本不知道該抄什麼。抄得多快都沒用——前面得先有個人先把路開出來。那個人有品味，抄的人沒有。
+
+<ClawdNote>
+這是一個很俐落的反擊。「好抄」不是品味不值錢的證據，恰恰相反——「好抄」證明品味存在，而且只有極少數人能做到。如果品味真的不存在、每個人都能做出一樣水準的東西，那就沒有什麼好抄的了。正是因為品味稀缺，才會有那麼多人在抄。
+</ClawdNote>
+
+---
+
+## 生產正在被商品化，品味還沒有
+
+品味一直都在，但為什麼現在突然變成關鍵差異化因素？
+
+> There have always been people with consistently good taste. But taste is coming up more regularly than ever before. It is becoming a critical differentiator.
+
+> For most of history, the ability to convert an idea to reality was itself valuable. Today, production is arguably rapidly becoming abundant. A single person with a defined vision (from anyone) can create what once required an entire team. This is, of course, largely driven by AI and partially driven simply by higher levels of abstraction.
+
+歷史上大部分時候，「把想法變成現實」這個能力本身就值錢。能寫程式的人不多、能設計的人不多、能把一個產品從頭到尾做完的人更少——所以只要能做出來，就有價值。但今天，生產正在快速變得充裕。一個有清晰願景的人，借助 AI 加上更高的抽象層，就能做出以前得養一整個團隊才能做的東西。
+
+而關鍵的不對稱在這裡：
+
+> Production is being commoditized much much faster than taste. It's an open question of whether AI will be able to produce "taste." For now, the ability to create qualitatively new judgments remains distinctly human.
+
+生產正在被商品化，速度比品味快得多。AI 能不能產生品味，目前還是個未知數；但至少現在，「創造質性上全新的判斷」這件事，仍然是人類獨有的。AI 可以生成程式碼、生成設計稿、生成文案、生成一百個候選方案——但「從一百個方案裡挑出那個對的」，目前還是人類的活。
+
+<ClawdNote>
+這段放在 gu-log 這邊讀，有種自己被指著鼻子說的感覺。這個站本身就是 Mitchell 這段話的實證：一個人加一堆 agent，產出的量跟品質都是過去不可能的規模。但反過來問：如果所有人都能這樣幹，那剩下來決定勝負的到底是什麼？答案不是 AI 用得多熟，是在沒有標準答案的地方做的那些選擇——這篇要不要寫、那個角度值不值得推、ClawdNote 要吐槽到什麼程度。能執行的人變多了，能判斷的人沒有跟著變多。
+
+順帶一提，「qualitatively new」這個用詞很微妙——不是「好」或「壞」的判斷，而是「質性上全新」的判斷。品味不只是從既有選項裡挑最好的，而是能開出一條還沒人走過的路。這個能力的稀缺程度，比「從 A 和 B 裡選一個」高太多了。
+</ClawdNote>
+
+---
+
+## 品味定義了該抄什麼
+
+最後一擊：
+
+> Taste isn't valuable because it's impossible to copy. Taste is valuable exactly because it defines what everyone else chooses to copy. Taste has always existed! But now we value it more.
+
+品味的價值不在於「抄不走」。品味的價值恰恰在於它決定了所有其他人選擇去抄什麼。品味是開路先鋒——世界上第一個做出某個決定的人，定義了後面一整群人的跟隨方向。跟隨者可以很多、可以很快、可以抄得很像，但開路的那個位置，只有一個人能站。
+
+<ClawdNote>
+AI 能不能產生品味這個問題，有點像在問「AI 能不能搞笑」。現在的 AI 可以生成符合笑話結構的文字、可以模仿某種風格的幽默，但真的被 AI 的原創笑話笑到過嗎？品味可能是類似的東西——AI 可以模仿有品味的人做過的決定，但能不能做出「第一個」有品味的決定，那是另一回事。Mitchell 說「for now」，意思是這扇門沒有永遠關上，但至少現在還關著。
+</ClawdNote>
+
+最後一個細節：這篇推文是在飛機上、沒有網路、用 Apple Notes 純手寫的。Mitchell 每次發文都會特別強調是親手寫的——在一個 AI 可以生成任何東西的年代，「親手寫」本身變成了一種宣示。
+
+## 結語
+
+下次再聽到有人說「未來靠品味」的時候，至少可以接一句：那不是因為品味抄不走，是因為品味決定了該抄什麼 (｡•̀ᴗ-)✧
+
+---
+
+## 延伸閱讀
+
+- [SP-241: Mitchell Hashimoto 談 Ghostty 的開機速度取捨](/posts/sp-241-20260622-mitchellh-ghostty-startup-tradeoffs/)——同一位作者，另一場關於「取捨」的示範課
+- [SP-228: 把研究品味練成一套刻意的迴圈](/posts/sp-228-20260610-research-taste-loop/)——如果品味可以刻意練，那迴圈長什麼樣子

--- a/src/data/post-versions.json
+++ b/src/data/post-versions.json
@@ -1,4 +1,6 @@
 {
+  "en-sp-246-20260628-mitchellh-defining-taste": 1,
+  "sp-246-20260628-mitchellh-defining-taste": 1,
   "en-sp-245-20260624-mattpocockuk-skill-no-op": 6,
   "sp-245-20260624-mattpocockuk-skill-no-op": 6,
   "en-cp-311-20260624-mikenevermiss-one-person-company-claude": 2,


### PR DESCRIPTION
## 這是什麼

把 Mitchell Hashimoto 的 X 長推〈[Defining Taste](https://x.com/mitchellh/status/2070665127331037290)〉翻成繁中 SP + en 版，附 ClawdNote 吐槽。User 丟 URL → 預設寫 SP。

**核心論點**：品味（taste）= 在沒有客觀指標可衡量的地方持續做出高品質的主觀判斷。品味的價值不在「抄不走」，而在它**定義了所有人選擇去抄什麼**；production 正被 AI 商品化，速度遠快於 taste，而「創造質性上全新的判斷」目前仍是人類獨有。

## 改了什麼

- `src/content/posts/sp-246-20260628-mitchellh-defining-taste.mdx`（zh-tw 主版本）
- `src/content/posts/en-sp-246-20260628-mitchellh-defining-taste.mdx`（en 衍生翻譯）
- `scripts/article-counter.json` → SP 計數 bump 到 247
- `src/data/post-versions.json` → 納入 SP-246（pre-push 重生）
- `playwright.config.ts` → 順手修：CCC sandbox 預裝 Chromium build（1194）落後 playwright-core 想要的版本（1217）、on-demand 下載又被 proxy 擋，導致 pre-commit 的 content-integrity 測試每個 CCC session 都炸。改成偵測到 `/opt/pw-browsers/chromium` 就 conditional 指過去；mac / CI 路徑不存在則維持 playwright 預設、行為不變

## 品質

四評審 tribunal 全 **PASS**（過首頁/featured gate）：

| Judge | Score | 重點維度 |
|---|---|---|
| Vibe (Opus 4.5 pinned) | **8** | persona 8 / clawdNote 9 / vibe 8 / narrative 8 |
| Fact Checker | **9** | accuracy/fidelity/consistency 9 / sourceBoundary 9 / commentarySeparation 9 |
| Librarian | **8** | glossary 8 / crossRef 9 / sourceAlign 9 / attribution 9 |
| Fresh Eyes | **8** | readability 9 / payoffDensity 8 / lengthFit 9 / clarity 9 |

流程：zh-tw 由 pinned Opus 4.5 寫（CCC 不在 session 4.8 生 prose）→ 跑四審 → Fact sourceBoundary 7 + Vibe 晶晶體扣分 → 一輪 de-scaffold rewrite（拿掉「Mitchell 接著X」逐段導讀、兩處詮釋 gloss 移進 ClawdNote、修晶晶體）→ 複跑全 PASS。en 為衍生翻譯。所有 deterministic gate（pronoun / 晶晶體 / ai-tells / glossary-links / validate-posts）皆過。

## 驗收

CI 綠後自 merge → prod deploy → 給可點 prod URL。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Eo96PMQqhrv2YQh6CGPKan)_