### PR TITLE
chore(security): 延長 astro runtime allowlist 到期日，解 security-gate 紅

### DIFF
--- a/quality/security-allowlist.json
+++ b/quality/security-allowlist.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updatedAt": "2026-06-16T00:00:00Z",
+  "updatedAt": "2026-06-30T00:00:00Z",
   "entries": [
     {
       "id": "1113296",
@@ -111,14 +111,14 @@
       "id": "1120912",
       "name": "astro",
       "reason": "Astro 5 runtime high advisory. gu-log builds static output from repo-controlled MDX/content and does not expose user-controlled slot names. Upgrading to Astro 6.4.6+ requires a legacy content collections migration; temporary exception until that migration lands.",
-      "expiresAt": "2026-06-30T00:00:00Z",
+      "expiresAt": "2026-07-14T00:00:00Z",
       "scope": "runtime"
     },
     {
       "id": "1120917",
       "name": "astro",
       "reason": "Astro 5 SSR host-header advisory. gu-log deploys static output on Vercel and does not use Astro SSR/prerendered error page runtime fetch. Upgrading to Astro 6.4.6+ requires a legacy content collections migration; temporary exception until that migration lands.",
-      "expiresAt": "2026-06-30T00:00:00Z",
+      "expiresAt": "2026-07-14T00:00:00Z",
       "scope": "runtime"
     }
   ]


### PR DESCRIPTION
## 問題

`quality/security-allowlist.json` 裡兩條 `astro` HIGH runtime 例外（id `1120912` / `1120917`）於 **2026-06-30 到期**。今天起 `security-gate` 對**每個 PR 與 main** 都 FAIL（`SECURITY GATE: FAIL (2 blocking finding(s))`）。這是個 date-triggered 時間炸彈，與任何 code 改動無關。

兩條 advisory 的 allowlist 理由不變且仍成立：
- gu-log 由 repo-controlled MDX/content **建置成靜態檔**，不暴露 user-controlled slot names
- 部署在 Vercel 的是靜態輸出，**不走 Astro SSR / prerendered error page runtime fetch**
- 真正修需升級 Astro 6.4.6+，但那要做 legacy content collections migration（另一個大且有風險的獨立任務）

## 改動

- 兩條 astro 例外 `expiresAt` 2026-06-30 → **2026-07-14**
- `updatedAt` → 2026-06-30

## 為什麼是 14 天，不是更久

`scripts/security-gate.mjs` 的 `MAX_ALLOWLIST_DAYS.runtime = 14` —— runtime scope 例外政策上限就是 14 天（刻意短命，逼人盡快真正修，不讓 runtime advisory 被無限期 suppress）。一開始誤設 92 天被 gate 擋下（`policy violation: expiry too far`），改回 14 天上限。

這 2 週窗口本身就是提醒：**Astro 6 migration 要排進來**，否則 2026-07-14 後 gate 會再紅。

## 驗證

- `node scripts/security-gate.mjs` → `SECURITY GATE: PASS`（exit 0）
- pre-commit / pre-push 全綠

> 註：gate log 另有 15 條 2026-04-17 過期、但「currently not matched」的 dev/unknown 殘留例外（warn-only，不擋 CI）。本 PR 範圍只處理 blocking 的 astro 兩條，殘留清理留作後續。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Txf3Y4rp6M5yeQG7VSmDt9)_