### PR TITLE
fix: 合併 article counter 取最大值

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,7 @@
 # `scripts/setup-hooks.sh` (runs via `pnpm install` → `prepare` script)
 # and is defined in `scripts/merge-post-versions.sh`.
 src/data/post-versions.json merge=post-versions-regen
+
+# Article ticket counters are monotonic per prefix. Resolve concurrent branch
+# bumps by taking max(next), while leaving real metadata conflicts for humans.
+scripts/article-counter.json merge=article-counter-max

--- a/scripts/merge-article-counter.mjs
+++ b/scripts/merge-article-counter.mjs
@@ -1,0 +1,163 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function parseCounterJson(text, label) {
+  let value;
+  try {
+    value = JSON.parse(text);
+  } catch (error) {
+    fail(`${label}: invalid JSON: ${error.message}`);
+  }
+
+  validateCounterSchema(value, label);
+  return value;
+}
+
+function validateCounterSchema(value, label) {
+  if (!isPlainObject(value)) {
+    fail(`${label}: expected top-level object`);
+  }
+
+  for (const [prefix, entry] of Object.entries(value)) {
+    if (!isPlainObject(entry)) {
+      fail(`${label}: ${prefix} must be an object`);
+    }
+    if (!Number.isInteger(entry.next) || entry.next < 0) {
+      fail(`${label}: ${prefix}.next must be a non-negative integer`);
+    }
+  }
+}
+
+function isPlainObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function stableStringify(value) {
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableStringify(item)).join(',')}]`;
+  }
+  if (isPlainObject(value)) {
+    return `{${Object.keys(value)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`)
+      .join(',')}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function sameValue(left, right) {
+  return stableStringify(left) === stableStringify(right);
+}
+
+function cloneJson(value) {
+  return value === undefined ? undefined : JSON.parse(JSON.stringify(value));
+}
+
+function mergeScalarField({ baseValue, oursValue, theirsValue, path }) {
+  const oursChanged = !sameValue(oursValue, baseValue);
+  const theirsChanged = !sameValue(theirsValue, baseValue);
+
+  if (!oursChanged && !theirsChanged) return oursValue;
+  if (oursChanged && !theirsChanged) return oursValue;
+  if (!oursChanged && theirsChanged) return theirsValue;
+  if (sameValue(oursValue, theirsValue)) return oursValue;
+
+  fail(`${path}: both sides changed differently`);
+}
+
+export function mergeArticleCounter(base, ours, theirs) {
+  validateCounterSchema(base, 'base');
+  validateCounterSchema(ours, 'ours');
+  validateCounterSchema(theirs, 'theirs');
+
+  const merged = {};
+  const prefixes = new Set([...Object.keys(base), ...Object.keys(ours), ...Object.keys(theirs)]);
+
+  for (const prefix of [...prefixes].sort()) {
+    const baseEntry = base[prefix];
+    const oursEntry = ours[prefix];
+    const theirsEntry = theirs[prefix];
+
+    if (baseEntry && (!oursEntry || !theirsEntry)) {
+      fail(`${prefix}: prefix deletion requires manual resolution`);
+    }
+    if (!oursEntry || !theirsEntry) {
+      merged[prefix] = cloneJson(oursEntry ?? theirsEntry);
+      continue;
+    }
+
+    const entry = {};
+    const fields = new Set([
+      ...Object.keys(baseEntry ?? {}),
+      ...Object.keys(oursEntry),
+      ...Object.keys(theirsEntry),
+    ]);
+
+    for (const field of [...fields].sort()) {
+      if (field === 'next') {
+        entry.next = Math.max(oursEntry.next, theirsEntry.next);
+        continue;
+      }
+
+      entry[field] = mergeScalarField({
+        baseValue: baseEntry?.[field],
+        oursValue: oursEntry[field],
+        theirsValue: theirsEntry[field],
+        path: `${prefix}.${field}`,
+      });
+    }
+
+    merged[prefix] = entry;
+  }
+
+  return merged;
+}
+
+export function mergeArticleCounterText(baseText, oursText, theirsText) {
+  return `${JSON.stringify(
+    mergeArticleCounter(
+      parseCounterJson(baseText, 'base'),
+      parseCounterJson(oursText, 'ours'),
+      parseCounterJson(theirsText, 'theirs')
+    ),
+    null,
+    2
+  )}\n`;
+}
+
+export function mergeArticleCounterFiles(basePath, oursPath, theirsPath) {
+  const merged = mergeArticleCounterText(
+    fs.readFileSync(basePath, 'utf8'),
+    fs.readFileSync(oursPath, 'utf8'),
+    fs.readFileSync(theirsPath, 'utf8')
+  );
+  fs.writeFileSync(oursPath, merged);
+}
+
+function main(argv) {
+  const [, , basePath, oursPath, theirsPath, worktreePath = 'scripts/article-counter.json'] = argv;
+  if (!basePath || !oursPath || !theirsPath) {
+    console.error('merge-article-counter.mjs: expected %O %A %B [%P]');
+    return 2;
+  }
+
+  try {
+    mergeArticleCounterFiles(basePath, oursPath, theirsPath);
+    console.error(`merge-article-counter.mjs: merged ${worktreePath}`);
+    return 0;
+  } catch (error) {
+    console.error(
+      `merge-article-counter.mjs: ${error.message} — leaving conflict for manual resolution`
+    );
+    return 1;
+  }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  process.exitCode = main(process.argv);
+}

--- a/scripts/merge-article-counter.sh
+++ b/scripts/merge-article-counter.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+# scripts/merge-article-counter.sh
+#
+# Custom git merge driver for `scripts/article-counter.json`.
+#
+# Git calling convention:
+#   $1 = %O — ancestor version (temp file)
+#   $2 = %A — our version (temp file, AND the file we must overwrite with
+#             the merged result; git reads the merged content from here
+#             after we exit 0)
+#   $3 = %B — their version (temp file)
+#   $4 = %P — pathname in the worktree (for logging)
+#
+# Strategy: JSON-aware three-way merge. Counter `next` values are monotonic,
+# so matching prefixes resolve to max(ours.next, theirs.next). Other fields
+# use normal three-way semantics and fail closed if both sides changed
+# differently.
+
+set -e
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+if [ -z "$2" ]; then
+    echo "merge-article-counter.sh: expected %A as arg 2" >&2
+    exit 2
+fi
+
+node "$REPO_ROOT/scripts/merge-article-counter.mjs" "$1" "$2" "$3" "$4"

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -45,4 +45,14 @@ git config --local merge.post-versions-regen.driver \
     "scripts/merge-post-versions.sh %O %A %B %P"
 echo "✓ Configured merge driver post-versions-regen"
 
+# ── Custom merge driver: article-counter-max ────────────────────────
+# .gitattributes marks `scripts/article-counter.json` as needing this
+# driver. The counter is monotonic, so concurrent `next` bumps resolve
+# with a JSON-aware max strategy while metadata conflicts fail closed.
+git config --local merge.article-counter-max.name \
+    "Merge article-counter.json by taking max next values"
+git config --local merge.article-counter-max.driver \
+    "scripts/merge-article-counter.sh %O %A %B %P"
+echo "✓ Configured merge driver article-counter-max"
+
 echo "Done!"

--- a/src/data/post-versions.json
+++ b/src/data/post-versions.json
@@ -1,8 +1,10 @@
 {
-  "en-sp-249-20260703-geoffreylitt-agent-code": 1,
-  "sp-249-20260703-geoffreylitt-agent-code": 1,
   "en-sp-248-20260703-zhangxinxu-ai-80": 1,
+  "en-sp-249-20260703-geoffreylitt-agent-code": 1,
   "sp-248-20260703-zhangxinxu-ai-80": 1,
+  "sp-249-20260703-geoffreylitt-agent-code": 1,
+  "en-sp-252-20260704-simonwillison-net-fable-simon-willison": 1,
+  "sp-252-20260704-simonwillison-net-fable-simon-willison": 1,
   "en-sp-251-20260704-trq212-fable": 1,
   "sp-251-20260704-trq212-fable": 1,
   "en-sp-250-20260703-philhchen-agent": 1,

--- a/tests/article-counter-merge-driver.test.ts
+++ b/tests/article-counter-merge-driver.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+
+import { mergeArticleCounterText } from '../scripts/merge-article-counter.mjs';
+
+const base = {
+  SD: {
+    next: 28,
+    label: 'ShroomDog Original',
+    description: 'Original articles written by ShroomDog',
+  },
+  SP: {
+    next: 253,
+    label: 'Gu-log Picks',
+    description: 'Articles picked by ShroomDog',
+  },
+  CP: {
+    next: 314,
+    label: 'Mogu Picks',
+    description: 'Articles autonomously picked and translated by Mogu',
+  },
+};
+
+function text(value: unknown): string {
+  return `${JSON.stringify(value, null, 2)}\n`;
+}
+
+function merge(ours: unknown, theirs: unknown): Record<string, { next: number; label: string }> {
+  return JSON.parse(mergeArticleCounterText(text(base), text(ours), text(theirs)));
+}
+
+describe('article-counter merge driver', () => {
+  it('takes max next when both sides bump the same prefix', () => {
+    const ours = structuredClone(base);
+    const theirs = structuredClone(base);
+    ours.SP.next = 254;
+    theirs.SP.next = 257;
+
+    expect(merge(ours, theirs).SP.next).toBe(257);
+  });
+
+  it('keeps independent next bumps on different prefixes', () => {
+    const ours = structuredClone(base);
+    const theirs = structuredClone(base);
+    ours.SP.next = 254;
+    theirs.CP.next = 316;
+
+    const merged = merge(ours, theirs);
+    expect(merged.SP.next).toBe(254);
+    expect(merged.CP.next).toBe(316);
+  });
+
+  it('accepts a one-sided label change', () => {
+    const ours = structuredClone(base);
+    const theirs = structuredClone(base);
+    ours.SP.label = 'Gu-log Picks / SP';
+
+    expect(merge(ours, theirs).SP.label).toBe('Gu-log Picks / SP');
+  });
+
+  it('fails when both sides change the same label differently', () => {
+    const ours = structuredClone(base);
+    const theirs = structuredClone(base);
+    ours.SP.label = 'One label';
+    theirs.SP.label = 'Another label';
+
+    expect(() => merge(ours, theirs)).toThrow('SP.label: both sides changed differently');
+  });
+
+  it('fails on malformed JSON', () => {
+    expect(() => mergeArticleCounterText(text(base), '{ nope', text(base))).toThrow(
+      'ours: invalid JSON'
+    );
+  });
+});


### PR DESCRIPTION
## 摘要
- 新增 `scripts/article-counter.json` 的 custom merge driver：同 prefix 的 `next` 取 `max(ours, theirs)`，其他 metadata 欄位走 JSON-aware 三方合併。
- 接上 `.gitattributes` 與 `scripts/setup-hooks.sh`，讓 `pnpm install` / `prepare` 安裝 local git merge driver。
- 補 Vitest coverage：同 prefix bump、不同 prefix bump、單邊 label、雙邊 label conflict、malformed JSON fail-safe。
- 補 pre-push 要求的 `src/data/post-versions.json` manifest 更新。

## 驗證
- `pnpm exec vitest run tests/article-counter-merge-driver.test.ts`：1 file / 5 tests passed。
- `pnpm exec eslint scripts/merge-article-counter.mjs`：passed。
- `pnpm exec prettier --check scripts/merge-article-counter.mjs tests/article-counter-merge-driver.test.ts`：passed。
- `sh -n scripts/merge-article-counter.sh`、`bash -n scripts/setup-hooks.sh`：passed。
- pre-commit hook：passed。
- pre-push hook：passed；`post-versions.json fresh: 1268 posts tracked`；bundle budget blocking checks passed，route trend warnings non-blocking。

## E2E merge driver 證據
在 `.task/e2e-counter-driver` 建臨時 worktree / scratch branches 後已清乾淨。

No-driver 對照組（base=`origin/main` / `0ff52da0955ba5a1e8c497db410d5cec83c5dc56`）：
```text
NO_DRIVER_STATUS=1
NO_DRIVER_UNMERGED=scripts/article-counter.json
Auto-merging scripts/article-counter.json
CONFLICT (content): Merge conflict in scripts/article-counter.json
Automatic merge failed; fix conflicts and then commit the result.
```

Driver 組（base=`HEAD` / `9a06a6608d4d6b4066a9f88042c8948e04503d59`）：
```text
DRIVER_STATUS=0
DRIVER_UNMERGED=none
DRIVER_SP_NEXT=257
merge-article-counter.mjs: merged scripts/article-counter.json
Auto-merging scripts/article-counter.json
Merge made by the 'ort' strategy.
```

## 注意
GitHub web merge / server-side merge 不會執行開發者本機的 custom merge driver。這個改動根治的是 gu-log 內容 branch 在本地 `merge` / `rebase` / sync 時，`scripts/article-counter.json` 因平行 bump 造成的重複人工衝突。PR merge 仍以 CI 與 branch protection 為準。
