### PR TITLE
fix(validate): en-*.mdx 內文加 CJK Unified Ideographs guard

### DIFF
--- a/scripts/validate-posts.mjs
+++ b/scripts/validate-posts.mjs
@@ -53,6 +53,82 @@ const CLAWD_NOTE_REDUNDANT_PREFIX = [
 ];
 const LONG_CLAWD_NOTE_CHARS = 420;
 const MAX_CLAWD_NOTE_SUMMARY_CHARS = 120;
+// CJK Unified Ideograph guard for en-*.mdx bodies (Rule 19). `\p{Unified_Ideograph}`
+// is the CJK Unified Ideographs block only — kaomoji-adjacent scripts like
+// katakana (ツ) or Greek (ω) are outside it and never trip this rule.
+// Known limitation: this only scans MDX source text, so it cannot catch
+// hardcoded user-visible strings baked into .astro components.
+const CJK_UNIFIED_IDEOGRAPH_PATTERN = /\p{Unified_Ideograph}/gu;
+const CJK_ESCAPE_MARKER = '<!-- cjk-ok -->';
+// Grandfather baseline: every en-* CJK Unified Ideograph line that already
+// existed the day Rule 19 shipped (SP-251 uiux fix task, 2026-07-06), so the
+// guard ships CI-green without a mass content-editing PR. Burn this down over
+// time — 11 of these 14 lines are legitimate citations/kaomoji that just need
+// the `<!-- cjk-ok -->` escape (see fixes-report.md for the file-by-file
+// classification); the 3 lines in en-sp-193 are a real untranslated-CJK bug
+// in a fenced code block, reported but not fixed here. Whoever resolves a
+// line (adds the escape, or retranslates the bug) should delete its entry
+// below — new CJK that isn't in this list still fails the guard.
+//
+// Keyed by exact trimmed line text (not line number) so unrelated edits
+// elsewhere in the file — which shift line numbers — don't silently drop a
+// line out of the baseline or let a false match through. Only editing the
+// flagged line itself invalidates its baseline entry, which is the correct
+// trigger to revisit it.
+const CJK_GRANDFATHERED_LINES = new Map([
+  [
+    'en-clawd-picks-20260204-anthropic-misalignment-hotmess.mdx',
+    new Set([
+      "That kind of industrial accident is what we're actually facing right now (ノಠ益ಠ)ノ彡┻━┻",
+    ]),
+  ],
+  [
+    'en-clawd-picks-20260226-cloudflare-vinext-tldraw-tests.mdx',
+    new Set([
+      "abstract 取得預設屬性(): 圖形['props']",
+      'abstract 取得幾何形狀(圖形: 圖形): 幾何圖形2d',
+      'But if you actually did this, code reviews would become incredibly entertaining: "Hey, why does your `取得幾何形狀` return `null`?" ┐(￣ヘ￣)┌',
+    ]),
+  ],
+  [
+    'en-sd-12-20260402-claude-code-bad-patterns.mdx',
+    new Set([
+      'Users express frustration in a thousand different ways. This regex catches a handful of English profanities. What does a frustrated Japanese user say? "もう無理" — doesn\'t match. German? "Scheiße" — doesn\'t match. An English user who types "this is completely broken and I want to cry"? Also doesn\'t match.',
+    ]),
+  ],
+  [
+    'en-sd-19-20260409-lightning-talk-ralph-loop.mdx',
+    new Set(["Hi, I'm [ShroomDog (香菇大狗狗)](/about)."]),
+  ],
+  [
+    'en-shroomdog-picks-20260210-anthropic-claude-for-nonprofits.mdx',
+    new Set([
+      'Taiwan has an organization called **GuangFuHero (光復超人)** ([GitHub](https://github.com/GuangFuHero)) — a disaster relief volunteer platform that builds volunteer maps, supply matching systems, demand pairing tools, and a logistics dispatch system called the "Little Bee Distribution System" (because of course it has a cute name — this is Taiwan). A textbook nonprofit tech organization, fully eligible for Claude for Nonprofits.',
+    ]),
+  ],
+  [
+    'en-sp-170-20260411-nickbaumann-codex-bespoke-cli-skill.mdx',
+    new Set([
+      "Now think about gu-log's setup. The [pre-commit hook](/posts/sp-159-20260404-zodchiii-claude-code-hooks-8-ai/) (that checks for \"你/我\" in zh-tw bodies), the `validate-posts.mjs` frontmatter checker, the [Ralph Loop](/en/glossary#ralph-loop) tribunal — philosophically they're doing the same job. Each one encodes \"the agent's default action should not be destructive.\" Nick's default-no lives at the skill-contract layer. gu-log's [Hooks](/en/glossary#hooks) live at the runtime layer. They're complementary, not substitutes.",
+    ]),
+  ],
+  [
+    'en-sp-193-20260508-article-autobrowse-agent.mdx',
+    new Set([
+      '# 第一步：先用 fetch 試探。',
+      '# 如果資料乾淨回來，就直接寫解析程式。',
+      '# 如果回應是空的、動態的，或被關卡擋住，再升級到 Autobrowse。',
+    ]),
+  ],
+  [
+    'en-sp-65-20260216-fast-mode-anthropic-vs-openai-spark.mdx',
+    new Set([
+      "> *📘 Based on [this thread](https://x.com/dotey/status/2023152141129429340) by **宝玉** ([@dotey](https://x.com/dotey)) on X. Additional references: [Sean Goedecke's analysis](https://www.seangoedecke.com/fast-llm-inference/), [Hacker News discussion](https://news.ycombinator.com/item?id=47022329), [Anthropic Fast Mode docs](https://platform.claude.com/docs/en/build-with-claude/fast-mode), and [OpenAI Codex Spark announcement](https://openai.com/index/introducing-gpt-5-3-codex-spark/).*",
+      "宝玉's original thread nailed it with one analogy: actuary vs explorer. Let's break down this battle.",
+      "宝玉's one-line summary:",
+    ]),
+  ],
+]);
 
 // ─── Helpers ───────────────────────────────────────────────────────
 function parseFrontmatter(content) {
@@ -453,6 +529,49 @@ function validatePost(filepath, allPosts, options = {}) {
       'Raw ```mermaid code fence detected — use <Mermaid chart={`...`} /> component instead. ' +
         'See src/components/Mermaid.astro for usage.'
     );
+  }
+
+  // ── Rule 19: en-*.mdx body must not contain CJK Unified Ideographs ──
+  // Catches untranslated zh-tw leftovers in en posts. Legitimate cases (a
+  // quoted Chinese name, a kaomoji with a real ideograph like 益) opt out with
+  // a `<!-- cjk-ok -->` comment on the same line. A deliberately bilingual
+  // *code example* opts out block-wide by putting the marker on the opening
+  // ``` fence line instead — an inline comment on a code line would render
+  // as literal garbage text in the published snippet. Frontmatter is exempt
+  // (source/attribution fields legitimately carry original-language names).
+  if (filename.startsWith('en-')) {
+    const bodyStartOffset = content.length - body.length;
+    const bodyStartLine = content.slice(0, bodyStartOffset).split('\n').length;
+    let inEscapedFence = false;
+    body.split('\n').forEach((line, idx) => {
+      if (/^\s*```/.test(line)) {
+        if (inEscapedFence) {
+          inEscapedFence = false; // closing fence of an escaped block
+        } else if (line.includes(CJK_ESCAPE_MARKER)) {
+          inEscapedFence = true; // opening fence marked as escaped
+        }
+        return;
+      }
+      if (inEscapedFence || line.includes(CJK_ESCAPE_MARKER)) return;
+      const matches = line.match(CJK_UNIFIED_IDEOGRAPH_PATTERN);
+      if (matches) {
+        const lineNo = bodyStartLine + idx;
+        const chars = [...new Set(matches)].join('');
+        if (CJK_GRANDFATHERED_LINES.get(filename)?.has(line.trim())) {
+          warnings.push(
+            `CJK Unified Ideograph "${chars}" at line ${lineNo} is grandfathered (pre-existing) — ` +
+              'resolve it (escape or retranslate) and remove its entry from ' +
+              'CJK_GRANDFATHERED_LINES in scripts/validate-posts.mjs'
+          );
+        } else {
+          errors.push(
+            `CJK Unified Ideograph "${chars}" found in en-* body at line ${lineNo} ` +
+              `(intentional? add "${CJK_ESCAPE_MARKER}" on that line, or on the opening ` +
+              '``` fence line to escape a whole code block, to allow it)'
+          );
+        }
+      }
+    });
   }
 
   return { filename, errors, warnings };

--- a/tests/validate-posts.test.ts
+++ b/tests/validate-posts.test.ts
@@ -224,6 +224,88 @@ describe('validatePost — content rules', () => {
   });
 });
 
+describe('validatePost — en-* CJK Unified Ideograph guard', () => {
+  const enFm = validFm.map((l) =>
+    l.startsWith('lang:') ? 'lang: en' : l.startsWith('ticketId:') ? 'ticketId: SP-2' : l
+  );
+  // makePost()'s shared padding is zh-tw text, which would itself trip this
+  // en-only rule — build these fixtures with English padding instead so each
+  // assertion isolates the exact behavior under test.
+  const enPadding = 'Enough English filler content to clear the minimum length. '.repeat(4);
+  function makeEnPost(fmLines: string[], body: string): string {
+    return `---\n${fmLines.join('\n')}\n---\n${enPadding}\n\n${body}\n`;
+  }
+
+  it('flags an untranslated CJK Unified Ideograph in an en-* body', () => {
+    const filepath = tmpPath('en-sp-2-x.mdx');
+    fs.writeFileSync(filepath, makeEnPost(enFm, 'This has a leftover 測試字 in it.'));
+    const r = validatePost(filepath, []);
+    expect(r.errors.some((e: string) => e.includes('CJK Unified Ideograph'))).toBe(true);
+  });
+
+  it('does not flag zh-tw posts (rule is en-only)', () => {
+    const filepath = tmpPath('sp-2-x.mdx');
+    fs.writeFileSync(filepath, makePost(validFm, `Body content with kaomoji ${KAOMOJI} 測試字.`));
+    const r = validatePost(filepath, []);
+    expect(r.errors.some((e: string) => e.includes('CJK Unified Ideograph'))).toBe(false);
+  });
+
+  it('does not flag katakana or Greek letters (outside the Unified Ideograph block)', () => {
+    const filepath = tmpPath('en-sp-3-x.mdx');
+    fs.writeFileSync(filepath, makeEnPost(enFm, 'Kaomoji like (◕ω◕) and ツ or ω are fine.'));
+    const r = validatePost(filepath, []);
+    expect(r.errors.some((e: string) => e.includes('CJK Unified Ideograph'))).toBe(false);
+  });
+
+  it('allows an inline escape via "<!-- cjk-ok -->" on the same line', () => {
+    const filepath = tmpPath('en-sp-4-x.mdx');
+    fs.writeFileSync(
+      filepath,
+      makeEnPost(enFm, 'Quoting a name like 測試字 is fine here. <!-- cjk-ok -->')
+    );
+    const r = validatePost(filepath, []);
+    expect(r.errors.some((e: string) => e.includes('CJK Unified Ideograph'))).toBe(false);
+  });
+
+  it('allows escaping a whole code block via the marker on the opening fence line', () => {
+    const filepath = tmpPath('en-sp-5-x.mdx');
+    const body = ['```typescript <!-- cjk-ok -->', 'const x = "測試字";', '```'].join('\n');
+    fs.writeFileSync(filepath, makeEnPost(enFm, body));
+    const r = validatePost(filepath, []);
+    expect(r.errors.some((e: string) => e.includes('CJK Unified Ideograph'))).toBe(false);
+  });
+
+  it('downgrades a grandfathered baseline line to a warning instead of an error', () => {
+    // Must use the real filename + exact line text from CJK_GRANDFATHERED_LINES
+    // in scripts/validate-posts.mjs — the baseline is keyed by both.
+    const filepath = tmpPath('en-sd-19-20260409-lightning-talk-ralph-loop.mdx');
+    fs.writeFileSync(filepath, makeEnPost(enFm, "Hi, I'm [ShroomDog (香菇大狗狗)](/about)."));
+    const r = validatePost(filepath, []);
+    expect(r.errors.some((e: string) => e.includes('CJK Unified Ideograph'))).toBe(false);
+    expect(r.warnings.some((w: string) => w.includes('grandfathered'))).toBe(true);
+  });
+
+  it('still fails a NEW (non-baseline) CJK line in an otherwise-grandfathered file', () => {
+    // The baseline exempts specific line *text*, not the whole file — a
+    // different offending line in the same file must still fail.
+    const filepath = tmpPath('en-sd-19-20260409-lightning-talk-ralph-loop.mdx');
+    fs.writeFileSync(filepath, makeEnPost(enFm, '這是全新的違規句子，不在 baseline 裡。'));
+    const r = validatePost(filepath, []);
+    expect(r.errors.some((e: string) => e.includes('CJK Unified Ideograph'))).toBe(true);
+  });
+
+  it('does not exempt frontmatter (only the body is scanned, not the guard bypass)', () => {
+    // Frontmatter itself is out of scope for this rule (source/attribution
+    // fields legitimately carry original-language names) — confirm a CJK
+    // name in frontmatter alone does not trigger the body guard.
+    const filepath = tmpPath('en-sp-6-x.mdx');
+    const fm = [...enFm, 'source: "凡人小北 @frxiaobei"'];
+    fs.writeFileSync(filepath, makeEnPost(fm, `Body content with kaomoji ${KAOMOJI}.`));
+    const r = validatePost(filepath, []);
+    expect(r.errors.some((e: string) => e.includes('CJK Unified Ideograph'))).toBe(false);
+  });
+});
+
 describe('validatePost — cross-file rules', () => {
   it('flags duplicate ticketId across non-paired files', () => {
     const filepath = tmpPath('sp-1-a.mdx');
@@ -253,6 +335,8 @@ describe('validatePost — cross-file rules', () => {
       { filename: 'sp-1-x.mdx', ticketId: 'SP-1' },
       { filename: 'en-sp-1-x.mdx', ticketId: 'SP-2' },
     ]);
-    expect(r.errors.some((e: string) => e.includes('Translation pair ticketId mismatch'))).toBe(true);
+    expect(r.errors.some((e: string) => e.includes('Translation pair ticketId mismatch'))).toBe(
+      true
+    );
   });
 });


### PR DESCRIPTION
## 摘要

- 新增 `scripts/validate-posts.mjs` Rule 19：`en-*.mdx` 內文（不含 frontmatter）不得出現 CJK Unified Ideographs（`\p{Unified_Ideograph}`，只掃該 Unicode 區段——katakana/希臘字母等不受影響）。
- 逃生門：行內 `<!-- cjk-ok -->` 註解跳過該行；code fence 開頭行加同樣註解可整塊放行（避免逃生註解汙染 code block 顯示內容）。
- **Grandfather baseline**：掃過現有語料庫找到 14 行既存 CJK，內建在 `CJK_GRANDFATHERED_LINES`（依「檔名 + 該行原文文字」比對，不用行號——不怕檔案其他地方編輯造成行號漂移），降級成 warning 而非 error，讓這條新規則上線當下就是 CI 綠、不需要一次性大改動所有既存內容。baseline 之外新出現的 CJK 一樣會擋下 commit / CI。

## 已知侷限

只掃 MDX 源檔，攔不住元件層寫死字串（例如 `src/components/PostImage.astro` 先前寫死的「點擊放大」，那個是在 PR #549 另外修的）。

## Baseline 14 行分類

**11 行是正當引用**（人名、kaomoji 含真 ideograph、雙語 code 範例），未來要補 `<!-- cjk-ok -->` escape 後從 baseline 移除：
- `en-clawd-picks-20260204-anthropic-misalignment-hotmess.mdx`：kaomoji 內的「益」
- `en-clawd-picks-20260226-cloudflare-vinext-tldraw-tests.mdx`：3 行，文章主題就是「把 code 翻成中文當 AI 防禦」的示範
- `en-sd-12-20260402-claude-code-bad-patterns.mdx`：引用日文「もう無理」
- `en-sd-19-20260409-lightning-talk-ralph-loop.mdx`：作者名「香菇大狗狗」
- `en-shroomdog-picks-20260210-anthropic-claude-for-nonprofits.mdx`：專有名詞「光復超人」
- `en-sp-170-20260411-nickbaumann-codex-bespoke-cli-skill.mdx`：引用 gu-log 自己 hook 規則裡的「你/我」
- `en-sp-65-20260216-fast-mode-anthropic-vs-openai-spark.mdx`：3 行，人名「宝玉」

**3 行是真的漏翻譯 bug**（回報，這個 PR 不修內容）：
- `en-sp-193-20260508-article-autobrowse-agent.mdx` 第 204/206/207 行：code fence 裡的 bash 註解沒翻譯，比對 zh-tw 原文（`sp-193-20260508-article-autobrowse-agent.mdx`）確認是逐字一樣的中文，英文版翻譯時漏掉了這段 code 註解。

## Baseline 燒掉計畫（留給 user 決定）

1. 幫 11 行正當引用補 `<!-- cjk-ok -->`（inline 或 fence-level），從 `CJK_GRANDFATHERED_LINES` 移除對應項目。
2. 幫 en-sp-193 補翻譯那 3 行 bash 註解，從 baseline 移除。
3. baseline 歸零後，`CJK_GRANDFATHERED_LINES` 這個 Map 可以整個刪掉。

> 附註：嘗試過直接把 escape 加進上述 7 個內容檔並委由 fork 補齊本來就缺的 `<ClawdNote summary="...">` 屬性以通過 pre-commit（這是另一條跟 CJK 無關的既存 debt，pre-commit 的 Rule 10 在檔案清單模式才會擋，CI 全量模式不會擋），後來 orchestrator 決定兩者都不深挖，改走這個 grandfather baseline 方案，讓 PR 保持乾淨、CI 綠、不碰內容檔。

## Test plan

- [x] `pnpm exec vitest run tests/validate-posts.test.ts`（36 tests，含 baseline 內放行 / baseline 外新違規仍擋 / 行內 escape / fence-level escape / katakana-希臘字母不誤判 五種情境）
- [x] `pnpm exec vitest run`（全套 383 tests 綠）
- [x] `node scripts/validate-posts.mjs`（全語料庫，exit 0，61 warnings 含 14 條 grandfathered CJK）
- [x] `pnpm exec eslint` / `pnpm exec prettier --check`
- [x] `pnpm exec astro check`（0 errors）
- [x] 人造違規樣本驗證規則邏輯正確（暫存檔已刪除）

🤖 Generated with [Claude Code](https://claude.com/claude-code)