### PR TITLE
fix: artifact callout 巢狀 <a> 拆版 + dark theme 對比修復

### DIFF
--- a/docs/dev-reference.md
+++ b/docs/dev-reference.md
@@ -41,6 +41,9 @@ src/
 
 ```bash
 pnpm run dev                   # 本地開發 localhost:4321
+                               # 雷：改 src/styles/global.css 後 HMR 可能吃到舊的
+                               # 內嵌 CSS（實測兩次）——清 node_modules/.vite 與
+                               # .astro/ 再重啟，並 curl page 確認新值有 serve 出來
 pnpm run build                 # 生產 build
 pnpm exec astro check          # TypeScript 檢查
 node scripts/validate-posts.mjs # 驗證所有文章

--- a/src/content/posts/en-sp-251-20260704-trq212-fable.mdx
+++ b/src/content/posts/en-sp-251-20260704-trq212-fable.mdx
@@ -75,7 +75,7 @@ import mapVsTerritory from '../../assets/posts/sp-251-fable-unknowns/map-vs-terr
 import knownUnknownsQuadrant from '../../assets/posts/sp-251-fable-unknowns/known-unknowns-quadrant-en.png';
 import unknownDiscoveryLoop from '../../assets/posts/sp-251-fable-unknowns/unknown-discovery-loop-en.png';
 
-For trq212, Claude Fable 5 is the first model where the quality bottleneck clearly shifted—away from the model itself, and toward whether the user can articulate their "unknowns."
+For [Thariq](/en/glossary#thariq) (@trq212), Claude Fable 5 is the first model where the quality bottleneck clearly shifted—away from the model itself, and toward whether the user can articulate their "unknowns."
 
 <ClawdNote>
 He borrows a classic phrase: "The map is not the territory." The [prompt](/glossary#prompt) and context are the map; the codebase and real world are the territory. The gap between them is your "unknowns." When an agent stumbles into unknowns, it can only guess—and bad guesses blow up. This one line explains why the same model feels effortless for some and disastrous for others. The difference isn't the model. It's whose map is more accurate.
@@ -118,7 +118,7 @@ The four-quadrant breakdown isn't vocabulary trivia—it forces developers to ad
   </span>
   <span class="artifact-callout__body">
     <span class="artifact-callout__label">original artifact mirror</span>
-    <strong>Explore [Thariq](/en/glossary#thariq)'s original 11 unknowns examples</strong>
+    <strong>Explore Thariq's original 11 unknowns examples</strong>
     <span class="artifact-callout__meta">English original · mirror copy · no API · runs in your browser</span>
     <span class="artifact-callout__cta">
       <span>Open mirror</span>

--- a/src/content/posts/sp-251-20260704-trq212-fable.mdx
+++ b/src/content/posts/sp-251-20260704-trq212-fable.mdx
@@ -75,7 +75,7 @@ import mapVsTerritory from '../../assets/posts/sp-251-fable-unknowns/map-vs-terr
 import knownUnknownsQuadrant from '../../assets/posts/sp-251-fable-unknowns/known-unknowns-quadrant.png';
 import unknownDiscoveryLoop from '../../assets/posts/sp-251-fable-unknowns/unknown-discovery-loop.png';
 
-對 trq212 來說，Claude Fable 5 是第一個讓他清楚感覺到：作品品質的瓶頸，開始不在模型本身，而在使用者能不能把「未知」講清楚。
+對 [Thariq](/glossary#thariq)（@trq212）來說，Claude Fable 5 是第一個讓他清楚感覺到：作品品質的瓶頸，開始不在模型本身，而在使用者能不能把「未知」講清楚。
 
 <ClawdNote>
 他借了一個經典說法：「地圖不是領土」（原文 "The map is not the territory"）。[Prompt](/glossary#prompt) 和 context 是地圖，codebase 和真實世界才是領土，兩者的落差就是「未知」。agent 撞進未知時只能靠猜，猜錯就炸。這一句就解釋了為什麼同一個模型，有人用得行雲流水，有人用得滿地血——差別不在模型，在誰的地圖畫得比較準。
@@ -118,7 +118,7 @@ import unknownDiscoveryLoop from '../../assets/posts/sp-251-fable-unknowns/unkno
   </span>
   <span class="artifact-callout__body">
     <span class="artifact-callout__label">繁中版互動頁</span>
-    <strong>看 [Thariq](/glossary#thariq) 11 個未知互動範例（繁體中文版）</strong>
+    <strong>看 Thariq 11 個未知互動範例（繁體中文版）</strong>
     <span class="artifact-callout__meta">繁中翻譯 · 無 API · 純瀏覽器內完成</span>
     <span class="artifact-callout__cta">
       <span>打開繁中版</span>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -444,7 +444,8 @@ blockquote.codex-note br {
   width: 2.15rem;
   height: 2.15rem;
   border-radius: 999px;
-  color: #fff8ef;
+  /* page bg as ink: dark #282a36 on orange ≈ 8.5:1, light cream on brown ≈ 5.6:1 */
+  color: var(--color-bg);
   background: var(--color-mogu-orange);
   font-weight: 900;
 }
@@ -456,7 +457,8 @@ blockquote.codex-note br {
   min-height: 1.2rem;
   padding: 0.08rem 0.38rem;
   border-radius: 999px;
-  color: var(--color-text-muted);
+  /* dark: brighter than __meta — the chip's alpha-mixed bg is lighter than the card */
+  color: #ccd4e8;
   background: color-mix(in srgb, var(--color-surface-hover) 72%, transparent);
   font-size: 0.66rem;
   font-weight: 800;
@@ -495,9 +497,15 @@ blockquote.codex-note br {
 }
 
 .artifact-callout__meta {
-  color: var(--color-text-muted);
+  /* dark: --color-text-muted is only 3.1:1 on the card surface; brighten locally */
+  color: #b2bcd8;
   font-size: 0.92rem;
   line-height: 1.5;
+}
+
+[data-theme='light'] .artifact-callout__meta,
+[data-theme='light'] .artifact-callout__tap {
+  color: var(--color-text-muted);
 }
 
 .artifact-callout__cta {
@@ -510,7 +518,8 @@ blockquote.codex-note br {
   margin-top: 0.6rem;
   padding: 0.5rem 0.72rem;
   border-radius: 999px;
-  color: #fff8ef;
+  /* page bg as ink — see .artifact-callout__icon */
+  color: var(--color-bg);
   background: var(--color-mogu-orange);
   box-shadow: 0 8px 18px rgba(255, 184, 108, 0.16);
   font-size: 0.92rem;


### PR DESCRIPTION
## 問題

production 的 sp-251 文章（zh/en 兩版）artifact callout 卡片破版：卡片內的 `[Thariq](/glossary#thariq)` markdown 連結編譯成巢狀 `<a>`，HTML parser 強制提早關閉外層錨點，卡片被剖開、CTA 按鈕疊到正文（user 截圖回報）。

## 修法

1. **content**：卡片內改純文字，glossary 連結移到正文第一次提到作者處（glossary coverage 檢查仍滿足）。
2. **styles**（uiux-auditor fresh-eyes 稽核順手抓到的 dark theme 對比債，同 PR 修掉）：
   - CTA/icon ink `#fff8ef` → `var(--color-bg)`：dark 1.62:1 → **8.36:1**，light 5.47:1 無退步
   - meta dark 提亮 `#b2bcd8`：3.14:1 → **4.83:1**
   - tap chip dark `#ccd4e8`：2.41:1 → **4.73:1**（chip alpha 混色底較亮）
   - light 一律由 `[data-theme='light']` override 保持原樣，實測無退步
3. **docs**：記錄 astro dev 的 global.css 內嵌快取雷點（本次被咬兩次）。

## 驗證

- 本地 dev server render：callout 內巢狀 `<a>` = 0（zh/en 皆驗）
- uiux-auditor 兩輪稽核：8/8 PASS（雙頁 × 雙主題 × desktop/mobile），對比全部像素實測達標
- `check-glossary-links` / `validate-posts` 全綠

🤖 Generated with [Claude Code](https://claude.com/claude-code)