### PR TITLE
docs(level-up): dynamic-workflows 學習紀錄（session 進行中）

### DIFF
--- a/.claude/skills/level-up/SKILL.md
+++ b/.claude/skills/level-up/SKILL.md
@@ -177,6 +177,28 @@ D) <option D>
 ---
 ```
 
+### MCQs as design decisions, not only comprehension checks
+
+When the session has a deliverable (article scope, architecture choice, plan), MCQs double as **decision points**: pack an include/exclude or angle-A-vs-angle-B call into an MCQ instead of "I recommend X, object if you disagree" (which nudges silent default-acceptance). A decision MCQ has no single correct answer — label it as a decision, offer real alternatives (including "exclude"), and record the user's pick as the decision. Mixing comprehension MCQs and decision MCQs in one batch is encouraged; embed decisions at the level where context is fresh, never batched into one big end-of-session judgment.
+
+### Numbered batches + terse reply protocol
+
+When asking more than one question in a turn, number them (1, 2, 3…) with options A–D each, so the user can reply tersely: `1A 2D`. Design for minimal typing — the human's keystrokes are the scarce resource:
+
+- Always accept the terse form; never require full sentences.
+- Keep numbering unambiguous within a turn (restart from 1 each turn).
+- If a reply skips a numbered question, ask only about the skipped one — treat it as "no answer yet", not as consent to your favorite option.
+
+```markdown
+**1. [理解] <question>**
+A) ...
+B) ...
+
+**2. [判決] <decision question>**
+A) ...
+B) ...
+```
+
 ## Adaptive Response
 
 ### Correct Answer

--- a/.claude/skills/level-up/learning/INDEX.md
+++ b/.claude/skills/level-up/learning/INDEX.md
@@ -9,6 +9,7 @@
 | Tribunal 24/7 readiness | mastered (Lv.1–9 full clear) | 9/9 MCQ 一次過；自己推出 claim 必須共享、用單機/clawd-vm 決策繞 boss | 2026-06-19 | topics/tribunal-24-7.md |
 | Spec-driven SDLC (openspec + multi-agent) | mastered (full clear) | 自己推導出 coach(macro) vs players(micro)、spec-altitude、reviewer+simplifier+implementor loop(=tribunal 形狀)、explore-first escalation；核心：一條 spec scenario = gate+rubric+邊界 | 2026-06-22 | topics/spec-driven-sdlc.md |
 | Self-help / 行為改變概念（Dan Koe 拆解） | mastered（判準+angle 層 full clear） | Lv.1–4 全一次過；自己挖 cybernetics↔Kubernetes 字根、提出「niche=angle 函數」、逼出 agent 三層定義 | 2026-06-20 | topics/self-help-concepts.md |
+| Dynamic workflows / token 效率 | learning (Lv.1 過) | control-flow 判準 MCQ 一次過；自提「決策內嵌每關」= evaluator-in-the-loop | 2026-07-13 | topics/dynamic-workflows.md |
 | Founder framework〈Before It Was Obvious〉 | mastered (Lv.1–5 full clear) | 5/5 MCQ 一次過；自己把 yin/wedge/hair-on-fire 套到 gu-log 並用無職轉生當 benchmark 自評 | 2026-06-20 | topics/founder-framework-before-obvious.md |
 
 Learner profile（taste / framing / 語氣）：`learner-profile.md`

--- a/.claude/skills/level-up/learning/topics/dynamic-workflows.md
+++ b/.claude/skills/level-up/learning/topics/dynamic-workflows.md
@@ -9,12 +9,14 @@
 - 2026-07-13: workflow vs agent 的 control-flow 判準一次答對（固定 5 出口的 ticket 分類 → routing workflow，不需 model 握 control flow），並正確排除「語意理解 = 需要 agent」的誘餌。
 - 2026-07-13: 自己提出「include/exclude 決策應該內嵌在每關、不要攢到最後」——等於自行推導出 evaluator-in-the-loop 優於 end-stage 驗收，直接用在學習流程設計上。
 - 2026-07-13: orchestrator-workers 分界（runtime dispatcher 決定派哪些 judge）MCQ 答對。
+- 2026-07-13: multi-agent 何時值得 15× token（廣度可平行 + 超過單一 context + 任務價值）MCQ 一次答對，並正確排除「序列 evaluator-optimizer 假扮 multi-agent」誘餌。
 - 2026-07-13: 憑對自家 tribunal 的正確直覺（「有很多 rewriter↔judge loop」）抓到教學者的事實 drift，並要求派 subagent ground-truth。實查結果：tribunal.sh 是 4 個 sequential stage、每 stage 各自帶 judge→writer→re-judge loop（= 四個 evaluator-optimizer 串 chain），非 parallelization；過標由 check_pass_bar code 判定，judge verdict 不算數。
 
 ## Known Gaps
 - （2026-07-13 曾把「worker 在做評估」誤判成 evaluator-optimizer，但後續證明其直覺（tribunal 有 rewrite loops）比出題者的題目前提更接近實作。pattern 形狀判準已在重驗 MCQ 證實掌握 → 移出 gap。）
 
 ## Teaching Notes
+- MCQ 互動協定（learner 指定，已寫進 SKILL.md）：多題編號 1/2/3 + ABCD，接受 `1A 2D` 極簡回覆；MCQ 同時當決策工具（[理解] / [判決] 混排），判決包成選項而不是「我建議 X 有異議再說」。
 - 框架沿用 Vainglory 高端類比（教練賽前腳本 = workflow / captain 場上 shotcall = agent / dynamic workflow = 宏觀腳本+微觀 shotcall），命中。
 - 可直接掛在已 mastered 的 coach(macro) vs players(micro)（spec-driven SDLC）上。
 - 本輪同時是 gu-log 選材任務：每關結尾做該關素材的 include/exclude 判決（learner 指定的流程）。

--- a/.claude/skills/level-up/learning/topics/dynamic-workflows.md
+++ b/.claude/skills/level-up/learning/topics/dynamic-workflows.md
@@ -1,0 +1,24 @@
+# Dynamic Workflows 與 task/token 效率
+
+## Current Level
+- Status: learning（Lv.1 過，進 Lv.2）
+- Last updated: 2026-07-13
+- Confidence: 高（learner 已 mastered spec-driven SDLC / tribunal，直接高段位開講）
+
+## Evidence
+- 2026-07-13: workflow vs agent 的 control-flow 判準一次答對（固定 5 出口的 ticket 分類 → routing workflow，不需 model 握 control flow），並正確排除「語意理解 = 需要 agent」的誘餌。
+- 2026-07-13: 自己提出「include/exclude 決策應該內嵌在每關、不要攢到最後」——等於自行推導出 evaluator-in-the-loop 優於 end-stage 驗收，直接用在學習流程設計上。
+
+## Known Gaps
+- （尚無）
+
+## Teaching Notes
+- 框架沿用 Vainglory 高端類比（教練賽前腳本 = workflow / captain 場上 shotcall = agent / dynamic workflow = 宏觀腳本+微觀 shotcall），命中。
+- 可直接掛在已 mastered 的 coach(macro) vs players(micro)（spec-driven SDLC）上。
+- 本輪同時是 gu-log 選材任務：每關結尾做該關素材的 include/exclude 判決（learner 指定的流程）。
+
+## Scope 判決（gu-log 文章素材，逐關累積）
+- Lv.1 workflow vs agent 判準：待判
+
+## Next Suggested Levels
+- Lv.2 五大 workflow patterns 光譜 → Lv.3 token 經濟學 → Lv.4 context engineering 四招 → Lv.5 dynamic runtime graphs 研究前緣 → Lv.6 彙整骨架

--- a/.claude/skills/level-up/learning/topics/dynamic-workflows.md
+++ b/.claude/skills/level-up/learning/topics/dynamic-workflows.md
@@ -1,16 +1,18 @@
 # Dynamic Workflows 與 task/token 效率
 
 ## Current Level
-- Status: learning（Lv.1 過，進 Lv.2）
+- Status: learning（Lv.1-2 過，進 Lv.3 token 經濟學）
 - Last updated: 2026-07-13
 - Confidence: 高（learner 已 mastered spec-driven SDLC / tribunal，直接高段位開講）
 
 ## Evidence
 - 2026-07-13: workflow vs agent 的 control-flow 判準一次答對（固定 5 出口的 ticket 分類 → routing workflow，不需 model 握 control flow），並正確排除「語意理解 = 需要 agent」的誘餌。
 - 2026-07-13: 自己提出「include/exclude 決策應該內嵌在每關、不要攢到最後」——等於自行推導出 evaluator-in-the-loop 優於 end-stage 驗收，直接用在學習流程設計上。
+- 2026-07-13: orchestrator-workers 分界（runtime dispatcher 決定派哪些 judge）MCQ 答對。
+- 2026-07-13: 憑對自家 tribunal 的正確直覺（「有很多 rewriter↔judge loop」）抓到教學者的事實 drift，並要求派 subagent ground-truth。實查結果：tribunal.sh 是 4 個 sequential stage、每 stage 各自帶 judge→writer→re-judge loop（= 四個 evaluator-optimizer 串 chain），非 parallelization；過標由 check_pass_bar code 判定，judge verdict 不算數。
 
 ## Known Gaps
-- 2026-07-13: 把「worker 在做評估」誤判成 evaluator-optimizer（正解 parallelization）。已重講：pattern 名字描述 control flow 形狀（有無回饋循環），不是 worker 的工作內容。待同關重驗。
+- （2026-07-13 曾把「worker 在做評估」誤判成 evaluator-optimizer，但後續證明其直覺（tribunal 有 rewrite loops）比出題者的題目前提更接近實作。pattern 形狀判準已在重驗 MCQ 證實掌握 → 移出 gap。）
 
 ## Teaching Notes
 - 框架沿用 Vainglory 高端類比（教練賽前腳本 = workflow / captain 場上 shotcall = agent / dynamic workflow = 宏觀腳本+微觀 shotcall），命中。
@@ -19,6 +21,7 @@
 
 ## Scope 判決（gu-log 文章素材，逐關累積）
 - Lv.1 workflow vs agent 判準：**include**，但 learner 修正角度——不轉述 Anthropic 2024「不要建 agent」教條（已過時：2026 baseline 是人人有 Claude Code/Codex 現成 agent），改寫成「agent vs workflow trade-off + 什麼時候從 agent 手上拿回 control flow」。吐槽點：2024 聖經 2026 還被原文背誦。
+- Lv.2 五大 patterns：**include**，但不做名詞解釋文——用自家 tribunal 當實例講「pattern 名字描述 control flow 形狀（有無回饋循環、拆解權在誰手上）」+「真實系統是 pattern 組合技（tribunal = 四個 evaluator-optimizer 串 chain）」+「code wins over agent verdict（check_pass_bar）」。附教訓：憑印象描述系統形狀會翻車，要讀實作。
 
 ## Next Suggested Levels
 - Lv.2 五大 workflow patterns 光譜 → Lv.3 token 經濟學 → Lv.4 context engineering 四招 → Lv.5 dynamic runtime graphs 研究前緣 → Lv.6 彙整骨架

--- a/.claude/skills/level-up/learning/topics/dynamic-workflows.md
+++ b/.claude/skills/level-up/learning/topics/dynamic-workflows.md
@@ -10,7 +10,7 @@
 - 2026-07-13: 自己提出「include/exclude 決策應該內嵌在每關、不要攢到最後」——等於自行推導出 evaluator-in-the-loop 優於 end-stage 驗收，直接用在學習流程設計上。
 
 ## Known Gaps
-- （尚無）
+- 2026-07-13: 把「worker 在做評估」誤判成 evaluator-optimizer（正解 parallelization）。已重講：pattern 名字描述 control flow 形狀（有無回饋循環），不是 worker 的工作內容。待同關重驗。
 
 ## Teaching Notes
 - 框架沿用 Vainglory 高端類比（教練賽前腳本 = workflow / captain 場上 shotcall = agent / dynamic workflow = 宏觀腳本+微觀 shotcall），命中。
@@ -18,7 +18,7 @@
 - 本輪同時是 gu-log 選材任務：每關結尾做該關素材的 include/exclude 判決（learner 指定的流程）。
 
 ## Scope 判決（gu-log 文章素材，逐關累積）
-- Lv.1 workflow vs agent 判準：待判
+- Lv.1 workflow vs agent 判準：**include**，但 learner 修正角度——不轉述 Anthropic 2024「不要建 agent」教條（已過時：2026 baseline 是人人有 Claude Code/Codex 現成 agent），改寫成「agent vs workflow trade-off + 什麼時候從 agent 手上拿回 control flow」。吐槽點：2024 聖經 2026 還被原文背誦。
 
 ## Next Suggested Levels
 - Lv.2 五大 workflow patterns 光譜 → Lv.3 token 經濟學 → Lv.4 context engineering 四招 → Lv.5 dynamic runtime graphs 研究前緣 → Lv.6 彙整骨架


### PR DESCRIPTION
## 內容

Level-up 教學 session（主題：dynamic workflows 與 task/token 效率）的持久學習紀錄：

- 新增 `topics/dynamic-workflows.md`：Lv.1（workflow vs agent control-flow 判準）過關證據、Vainglory 框架命中筆記、逐關 scope 判決欄位
- `INDEX.md` 加一列路由

Session 還在進行中（共 6 關），後續各關證據與 gu-log 文章 scope 判決會繼續 append 到同一份紀錄、同一條 branch。等 session 收尾再轉 ready for review。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015uAmVM5k2ZniVKFh5z388b

---
_Generated by [Claude Code](https://claude.ai/code/session_015uAmVM5k2ZniVKFh5z388b)_