### PR TITLE
chore: 重生 post-versions.json（修 main 的 manifest freshness 紅燈）

### DIFF
--- a/src/data/post-versions.json
+++ b/src/data/post-versions.json
@@ -1,4 +1,6 @@
 {
+  "en-sp-251-20260704-trq212-fable": 5,
+  "sp-251-20260704-trq212-fable": 5,
   "en-clawd-picks-20260204-anthropic-misalignment-hotmess": 14,
   "en-clawd-picks-20260226-cloudflare-vinext-tldraw-tests": 13,
   "en-sd-12-20260402-claude-code-bad-patterns": 7,
@@ -7,8 +9,6 @@
   "en-sp-170-20260411-nickbaumann-codex-bespoke-cli-skill": 9,
   "en-sp-65-20260216-fast-mode-anthropic-vs-openai-spark": 4,
   "en-sp-193-20260508-article-autobrowse-agent": 3,
-  "sp-251-20260704-trq212-fable": 4,
-  "en-sp-251-20260704-trq212-fable": 4,
   "cp-230-20260330-figma-figma-ai-agent-canvas": 7,
   "en-cp-230-20260330-figma-figma-ai-agent-canvas": 9,
   "en-cp-304-20260529-clawd-rip-claude-timeline": 2,


### PR DESCRIPTION
#558 修改 sp-251 zh/en 內文後，pre-push 的 manifest 檢查沒攔到過期（CI 的 freshness 測試比 hook 嚴格），main 的 `post-version-manifest.test.ts > keeps the production manifest fresh for Vercel shallow builds` 轉紅。

重生 `post-versions.json`（sp-251 兩版 4→5），本地 5/5 測試綠。

側註：hook 與 CI 測試的嚴格度落差（hook 沒攔、CI 紅）是既有 gap，這裡先止血；要不要把 pre-push 檢查對齊 CI 邏輯留給後續。

🤖 Generated with [Claude Code](https://claude.com/claude-code)