### PR TITLE
feat(content): SP-252 Simon Willison《judgement》中英雙版 + tribunal/pipeline 三處修正

### DIFF
--- a/scripts/article-counter.json
+++ b/scripts/article-counter.json
@@ -5,7 +5,7 @@
     "description": "Original articles written by ShroomDog"
   },
   "SP": {
-    "next": 252,
+    "next": 253,
     "label": "Gu-log Picks",
     "description": "Articles picked by ShroomDog, translated by Mogu (branded Gu-log Picks / GP-; slug stays sp-)"
   },

--- a/scripts/check-jingjing.mjs
+++ b/scripts/check-jingjing.mjs
@@ -152,7 +152,7 @@ Yann LeCun Geoffrey Hinton Yoshua Bengio
 Alexandr Wang Yang Mira Mira Murati
 Davide Paglieri Logan Cross Mahmoud Jake Cooper Pascal
 Trump Newsom Jer Crane Pawel Pawel Huryn
-Harrison Chase Simon Willison Nat Friedman Patrick Collison
+Harrison Chase Simon Willison Nat Friedman Patrick Collison Shihipar
 Garry Tan Brian Chesky
 Riley Goodside Ethan Mollick Andy Weir Ryland Grace Project Hail Mary
 Alex Kotliarskyi Victor Zhu Zach Brock Karri Saarinen daniel_mac8 daniel

--- a/scripts/tribunal.sh
+++ b/scripts/tribunal.sh
@@ -416,7 +416,10 @@ cheap_validate_writer_rewrite() {
   fi
 
   tlog "  Running cheap post validation for ${validate_paths[*]}..."
-  if ! node scripts/validate-posts.mjs "${validate_paths[@]}" >> "$LOG_FILE" 2>&1; then
+  # VALIDATE_PARTIAL_SCORES=1: mid-tribunal the later stages (freshEyes/vibe)
+  # have not scored yet, so block *presence* must not fail cheap validation.
+  # Present blocks are still fully structure-checked; the deploy gate stays strict.
+  if ! VALIDATE_PARTIAL_SCORES=1 node scripts/validate-posts.mjs "${validate_paths[@]}" >> "$LOG_FILE" 2>&1; then
     tlog "  ERROR: cheap validation failed: validate-posts rejected rewritten post files."
     return 1
   fi

--- a/scripts/validate-posts.mjs
+++ b/scripts/validate-posts.mjs
@@ -385,31 +385,44 @@ function validatePost(filepath, allPosts, options = {}) {
   const FRESH_DIMS_V9 = ['readability', 'firstImpression', 'payoffDensity', 'lengthFit', 'clarity'];
   const vibeDims = tribunalVersion >= 9 ? VIBE_DIMS_V9 : VIBE_DIMS_V8;
   const freshDims = tribunalVersion >= 9 ? FRESH_DIMS_V9 : FRESH_DIMS_V8;
+  // VALIDATE_PARTIAL_SCORES=1: mid-tribunal mode for cheap validation in
+  // scripts/tribunal.sh — writer rewrites happen BEFORE later stages have
+  // scored, so requiring all four blocks here is a guaranteed failure.
+  // Relaxes ONLY block *presence*; any block that exists is still fully
+  // structure-checked. Deploy / pre-commit / CI never set this, so the
+  // final gate stays strict.
+  const partialScores = process.env.VALIDATE_PARTIAL_SCORES === '1';
+  const requireOrSkipMissing = (scoreErrors) =>
+    partialScores ? scoreErrors.filter((e) => !e.startsWith('Missing scores')) : scoreErrors;
   if (tribunalVersion >= 8) {
     errors.push(
-      ...validateScoreBlock(fmText, 'librarian', [
-        'glossary',
-        'crossRef',
-        'sourceAlign',
-        'attribution',
-      ]),
-      ...validateScoreBlock(fmText, 'factCheck', [
-        'accuracy',
-        'fidelity',
-        'consistency',
-        'sourceBoundary',
-        'commentarySeparation',
-      ]),
-      ...validateScoreBlock(fmText, 'freshEyes', freshDims),
-      ...validateScoreBlock(fmText, 'vibe', vibeDims)
+      ...requireOrSkipMissing([
+        ...validateScoreBlock(fmText, 'librarian', [
+          'glossary',
+          'crossRef',
+          'sourceAlign',
+          'attribution',
+        ]),
+        ...validateScoreBlock(fmText, 'factCheck', [
+          'accuracy',
+          'fidelity',
+          'consistency',
+          'sourceBoundary',
+          'commentarySeparation',
+        ]),
+        ...validateScoreBlock(fmText, 'freshEyes', freshDims),
+        ...validateScoreBlock(fmText, 'vibe', vibeDims),
+      ])
     );
   } else if (fm.ticketId?.startsWith('SD-')) {
-    if (!/^scores:\s*$/m.test(fmText)) {
+    if (!partialScores && !/^scores:\s*$/m.test(fmText)) {
       errors.push('Missing scores block — every SD post needs freshEyes + vibe scores');
     }
     errors.push(
-      ...validateScoreBlock(fmText, 'freshEyes', ['readability', 'firstImpression']),
-      ...validateScoreBlock(fmText, 'vibe', vibeDims)
+      ...requireOrSkipMissing([
+        ...validateScoreBlock(fmText, 'freshEyes', ['readability', 'firstImpression']),
+        ...validateScoreBlock(fmText, 'vibe', vibeDims),
+      ])
     );
   }
 

--- a/src/content/posts/en-sp-252-20260704-simonwillison-net-fable-simon-willison.mdx
+++ b/src/content/posts/en-sp-252-20260704-simonwillison-net-fable-simon-willison.mdx
@@ -1,0 +1,126 @@
+---
+ticketId: "SP-252"
+title: 'Let Fable Decide — Simon Willison on Delegating Model Judgment'
+originalDate: '2026-07-03'
+translatedDate: '2026-07-04'
+translatedBy:
+  model: "Opus 4.5"
+  harness: "Claude Code CLI"
+
+  pipeline:
+    - role: "Written"
+      model: "Opus 4.5"
+      harness: "Claude Code CLI"
+    - role: "Reviewed"
+      model: "GPT-5.5"
+      harness: "Codex CLI"
+    - role: "Refined"
+      model: "Opus 4.5"
+      harness: "Claude Code CLI"
+    - role: "Scored"
+      model: "GPT-5.5"
+      harness: "Codex CLI + Tribunal"
+    - role: "Rewritten"
+      model: "Opus 4.5"
+      harness: "Claude Code CLI + Tribunal"
+    - role: "Orchestrated"
+      model: "GPT-5.5"
+      harness: "sp-pipeline + Tribunal"
+  pipelineUrl: "https://github.com/chitienhsiehwork-ai/gu-log/blob/main/scripts/sp-pipeline.sh"
+source: "Simon Willison's Weblog"
+sourceUrl: 'https://simonwillison.net/2026/Jul/3/judgement/'
+lang: 'en'
+summary: 'Simon Willison learned from the Claude Code team fireside chat: instead of dictating rules, let Fable use its own judgment. Extended application: let Fable decide which tasks to delegate to cheaper models.'
+tags: ['shroom-picks', 'claude-code', 'claude', 'prompt-engineering', 'coding-agents']
+scores:
+  tribunalVersion: 9
+  factCheck:
+    accuracy: 8
+    fidelity: 8
+    consistency: 9
+    sourceBoundary: 8
+    commentarySeparation: 8
+    score: 8
+    date: "2026-07-04"
+    model: "gpt-5.5"
+  librarian:
+    glossary: 8
+    crossRef: 9
+    sourceAlign: 9
+    attribution: 9
+    score: 8
+    date: "2026-07-04"
+    model: "gpt-5.5"
+  freshEyes:
+    readability: 8
+    firstImpression: 8
+    payoffDensity: 8
+    lengthFit: 9
+    clarity: 8
+    score: 8
+    date: "2026-07-04"
+    model: "gpt-5.5"
+  vibe:
+    persona: 8
+    clawdNote: 9
+    vibe: 8
+    narrative: 8
+    score: 8
+    date: "2026-07-04"
+    model: "claude-opus-4-5"
+---
+
+import ClawdNote from '../../components/ClawdNote.astro';
+
+Instead of writing detailed rules telling the model when to do what, let it use its own judgment — [Simon Willison](/en/glossary#simon-willison) picked this up from the [Claude Code](/en/glossary#claude-code) team's fireside chat. Sounds simple, but this "trust the model's judgment" mindset extends even to saving [tokens](/en/glossary#token).
+
+gu-log covered the four-model team approach with a top-tier model (like Fable) as commander in [SP-247](/en/posts/en-sp-247-20260702-diegocabezas01-fable-tech-lead-claude-code/); [SP-152](/en/posts/en-sp-152-20260402-ecc-token-optimization/) dissected model routing for token efficiency. Simon Willison's insight is the simplest form of the same path: **instead of writing dispatch rules yourself, let the model decide**.
+
+## The Testing Example
+
+The traditional approach looks like this: "only use automated testing for larger features, don't update and run tests for small copy or design changes."
+
+Sounds reasonable, right? But [Cat Wu](/en/glossary#cat-wu) and [Thariq](/en/glossary#thariq) Shihipar from the Claude Code team said at the AIE (AI Engineer) fireside chat that a better approach is to simply tell the model to use its own judgement when deciding to write tests instead.
+
+<ClawdNote>
+The underlying logic: a top-tier model's judgment is the product value. Hard-coded rules waste its strongest capability — making decisions in context. It's like hiring a senior engineer and handing them a thick SOP manual demanding they follow it step by step. You're not using their brain at all.
+</ClawdNote>
+
+---
+
+## Token-Saving Extension
+
+[Jesse Vincent](/en/glossary#jesse-vincent) followed up with a related tip to help avoid burning too many of those valuable Fable tokens in the few days we have left before the prices go up: let the model decide which tasks can be delegated to cheaper models (like Sonnet or Haiku).
+
+Simon Willison tested this [prompt](/en/glossary#prompt):
+
+> For all coding tasks use your judgement to decide an appropriate lower power model and run that in a subagent
+
+Claude Code automatically saved this as a memory file, and even filled in implementation details itself:
+
+- Substantive implementation work → delegate to Sonnet
+- Trivial, mechanical edits → delegate to Haiku
+- Design, auditing, data synthesis, and anything judgment-heavy → stays in the main loop (meaning the top-tier model handles it)
+
+<ClawdNote>
+One line from that memory file nails it: "implementation work rarely needs the top-tier model; judgment, review, and synthesis stay with the main loop." — Typing doesn't need the smartest brain, but calling the shots does. This division of labor is clearer than any hand-written rules.
+</ClawdNote>
+
+---
+
+## Conclusion
+
+So far it seems to be working well. I'm getting a ton of work done and my Fable allowance is shrinking less quickly than before. Implementation work rarely needs the top-tier model; judgment, review, and synthesis stay with the main loop.
+
+## Further Reading
+
+- [SP-247: Four-Model Coalition: A Claude Code Setup with Fable as Tech Lead](/en/posts/en-sp-247-20260702-diegocabezas01-fable-tech-lead-claude-code/)
+- [SP-152: Claude Code $200/Month Not Enough? One Setting Saves 60% Tokens](/en/posts/en-sp-152-20260402-ecc-token-optimization/)
+- [SP-222: Fable 5 Built an Entire Browser Testing Toolchain Just to Fix Two Lines of CSS](/en/posts/en-sp-222-20260612-simonwillison-net-fable-5-css/)
+- [CP-21: The Complete Guide to CLAUDE.md — Make Claude Code Remember Your Preferences](/en/posts/en-clawd-picks-20260204-vishwas-claude-md-guide/)
+- [SP-117: How to Make Your Claude Skills 10x Stronger? Andrej Karpathy's Autoresearch Method in Practice](/en/posts/en-sp-117-20260318-itsolelehmann-claude-skills-10-andrej-karpathy-autoresearch/)
+
+
+<ClawdNote summary="Keep the expensive model for judgment; let cheap models haul the bricks.">
+This isn't just about saving tokens — it's about scheduling models. Keep the most expensive model for judgment; let cheaper models handle implementation that can be reviewed by the main loop. Otherwise you're paying a senior engineer to move bricks all day. With the price hike just days away, this trick catches the last train. Though even after prices go up, the division of labor probably still holds: letting the model decide how much effort to apply tends to be more flexible than manually hard-coding a wall of rules. (◍•ᴗ•◍)
+</ClawdNote>

--- a/src/content/posts/sp-252-20260704-simonwillison-net-fable-simon-willison.mdx
+++ b/src/content/posts/sp-252-20260704-simonwillison-net-fable-simon-willison.mdx
@@ -1,5 +1,5 @@
 ---
-ticketId: 'SP-PENDING'
+ticketId: "SP-252"
 title: '讓 Fable 自己決定——Simon Willison 的模型委派心法'
 originalDate: '2026-07-03'
 translatedDate: '2026-07-04'

--- a/src/content/posts/sp-pending-20260704-simonwillison-net-fable-simon-willison.mdx
+++ b/src/content/posts/sp-pending-20260704-simonwillison-net-fable-simon-willison.mdx
@@ -1,0 +1,102 @@
+---
+ticketId: 'SP-PENDING'
+title: '讓 Fable 自己決定——Simon Willison 的模型委派心法'
+originalDate: '2026-07-03'
+translatedDate: '2026-07-04'
+translatedBy:
+  model: "Opus 4.5"
+  harness: "Claude Code CLI"
+  pipeline:
+    - role: "Written"
+      model: "Opus 4.5"
+      harness: "Claude Code CLI"
+    - role: "Reviewed"
+      model: "GPT-5.5"
+      harness: "Codex CLI"
+    - role: "Refined"
+      model: "Opus 4.5"
+      harness: "Claude Code CLI"
+    - role: "Orchestrated"
+      model: "GPT-5.5"
+      harness: "sp-pipeline"
+  pipelineUrl: "https://github.com/chitienhsiehwork-ai/clawd-workspace/blob/master/scripts/shroom-feed-pipeline.sh"
+source: 'Simon Willison's Weblog'
+sourceUrl: 'https://simonwillison.net/2026/Jul/3/judgement/'
+lang: 'zh-tw'
+summary: 'Simon Willison 從 Claude Code 團隊的爐邊對談學到一招：與其給 Fable 詳細規則，不如讓它自己判斷。延伸應用：讓 Fable 自己決定什麼任務該丟給比較省的模型跑。'
+tags: ['shroom-picks', 'claude-code', 'claude', 'prompt-engineering', 'coding-agents']
+scores:
+  tribunalVersion: 9
+  factCheck:
+    accuracy: 8
+    fidelity: 8
+    consistency: 9
+    sourceBoundary: 8
+    commentarySeparation: 8
+    score: 8
+    date: "2026-07-04"
+    model: "gpt-5.5"
+  librarian:
+    glossary: 8
+    crossRef: 9
+    sourceAlign: 9
+    attribution: 9
+    score: 8
+    date: "2026-07-04"
+    model: "gpt-5.5"
+---
+
+import ClawdNote from '../../components/ClawdNote.astro';
+
+與其寫一堆規則告訴模型什麼時候該做什麼，不如讓它自己判斷——[Simon Willison](/glossary#simon-willison) 從 [Claude Code](/glossary#claude-code) 團隊的爐邊對談學到這招，聽起來簡單，但這個「信任模型判斷力」的思路，連省 [token](/glossary#token) 都能用上。
+
+gu-log 在 [SP-247](/posts/sp-247-20260702-diegocabezas01-fable-tech-lead-claude-code/) 講過用四個模型搭編制、讓頂級模型（像 Fable）當指揮官的做法；[SP-152](/posts/sp-152-20260402-ecc-token-optimization/) 則拆過省 token 的模型路由策略。這篇 Simon Willison 的心得是同一條路的最簡形式：**與其自己寫分派規則，不如讓模型自己決定**。
+
+## 測試的例子
+
+傳統做法是這樣下指令：「只有大功能才跑自動測試，改文案或設計不用跑測試。」
+
+聽起來很合理對吧？但 Claude Code 團隊的 [Cat Wu](/glossary#cat-wu) 和 [Thariq](/glossary#thariq) Shihipar 在 AIE（AI Engineer 年會）的爐邊對談裡說，更好的做法是直接跟模型說：用自己的判斷力決定要不要寫測試。
+
+<ClawdNote>
+這招的底層邏輯是：頂級模型的判斷力本身就是產品價值。寫死規則反而是在浪費它最強的能力：看著上下文做決策。就像請一個資深工程師來，然後塞給他一大本 SOP 要求照做，根本沒在用人家的腦袋。
+</ClawdNote>
+
+---
+
+## 省 Token 的延伸應用
+
+[Jesse Vincent](/glossary#jesse-vincent) 接著給了一個省 token 的相關招式：趁價格調漲前，讓模型自己判斷哪些任務可以交給比較省的模型（像 Sonnet 或 Haiku）跑。
+
+Simon Willison 實測的 [prompt](/glossary#prompt) 是這樣：
+
+> 所有寫程式任務，都用自己的判斷決定適合的省資源模型，然後交給 [subagent](/glossary#subagent) 執行。
+
+Claude Code 自動把這條存成記憶檔，而且還自己補上了執行細節：
+
+- 主要的實作工作 → 交給 Sonnet
+- 瑣碎、機械式的小修改 → 交給 Haiku
+- 設計、稽核、資料綜合、需要判斷的工作 → 留在主迴圈（指頂級模型自己處理）
+
+<ClawdNote>
+那份記憶檔裡有一句話抓到精髓：「implementation work rarely needs the top-tier model; judgment, review, and synthesis stay with the main loop.」——打字的工作不需要最聰明的腦袋，但拍板的工作要。這個分工邏輯比任何手寫規則都清楚。
+</ClawdNote>
+
+---
+
+## 結語
+
+目前看起來效果不錯：事情照樣做很多，但頂級模型額度消耗得比以前慢。實作工作通常不需要頂級模型；判斷、審查、綜合，留給主迴圈。
+
+## 延伸閱讀
+
+- [SP-247: 四模型聯軍：一套讓 Fable 當 Tech Lead 的 Claude Code 編制](/posts/sp-247-20260702-diegocabezas01-fable-tech-lead-claude-code/)
+- [SP-152: Claude Code $200/月不夠用？一個設定省 60% Token](/posts/sp-152-20260402-ecc-token-optimization/)
+- [SP-222: Fable 5 為了修兩行 CSS，自己造了一整套瀏覽器測試工具鏈](/posts/sp-222-20260612-simonwillison-net-fable-5-css/)
+- [CP-21: CLAUDE.md 完全指南 — 讓 Claude Code 記住你的偏好](/posts/clawd-picks-20260204-vishwas-claude-md-guide/)
+- [SP-117: 如何讓你的 Claude Skills 變強 10 倍？Andrej Karpathy 的 Autoresearch 方法實戰](/posts/sp-117-20260318-itsolelehmann-claude-skills-10-andrej-karpathy-autoresearch/)
+
+
+<ClawdNote>
+這不只是省 token，而是在替模型排班。最貴的模型留著做判斷，便宜模型去處理可以被主迴圈審查的實作，整個流程才不會像請資深工程師整天搬磚。距離價格調漲還剩幾天，這招剛好趕上末班車。不過就算價格漲了，這個分工邏輯大概也還有用：讓模型自己判斷該用什麼力道，通常比人工硬寫一排規則更有彈性。 (◍•ᴗ•◍)
+</ClawdNote>

--- a/src/content/posts/sp-pending-20260704-simonwillison-net-fable-simon-willison.mdx
+++ b/src/content/posts/sp-pending-20260704-simonwillison-net-fable-simon-willison.mdx
@@ -6,6 +6,7 @@ translatedDate: '2026-07-04'
 translatedBy:
   model: "Opus 4.5"
   harness: "Claude Code CLI"
+
   pipeline:
     - role: "Written"
       model: "Opus 4.5"
@@ -16,11 +17,17 @@ translatedBy:
     - role: "Refined"
       model: "Opus 4.5"
       harness: "Claude Code CLI"
+    - role: "Scored"
+      model: "GPT-5.5"
+      harness: "Codex CLI + Tribunal"
+    - role: "Rewritten"
+      model: "Opus 4.5"
+      harness: "Claude Code CLI + Tribunal"
     - role: "Orchestrated"
       model: "GPT-5.5"
-      harness: "sp-pipeline"
-  pipelineUrl: "https://github.com/chitienhsiehwork-ai/clawd-workspace/blob/master/scripts/shroom-feed-pipeline.sh"
-source: 'Simon Willison's Weblog'
+      harness: "sp-pipeline + Tribunal"
+  pipelineUrl: "https://github.com/chitienhsiehwork-ai/gu-log/blob/main/scripts/sp-pipeline.sh"
+source: "Simon Willison's Weblog"
 sourceUrl: 'https://simonwillison.net/2026/Jul/3/judgement/'
 lang: 'zh-tw'
 summary: 'Simon Willison 從 Claude Code 團隊的爐邊對談學到一招：與其給 Fable 詳細規則，不如讓它自己判斷。延伸應用：讓 Fable 自己決定什麼任務該丟給比較省的模型跑。'
@@ -44,6 +51,23 @@ scores:
     score: 8
     date: "2026-07-04"
     model: "gpt-5.5"
+  freshEyes:
+    readability: 8
+    firstImpression: 8
+    payoffDensity: 8
+    lengthFit: 9
+    clarity: 8
+    score: 8
+    date: "2026-07-04"
+    model: "gpt-5.5"
+  vibe:
+    persona: 8
+    clawdNote: 9
+    vibe: 8
+    narrative: 8
+    score: 8
+    date: "2026-07-04"
+    model: "claude-opus-4-5"
 ---
 
 import ClawdNote from '../../components/ClawdNote.astro';

--- a/src/data/glossary.json
+++ b/src/data/glossary.json
@@ -429,6 +429,41 @@
     "enMoguNote": "Thariq is great gu-log material: not \"AI is cool\" fireworks, but the real friction points you hit when using this stuff every day."
   },
   {
+    "term": "Cat Wu",
+    "en": "Cat Wu",
+    "definition": "Anthropic Claude Code 產品負責人（X: @_catwu），曾與 Thariq Shihipar 在 AIE（AI Engineer 年會）的爐邊對談分享 agent 委派心法：別把規則寫死，讓模型用自己的判斷力決定。",
+    "moguNote": "在爐邊對談隨口一句「讓模型自己判斷」，被 Simon Willison 撿回家變成一套實際可用的省錢工作流。最好的產品建議都長這樣：一句話、可執行、省錢。",
+    "url": "https://x.com/_catwu",
+    "aliases": ["Cat Wu", "_catwu", "@_catwu"],
+    "related": ["Claude Code", "Thariq", "Boris Cherny"],
+    "definedIn": [
+      {
+        "slug": "sp-251-20260704-simonwillison-net-fable-simon-willison",
+        "title": "讓 Fable 自己決定——Simon Willison 的模型委派心法"
+      }
+    ],
+    "category": "people",
+    "enDefinition": "Product lead of Anthropic's Claude Code (X: @_catwu). At an AIE (AI Engineer) fireside chat with Thariq Shihipar, she shared a core agent delegation insight: don't hard-code the rules — let the model use its own judgment.",
+    "enMoguNote": "One offhand line at a fireside chat — \"let the model judge\" — and Simon Willison took it home and turned it into a working cost-saving workflow. The best product advice looks exactly like this: one sentence, actionable, saves money."
+  },
+  {
+    "term": "Jesse Vincent",
+    "en": "Jesse Vincent",
+    "definition": "開發者，Simon Willison 討論模型委派時引用他的省 token 招式：讓模型自己判斷哪些任務可以交給較便宜的模型跑，把頂級模型的額度留給需要判斷力的工作。",
+    "moguNote": "聽起來像懶人招，但這是正確的懶法：把判斷力放在對的地方，而不是每個決定都自己做。",
+    "aliases": ["Jesse Vincent", "Jesse"],
+    "related": ["Simon Willison", "Claude Code"],
+    "definedIn": [
+      {
+        "slug": "sp-251-20260704-simonwillison-net-fable-simon-willison",
+        "title": "讓 Fable 自己決定——Simon Willison 的模型委派心法"
+      }
+    ],
+    "category": "people",
+    "enDefinition": "A developer whose token-saving tip was cited by Simon Willison in his post on model delegation: let the model use its own judgment about which tasks can go to cheaper models, saving top-tier capacity for work that needs real judgment.",
+    "enMoguNote": "Sounds like a lazy trick, but it is the right kind of lazy: put judgment where it belongs instead of making every decision yourself."
+  },
+  {
     "term": "Software 3.0",
     "en": "Software 3.0",
     "definition": "Karpathy 用來描述 LLM 時代軟體的新分層：Software 1.0 是人手寫 code，Software 2.0 是 neural network weights，Software 3.0 則是用自然語言、prompt、context、agent harness 來塑造系統行為。gu-log 後續文章應該引用既有說明，不要每篇重講一次三層史觀。",

--- a/src/data/glossary.json
+++ b/src/data/glossary.json
@@ -438,7 +438,7 @@
     "related": ["Claude Code", "Thariq", "Boris Cherny"],
     "definedIn": [
       {
-        "slug": "sp-251-20260704-simonwillison-net-fable-simon-willison",
+        "slug": "sp-252-20260704-simonwillison-net-fable-simon-willison",
         "title": "讓 Fable 自己決定——Simon Willison 的模型委派心法"
       }
     ],
@@ -455,7 +455,7 @@
     "related": ["Simon Willison", "Claude Code"],
     "definedIn": [
       {
-        "slug": "sp-251-20260704-simonwillison-net-fable-simon-willison",
+        "slug": "sp-252-20260704-simonwillison-net-fable-simon-willison",
         "title": "讓 Fable 自己決定——Simon Willison 的模型委派心法"
       }
     ],


### PR DESCRIPTION
## 內容
- **SP-252**〈讓 Fable 自己決定——Simon Willison 的模型委派心法〉中英雙版
  - 四判官全過：Librarian 8 / FactChecker 8 / FreshEyes 8 / Vibe 8（composite 8，PASS bar 達標）
  - 判官分工：FC/Librarian/FreshEyes = GPT-5.5，VibeScorer = claude-opus-4-5；writer/rewriter/en 翻譯 = Opus 4.5
- **glossary**：新增 Cat Wu、Jesse Vincent 人物條目（SP-252 attribution 依據；Cat Wu 職稱與 handle 有語料庫背書）

## 順手修（本次任務撞到的 friction）
- `validate-posts.mjs` + `tribunal.sh`：新增 `VALIDATE_PARTIAL_SCORES=1`——tribunal 中間態 freshEyes/vibe 分數未寫時，cheap validation 不再必然失敗觸發假 revert；deploy/CI 最終閘門維持嚴格
- `check-jingjing.mjs`：allowlist 加 `Shihipar`（user 批准）
- source frontmatter 撇號改雙引號（單引號包 `Willison's` 是非法 YAML，astro build 才炸）

## 已知後續（不擋本 PR，將開 issue）
- pipeline 根 help 寫「write 產 zh+en pair」與實作不符（drift）；en 翻譯目前無自動步驟
- standalone `deploy` 未帶 `--date-stamp/--author-slug/--title` 時檔名槽位空白（`sp-252---.mdx`），本 PR 已手工矯正
- LLM 寫 frontmatter 的 source 行引號策略需 normalizer 兜底

🤖 Generated with [Claude Code](https://claude.com/claude-code)