### PR TITLE
fix(search): 結果上限 5→15 並顯示總數，廣詞不再吃掉文章

### DIFF
--- a/src/components/SearchBar.astro
+++ b/src/components/SearchBar.astro
@@ -11,11 +11,15 @@ const i18n = {
   'zh-tw': {
     placeholder: '搜尋文章（可用 SD-1, SP-14...）',
     noResults: '找不到結果',
+    countAll: '共 {total} 篇',
+    countCapped: '共 {total} 篇，顯示前 {shown} 篇',
     shortcut: '⌘K',
   },
   en: {
     placeholder: 'Search (e.g., SD-1, SP-14...)',
     noResults: 'No results found',
+    countAll: '{total} results',
+    countCapped: '{total} results, showing top {shown}',
     shortcut: '⌘K',
   },
 };
@@ -47,6 +51,8 @@ const t = i18n[lang];
   data-search-modal
   data-lang={lang}
   data-no-results={t.noResults}
+  data-count-all={t.countAll}
+  data-count-capped={t.countCapped}
   data-max-results={searchConfig.maxResults}
   data-debounce-ms={searchConfig.debounceMs}
   aria-hidden="true"
@@ -98,7 +104,9 @@ const t = i18n[lang];
 
   const currentLang = modal?.dataset.lang || 'zh-tw';
   const noResultsText = modal?.dataset.noResults || 'No results found';
-  const maxResults = parseInt(modal?.dataset.maxResults || '5', 10);
+  const countAllTpl = modal?.dataset.countAll || '{total} results';
+  const countCappedTpl = modal?.dataset.countCapped || '{total} results, showing top {shown}';
+  const maxResults = parseInt(modal?.dataset.maxResults || '15', 10);
   const debounceMs = parseInt(modal?.dataset.debounceMs || '150', 10);
 
   let searchIndex: SearchEntry[] | null = null;
@@ -220,7 +228,7 @@ const t = i18n[lang];
       return;
     }
 
-    let matches: FuseResult<SearchEntry>[];
+    let allMatches: FuseResult<SearchEntry>[];
 
     // Special-case: ticket ID prefix search (SD, SP, CP, Lv) — exact prefix match
     const isTicketPrefix = /^(sd|sp|cp|lv)[-\s]?\d*/i.test(trimmed);
@@ -228,37 +236,45 @@ const t = i18n[lang];
       const lower = trimmed.toLowerCase();
       const ticketMatches = searchIndex
         .filter((p) => p.ticketId && p.ticketId.toLowerCase().startsWith(lower))
-        .slice(0, maxResults)
         .map((item) => ({ item, matches: [] as FuseResultMatch[], refIndex: 0, score: 0 }));
 
-      matches =
-        ticketMatches.length > 0
-          ? ticketMatches
-          : (fuse?.search(trimmed, { limit: maxResults }) ?? []);
+      allMatches = ticketMatches.length > 0 ? ticketMatches : (fuse?.search(trimmed) ?? []);
     } else {
-      matches = fuse?.search(trimmed, { limit: maxResults }) ?? [];
+      allMatches = fuse?.search(trimmed) ?? [];
     }
 
-    if (matches.length === 0) {
+    if (allMatches.length === 0) {
       results.innerHTML = `<div class="search-no-results">${noResultsText}</div>`;
       selectedIndex = -1;
       return;
     }
 
+    // Cap the rendered list (panel scrolls); surface the full count above so
+    // broad terms that match more than maxResults don't silently hide posts.
+    const total = allMatches.length;
+    const matches = allMatches.slice(0, maxResults);
+    const countTpl = total > matches.length ? countCappedTpl : countAllTpl;
+    const countText = countTpl
+      .replace('{total}', String(total))
+      .replace('{shown}', String(matches.length));
+    const countHtml = `<div class="search-results-meta">${escapeHtml(countText)}</div>`;
+
     const baseUrl = currentLang === 'en' ? '/en/posts/' : '/posts/';
-    results.innerHTML = matches
-      .map((result, index) => {
-        const post = result.item;
-        const fuseMatches = result.matches ?? [];
+    results.innerHTML =
+      countHtml +
+      matches
+        .map((result, index) => {
+          const post = result.item;
+          const fuseMatches = result.matches ?? [];
 
-        const ticketBadge = post.ticketId
-          ? `<span class="search-result-ticket">${escapeHtml(post.ticketId)}</span>`
-          : '';
+          const ticketBadge = post.ticketId
+            ? `<span class="search-result-ticket">${escapeHtml(post.ticketId)}</span>`
+            : '';
 
-        const titleHtml = highlightText(post.title, fuseMatches, 'title');
-        const summaryHtml = highlightText(post.summary, fuseMatches, 'summary');
+          const titleHtml = highlightText(post.title, fuseMatches, 'title');
+          const summaryHtml = highlightText(post.summary, fuseMatches, 'summary');
 
-        return `
+          return `
         <a href="${baseUrl}${post.slug}"
            class="search-result-item"
            role="option"
@@ -271,8 +287,8 @@ const t = i18n[lang];
           <div class="search-result-source">${summaryHtml}</div>
         </a>
       `;
-      })
-      .join('');
+        })
+        .join('');
 
     selectedIndex = -1;
   }
@@ -498,6 +514,18 @@ const t = i18n[lang];
 
   .search-results:empty {
     display: none;
+  }
+
+  /* Total-count meta line above results — sticky so it stays visible while scrolling */
+  .search-results-meta {
+    position: sticky;
+    top: 0;
+    padding: 0.5rem 1.25rem;
+    background: var(--color-bg);
+    border-bottom: 1px solid var(--color-border);
+    color: var(--color-text-muted);
+    font-size: 0.72rem;
+    z-index: 1;
   }
 
   /* Individual result item — card-like with clear separation */

--- a/src/config/search.ts
+++ b/src/config/search.ts
@@ -1,7 +1,7 @@
 // Search configuration
 export const searchConfig = {
-  // Maximum number of results to display
-  maxResults: 5,
+  // Maximum number of results to display (panel scrolls; total count shown above)
+  maxResults: 15,
 
   // Debounce delay in milliseconds
   debounceMs: 150,


### PR DESCRIPTION
## 問題

搜尋廣詞（如 `cursor`）時找不到特定文章。根因不是 ranking，而是 `maxResults: 5` 把結果截斷：

- 打 `cursor` 共 match **20 篇**（en 版 27 篇），但 UI 只顯示前 5 名
- SP-215〈Cursor 花 260 美元，把 CMS 刪回程式碼〉排第 **8** 名 → 永遠看不到
- 前 5 名全被其他 Cursor 文佔滿，使用者也不知道後面還有

e2e 重現：用真的 search index + 真的 `fuseOptions` 跑 Fuse，確認 SP-215 rank #8、被 `maxResults=5` 切掉。

## 改動

- **`src/config/search.ts`**：`maxResults` 5 → 15（`.search-results` 面板本來就有 `max-height + overflow-y: auto`，直接靠捲動）
- **`src/components/SearchBar.astro`**：
  - `performSearch` 不再用 Fuse `{ limit }` 截斷，改成「取全部 → 算總數 `total` → `slice(0, maxResults)` 顯示」
  - 結果上方加一條 sticky 總數行：`共 N 篇` / 被截斷時 `共 N 篇，顯示前 15 篇`，讓使用者知道有沒有更多
  - 雙語 i18n（zh-tw / en）模板，透過 `data-*` 屬性傳入 client script
  - 新增 `.search-results-meta` 樣式，沿用既有 muted token（與 date/summary 同款，對比已驗證）

ticket-prefix 特例（`SD`/`SP`/`CP`/`Lv`）一併改成先取全部再 slice，總數提示同樣適用。

## 驗證

- **e2e（Playwright）**：
  - `cursor` zh-tw → `共 20 篇，顯示前 15 篇`，SP-215 出現 ✓
  - `cursor` en → `27 results, showing top 15`，SP-215 出現 ✓
  - 少量結果（`CMS 刪回程式碼` → 2 筆）→ `共 2 篇`，無截斷後綴 ✓
- **雙主題截圖**（Dracula dark + Solarized light，iPhone 13 viewport）：總數行清楚可見、對比正常、sticky 定位正確
- `pnpm run test:search-relevance` 6 passed
- ESLint / Prettier / pre-commit 全綠

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Txf3Y4rp6M5yeQG7VSmDt9)_